### PR TITLE
Allow static configuration of NTP and DNS in DHCP mode

### DIFF
--- a/ethernet_interface.cpp
+++ b/ethernet_interface.cpp
@@ -441,7 +441,6 @@ ServerList EthernetInterface::nameservers(ServerList value)
     try
     {
         EthernetInterfaceIntf::nameservers(value);
-
         writeConfigurationFile();
 
         // Currently we don't have systemd-resolved enabled
@@ -635,6 +634,18 @@ void EthernetInterface::writeConfigurationFile()
         stream << "VLAN=" << intf.second->EthernetInterface::interfaceName()
                << "\n";
     }
+    // Add the NTP server
+    for (const auto& ntp : EthernetInterfaceIntf::nTPServers())
+    {
+        stream << "NTP=" << ntp << "\n";
+    }
+
+    // Add the DNS entry
+    for (const auto& dns : EthernetInterfaceIntf::nameservers())
+    {
+        stream << "DNS=" << dns << "\n";
+    }
+
     // Add the DHCP entry
     auto value = dHCPEnabled() ? "true"s : "false"s;
     stream << "DHCP="s + value + "\n";
@@ -643,18 +654,6 @@ void EthernetInterface::writeConfigurationFile()
     // in config file.
     if (dHCPEnabled() == false)
     {
-        // Add the NTP server
-        for (const auto& ntp : EthernetInterfaceIntf::nTPServers())
-        {
-            stream << "NTP=" << ntp << "\n";
-        }
-
-        // Add the DNS entry
-        for (const auto& dns : EthernetInterfaceIntf::nameservers())
-        {
-            stream << "DNS=" << dns << "\n";
-        }
-
         // Static
         for (const auto& addr : addrs)
         {


### PR DESCRIPTION
Before this fix we don't allow the static DNS or NTP configuration
this fix is removing that limitation and allow the static NTP
and DNS configuration in DHCP mode.

Change-Id: I5a909373ee1eaff850cf96622451af6acfaddcc3
Signed-off-by: Ratan Gupta <ratagupt@linux.vnet.ibm.com>