### PR TITLE
Network : Added Validation of Nameserver IP's

### DIFF
--- a/ethernet_interface.cpp
+++ b/ethernet_interface.cpp
@@ -426,6 +426,18 @@ bool EthernetInterface::dHCPEnabled(bool value)
 
 ServerList EthernetInterface::nameservers(ServerList value)
 {
+    for (const auto& nameserverip : value)
+    {
+        if (!isValidIP(AF_INET, nameserverip) &&
+            !isValidIP(AF_INET6, nameserverip))
+        {
+            log<level::ERR>("Not a valid IP address"),
+                entry("ADDRESS=%s", nameserverip.c_str());
+            elog<InvalidArgument>(
+                Argument::ARGUMENT_NAME("Nameserver"),
+                Argument::ARGUMENT_VALUE(nameserverip.c_str()));
+        }
+    }
     try
     {
         EthernetInterfaceIntf::nameservers(value);


### PR DESCRIPTION
The exiting design does not have the Nameserver IP
validation, it blindly patches the Nameservers property
with any string.

The idea behind this commit is to add necessary validation
in the back end to throw InvalidArgument exception when the
Nameserver property is patched with junk data.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>
Change-Id: Ia2693d2c1b470cdabade57a9955a4816a48e4be0