### PR TITLE
SW471678: Allow 60 seconds for systemd D-bus call

### DIFF
--- a/network_manager.cpp
+++ b/network_manager.cpp
@@ -224,7 +224,13 @@ void Manager::restartSystemdUnit(const std::string& unit)
         auto method = bus.new_method_call(SYSTEMD_BUSNAME, SYSTEMD_PATH,
                                           SYSTEMD_INTERFACE, "ResetFailedUnit");
         method.append(unit);
-        bus.call_noreply(method);
+
+        // See openbmc/phostphor-state-manager#4
+        // This call is made around the same time systemd is mounting the
+        // host filesystems. This can cause a delay in D-bus calls to systemd.
+        // Increase the timeout from the default 25 seconds to 60 seconds to
+        // workaround this.
+        bus.call_noreply(method, (60 * 1000000L));
     }
     catch (const sdbusplus::exception::SdBusError& ex)
     {


### PR DESCRIPTION
When systemd mounts the UBI filesystem on witherspoon, it appears to
hang itself for a period of time. Applications can not talk to systemd
during this time over D-bus and in certain situations can exceed the 25
second default timeout used for D-bus communication.

A lot of testing, internet searching, and debugging has not gotten us
any closer to root cause. With UBI going away in future OpenBMC
releases, the easiest solution at this point is to just increase the
timeout from 25 seconds to 60 seconds.

The network service failure for this would manifest itself like this:
Jul 31 04:15:19 witherspoon phosphor-network-manager[1279]: Failed to reset failed unit
Jul 31 04:15:19 witherspoon phosphor-network-manager[1279]: The operation failed internally.

Tested:
Built image and had test team attempt recreate. They were unable
to recreate the network service failure.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>