### PR TITLE
Network:add link local auto configuration support on

### DIFF
--- a/ethernet_interface.cpp
+++ b/ethernet_interface.cpp
@@ -51,6 +51,7 @@ EthernetInterface::EthernetInterface(sdbusplus::bus::bus& bus,
     MacAddressIntf::mACAddress(getMACAddress(intfName));
     EthernetInterfaceIntf::nTPServers(getNTPServersFromConf());
     EthernetInterfaceIntf::nameservers(getNameServerFromConf());
+    EthernetInterfaceIntf::linkLocalAutoConf(getLinkLocalAutoConfFromConf());
 
     // Emit deferred signal.
     if (emitSignal)
@@ -424,6 +425,18 @@ bool EthernetInterface::dHCPEnabled(bool value)
     return value;
 }
 
+LinkLocalAutoConf EthernetInterface::linkLocalAutoConf(LinkLocalAutoConf value)
+{
+    if (value == EthernetInterfaceIntf::linkLocalAutoConf())
+    {
+        return value;
+    }
+
+    EthernetInterfaceIntf::linkLocalAutoConf(value);
+    manager.writeToConfigurationFile();
+    return value;
+}
+
 ServerList EthernetInterface::nameservers(ServerList value)
 {
     for (const auto& nameserverip : value)
@@ -560,6 +573,54 @@ ServerList EthernetInterface::getNTPServersFromConf()
     return servers;
 }
 
+LinkLocalAutoConf EthernetInterface::getLinkLocalAutoConfFromConf()
+{
+    fs::path confPath = manager.getConfDir();
+
+    std::string fileName = systemd::config::networkFilePrefix +
+                           interfaceName() + systemd::config::networkFileSuffix;
+    confPath /= fileName;
+
+    config::ValueList values;
+
+    auto linkLocalConf = LinkLocalAutoConf::fallback;
+
+    config::Parser parser(confPath.string());
+    auto rc = config::ReturnCode::SUCCESS;
+
+    std::tie(rc, values) = parser.getValues("Network", "LinkLocalAddressing");
+    if (rc != config::ReturnCode::SUCCESS)
+    {
+        log<level::DEBUG>(
+            "Unable to get the value for Network[LinkLocalAddressing]",
+            entry("rc=%d", rc));
+        return linkLocalConf;
+    }
+
+    if (values[0] == "yes")
+    {
+        linkLocalConf = LinkLocalAutoConf::both;
+    }
+    else if (values[0] == "ipv4")
+    {
+        linkLocalConf = LinkLocalAutoConf::v4;
+    }
+    else if (values[0] == "fallback")
+    {
+        linkLocalConf = LinkLocalAutoConf::fallback;
+    }
+
+    else if (values[0] == "ipv6")
+    {
+        linkLocalConf = LinkLocalAutoConf::v6;
+    }
+    else if (values[0] == "no")
+    {
+        linkLocalConf = LinkLocalAutoConf::none;
+    }
+    return linkLocalConf;
+}
+
 ServerList EthernetInterface::nTPServers(ServerList servers)
 {
     auto ntpServers = EthernetInterfaceIntf::nTPServers(servers);
@@ -622,12 +683,36 @@ void EthernetInterface::writeConfigurationFile()
 
     // write the network section
     stream << "[Network]\n";
-#ifdef LINK_LOCAL_AUTOCONFIGURATION
-    stream << "LinkLocalAddressing=yes\n";
-#else
-    stream << "LinkLocalAddressing=no\n";
-#endif
-    stream << "IPv6AcceptRA=false\n";
+
+    // Add the Link local auto configuration entry
+    auto conf = EthernetInterfaceIntf::linkLocalAutoConf();
+
+    std::string linkLocalConf;
+    if (conf == LinkLocalConf::both)
+    {
+        linkLocalConf = "yes";
+    }
+    else if (conf == LinkLocalConf::fallback)
+    {
+        linkLocalConf = "fallback";
+    }
+    else if (conf == LinkLocalConf::v6)
+    {
+        linkLocalConf = "ipv6";
+    }
+    else if (conf == LinkLocalConf::v4)
+    {
+        linkLocalConf = "ipv4";
+    }
+    else if (conf == LinkLocalConf::none)
+    {
+        linkLocalConf = "no";
+    }
+
+    stream << "LinkLocalAddressing=" + linkLocalConf + "\n";
+
+    stream << std::boolalpha
+           << "IPv6AcceptRA=" << EthernetInterfaceIntf::iPv6AcceptRA() << "\n";
 
     // Add the VLAN entry
     for (const auto& intf : vlanInterfaces)

--- a/ethernet_interface.hpp
+++ b/ethernet_interface.hpp
@@ -31,6 +31,8 @@ using EthernetInterfaceIntf =
     sdbusplus::xyz::openbmc_project::Network::server::EthernetInterface;
 using MacAddressIntf =
     sdbusplus::xyz::openbmc_project::Network::server::MACAddress;
+using LinkLocalAutoConf = sdbusplus::xyz::openbmc_project::Network::server::
+    EthernetInterface::LinkLocalConf;
 
 using ServerList = std::vector<std::string>;
 using ObjectPath = sdbusplus::message::object_path;
@@ -146,6 +148,9 @@ class EthernetInterface : public Ifaces
     /** Set value of DHCPEnabled */
     bool dHCPEnabled(bool value) override;
 
+    /** Set value of LinkLocalAutoConf */
+    LinkLocalAutoConf linkLocalAutoConf(LinkLocalAutoConf value) override;
+
     /** @brief sets the MAC address.
      *  @param[in] value - MAC address which needs to be set on the system.
      *  @returns macAddress of the interface or throws an error.
@@ -183,8 +188,8 @@ class EthernetInterface : public Ifaces
 
     using EthernetInterfaceIntf::dHCPEnabled;
     using EthernetInterfaceIntf::interfaceName;
+    using EthernetInterfaceIntf::linkLocalAutoConf;
     using MacAddressIntf::mACAddress;
-
     /** @brief Absolute path of the resolv conf file */
     static constexpr auto resolvConfFile = "/etc/resolv.conf";
 
@@ -263,6 +268,11 @@ class EthernetInterface : public Ifaces
      *
      */
     ServerList getNameServerFromConf();
+
+    /** @brief get the link local auto conf from the network conf
+     *
+     */
+    LinkLocalAutoConf getLinkLocalAutoConfFromConf();
 
     /** @brief Persistent sdbusplus DBus bus connection. */
     sdbusplus::bus::bus& bus;

--- a/network_config.cpp
+++ b/network_config.cpp
@@ -20,7 +20,7 @@ void writeDHCPDefault(const std::string& filename, const std::string& interface)
     filestream << "[Match]\nName=" << interface <<
                 "\n[Network]\nDHCP=true\n"
 #ifdef LINK_LOCAL_AUTOCONFIGURATION
-                "LinkLocalAddressing=yes\n"
+                "LinkLocalAddressing=fallback\n"
 #else
                 "LinkLocalAddressing=no\n"
 #endif


### PR DESCRIPTION
ethernet interface.

this commit enables runtime link-local address
configuration and supports "yes","no","ipv4","ipv6"
and "fallback" options supported by systemd

Here is commit to add dbus fallback enum
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-dbus-interfaces/+/25407

Tested by:
configured linkLocalAutoConf to ipv6,ipv4,none,both
and fallback
and verified link local address objects created

Signed-off-by: Ravi Teja <raviteja28031990@gmail.com>
Change-Id: I70c4b3b2502e37478c9cd747bc9eadfca224ff4e

Conflicts:
	ethernet_interface.cpp