### PR TITLE
Add two MAC addresses support for Mihawk's 2 NICs

### DIFF
--- a/ethernet_interface.cpp
+++ b/ethernet_interface.cpp
@@ -600,6 +600,14 @@ void EthernetInterface::writeConfigurationFile()
 
     auto addrs = getAddresses();
 
+    // Write the link section
+    stream << "[Link]\n";
+    auto mac = MacAddressIntf::mACAddress();
+    if (!mac.empty())
+    {
+        stream << "MACAddress=" << mac << "\n";
+    }
+
     // write the network section
     stream << "[Network]\n";
 #ifdef LINK_LOCAL_AUTOCONFIGURATION
@@ -779,16 +787,12 @@ std::string EthernetInterface::mACAddress(std::string value)
 
         auto interface = interfaceName();
         execute("/sbin/fw_setenv", "fw_setenv", "ethaddr", value.c_str());
-        // TODO: would replace below three calls
-        //      with restarting of systemd-netwokd
+        // TODO: would remove the call below and
+        //      just restart systemd-netwokd
         //      through https://github.com/systemd/systemd/issues/6696
         execute("/sbin/ip", "ip", "link", "set", "dev", interface.c_str(),
                 "down");
-        execute("/sbin/ip", "ip", "link", "set", "dev", interface.c_str(),
-                "address", value.c_str());
-        execute("/sbin/ip", "ip", "link", "set", "dev", interface.c_str(),
-                "up");
-        manager.restartSystemdUnit(networkdService);
+        manager.writeToConfigurationFile();
     }
 
     return value;

--- a/ethernet_interface.cpp
+++ b/ethernet_interface.cpp
@@ -759,7 +759,8 @@ std::string EthernetInterface::mACAddress(std::string value)
         {
             try
             {
-                auto inventoryMAC = mac_address::getfromInventory(bus);
+                auto inventoryMAC =
+                    mac_address::getfromInventory(bus, interfaceName());
                 if (!equal(newMAC, inventoryMAC))
                 {
                     log<level::ERR>(

--- a/ethernet_interface.cpp
+++ b/ethernet_interface.cpp
@@ -786,7 +786,12 @@ std::string EthernetInterface::mACAddress(std::string value)
         MacAddressIntf::mACAddress(value);
 
         auto interface = interfaceName();
-        execute("/sbin/fw_setenv", "fw_setenv", "ethaddr", value.c_str());
+        auto envVar = interfaceToUbootEthAddr(interface.c_str());
+        if (envVar)
+        {
+            execute("/sbin/fw_setenv", "fw_setenv", envVar->c_str(),
+                    value.c_str());
+        }
         // TODO: would remove the call below and
         //      just restart systemd-netwokd
         //      through https://github.com/systemd/systemd/issues/6696

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -220,6 +220,19 @@ TEST_F(TestUtil, getNetworkAddress)
     EXPECT_EQ("fe80::", address);
 }
 
+TEST_F(TestUtil, InterfaceToUbootEthAddr)
+{
+    EXPECT_EQ(std::nullopt, interfaceToUbootEthAddr("et"));
+    EXPECT_EQ(std::nullopt, interfaceToUbootEthAddr("eth"));
+    EXPECT_EQ(std::nullopt, interfaceToUbootEthAddr("sit0"));
+    EXPECT_EQ(std::nullopt, interfaceToUbootEthAddr("ethh0"));
+    EXPECT_EQ(std::nullopt, interfaceToUbootEthAddr("eth0h"));
+    EXPECT_EQ("ethaddr", interfaceToUbootEthAddr("eth0"));
+    EXPECT_EQ("eth1addr", interfaceToUbootEthAddr("eth1"));
+    EXPECT_EQ("eth5addr", interfaceToUbootEthAddr("eth5"));
+    EXPECT_EQ("eth28addr", interfaceToUbootEthAddr("eth28"));
+}
+
 TEST_F(TestUtil, CopyFromTooSmall)
 {
     constexpr auto expected = "abcde"sv;

--- a/util.cpp
+++ b/util.cpp
@@ -578,7 +578,8 @@ constexpr auto invNetworkIntf =
     "xyz.openbmc_project.Inventory.Item.NetworkInterface";
 constexpr auto invRoot = "/xyz/openbmc_project/inventory";
 
-ether_addr getfromInventory(sdbusplus::bus::bus& bus)
+ether_addr getfromInventory(sdbusplus::bus::bus& bus,
+                            const std::string& intfName)
 {
     std::vector<DbusInterface> interfaces;
     interfaces.emplace_back(invNetworkIntf);
@@ -607,10 +608,37 @@ ether_addr getfromInventory(sdbusplus::bus::bus& bus)
         elog<InternalFailure>();
     }
 
-    // It is expected that only one object has implemented this interface.
+    DbusObjectPath objPath;
+    DbusService service;
 
-    auto objPath = objectTree.begin()->first;
-    auto service = objectTree.begin()->second.begin()->first;
+    if (1 == objectTree.size())
+    {
+        objPath = objectTree.begin()->first;
+        service = objectTree.begin()->second.begin()->first;
+    }
+    else
+    {
+        // If there are more than 2 objects, object path must contain the
+        // interface name
+        for (auto const& object : objectTree)
+        {
+            log<level::INFO>("interface", entry("INT=%s", intfName.c_str()));
+            log<level::INFO>("object", entry("OBJ=%s", object.first.c_str()));
+            if (std::string::npos != object.first.find(intfName))
+            {
+                objPath = object.first;
+                service = object.second.begin()->first;
+                break;
+            }
+        }
+
+        if (objPath.empty())
+        {
+            log<level::ERR>("Can't find the object for the interface",
+                            entry("intfName=%s", intfName.c_str()));
+            elog<InternalFailure>();
+        }
+    }
 
     auto method = bus.new_method_call(service.c_str(), objPath.c_str(),
                                       propIntf, methodGet);

--- a/util.cpp
+++ b/util.cpp
@@ -9,6 +9,8 @@
 #include <sys/wait.h>
 
 #include <algorithm>
+#include <cstdlib>
+#include <cstring>
 #include <experimental/filesystem>
 #include <iostream>
 #include <list>
@@ -439,6 +441,32 @@ void deleteInterface(const std::string& intf)
             elog<InternalFailure>();
         }
     }
+}
+
+std::optional<std::string> interfaceToUbootEthAddr(const char* intf)
+{
+    constexpr char ethPrefix[] = "eth";
+    constexpr size_t ethPrefixLen = sizeof(ethPrefix) - 1;
+    if (strncmp(ethPrefix, intf, ethPrefixLen) != 0)
+    {
+        return std::nullopt;
+    }
+    const auto intfSuffix = intf + ethPrefixLen;
+    if (intfSuffix[0] == '\0')
+    {
+        return std::nullopt;
+    }
+    char* end;
+    unsigned long idx = strtoul(intfSuffix, &end, 10);
+    if (end[0] != '\0')
+    {
+        return std::nullopt;
+    }
+    if (idx == 0)
+    {
+        return "ethaddr";
+    }
+    return "eth" + std::to_string(idx) + "addr";
 }
 
 bool getDHCPValue(const std::string& confDir, const std::string& intf)

--- a/util.hpp
+++ b/util.hpp
@@ -2,6 +2,7 @@
 
 #include "config.h"
 
+#include "ethernet_interface.hpp"
 #include "types.hpp"
 
 #include <netinet/ether.h>
@@ -29,8 +30,10 @@ namespace mac_address
 
 /** @brief gets the MAC address from the Inventory.
  *  @param[in] bus - DBUS Bus Object.
+ *  @param[in] intfName - Interface name
  */
-ether_addr getfromInventory(sdbusplus::bus::bus& bus);
+ether_addr getfromInventory(sdbusplus::bus::bus& bus,
+                            const std::string& intfName);
 
 /** @brief Converts the given mac address into byte form
  *  @param[in] str - The mac address in human readable form

--- a/util.hpp
+++ b/util.hpp
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #include <cstring>
+#include <optional>
 #include <sdbusplus/bus.hpp>
 #include <string>
 #include <string_view>
@@ -148,6 +149,14 @@ InterfaceList getInterfaces();
  *  @param[in] intf - interface name.
  */
 void deleteInterface(const std::string& intf);
+
+/** @brief Converts the interface name into a u-boot environment
+ *         variable that would hold its ethernet address.
+ *
+ *  @param[in] intf - interface name
+ *  @return The name of th environment key
+ */
+std::optional<std::string> interfaceToUbootEthAddr(const char* intf);
 
 /** @brief read the DHCP value from the configuration file
  *  @param[in] confDir - Network configuration directory.


### PR DESCRIPTION
Contains 3 commits
1. Add two MAC addresses support for Mihawk's 2 NICs
2. ethernet_interface: Fix u-boot MAC environment variable
3. ethernet_interface: Write the MAC to configuration