### PR TITLE
Revert linklocal  auto conf support

### DIFF
--- a/ethernet_interface.cpp
+++ b/ethernet_interface.cpp
@@ -51,7 +51,6 @@ EthernetInterface::EthernetInterface(sdbusplus::bus::bus& bus,
     MacAddressIntf::mACAddress(getMACAddress(intfName));
     EthernetInterfaceIntf::nTPServers(getNTPServersFromConf());
     EthernetInterfaceIntf::nameservers(getNameServerFromConf());
-    EthernetInterfaceIntf::linkLocalAutoConf(getLinkLocalAutoConfFromConf());
 
     // Emit deferred signal.
     if (emitSignal)
@@ -425,18 +424,6 @@ bool EthernetInterface::dHCPEnabled(bool value)
     return value;
 }
 
-LinkLocalAutoConf EthernetInterface::linkLocalAutoConf(LinkLocalAutoConf value)
-{
-    if (value == EthernetInterfaceIntf::linkLocalAutoConf())
-    {
-        return value;
-    }
-
-    EthernetInterfaceIntf::linkLocalAutoConf(value);
-    manager.writeToConfigurationFile();
-    return value;
-}
-
 ServerList EthernetInterface::nameservers(ServerList value)
 {
     for (const auto& nameserverip : value)
@@ -572,54 +559,6 @@ ServerList EthernetInterface::getNTPServersFromConf()
     return servers;
 }
 
-LinkLocalAutoConf EthernetInterface::getLinkLocalAutoConfFromConf()
-{
-    fs::path confPath = manager.getConfDir();
-
-    std::string fileName = systemd::config::networkFilePrefix +
-                           interfaceName() + systemd::config::networkFileSuffix;
-    confPath /= fileName;
-
-    config::ValueList values;
-
-    auto linkLocalConf = LinkLocalAutoConf::fallback;
-
-    config::Parser parser(confPath.string());
-    auto rc = config::ReturnCode::SUCCESS;
-
-    std::tie(rc, values) = parser.getValues("Network", "LinkLocalAddressing");
-    if (rc != config::ReturnCode::SUCCESS)
-    {
-        log<level::DEBUG>(
-            "Unable to get the value for Network[LinkLocalAddressing]",
-            entry("rc=%d", rc));
-        return linkLocalConf;
-    }
-
-    if (values[0] == "yes")
-    {
-        linkLocalConf = LinkLocalAutoConf::both;
-    }
-    else if (values[0] == "ipv4")
-    {
-        linkLocalConf = LinkLocalAutoConf::v4;
-    }
-    else if (values[0] == "fallback")
-    {
-        linkLocalConf = LinkLocalAutoConf::fallback;
-    }
-
-    else if (values[0] == "ipv6")
-    {
-        linkLocalConf = LinkLocalAutoConf::v6;
-    }
-    else if (values[0] == "no")
-    {
-        linkLocalConf = LinkLocalAutoConf::none;
-    }
-    return linkLocalConf;
-}
-
 ServerList EthernetInterface::nTPServers(ServerList servers)
 {
     auto ntpServers = EthernetInterfaceIntf::nTPServers(servers);
@@ -682,35 +621,12 @@ void EthernetInterface::writeConfigurationFile()
 
     // write the network section
     stream << "[Network]\n";
-
-    // Add the Link local auto configuration entry
-    auto conf = EthernetInterfaceIntf::linkLocalAutoConf();
-
-    std::string linkLocalConf;
-    if (conf == LinkLocalConf::both)
-    {
-        linkLocalConf = "yes";
-    }
-    else if (conf == LinkLocalConf::fallback)
-    {
-        linkLocalConf = "fallback";
-    }
-    else if (conf == LinkLocalConf::v6)
-    {
-        linkLocalConf = "ipv6";
-    }
-    else if (conf == LinkLocalConf::v4)
-    {
-        linkLocalConf = "ipv4";
-    }
-    else if (conf == LinkLocalConf::none)
-    {
-        linkLocalConf = "no";
-    }
-
-    stream << "LinkLocalAddressing=" + linkLocalConf + "\n";
+#ifdef LINK_LOCAL_AUTOCONFIGURATION
+    stream << "LinkLocalAddressing=yes\n";
+#else
+    stream << "LinkLocalAddressing=no\n";
+#endif
     stream << "IPv6AcceptRA=false\n";
-
 
     // Add the VLAN entry
     for (const auto& intf : vlanInterfaces)

--- a/ethernet_interface.hpp
+++ b/ethernet_interface.hpp
@@ -31,8 +31,6 @@ using EthernetInterfaceIntf =
     sdbusplus::xyz::openbmc_project::Network::server::EthernetInterface;
 using MacAddressIntf =
     sdbusplus::xyz::openbmc_project::Network::server::MACAddress;
-using LinkLocalAutoConf = sdbusplus::xyz::openbmc_project::Network::server::
-    EthernetInterface::LinkLocalConf;
 
 using ServerList = std::vector<std::string>;
 using ObjectPath = sdbusplus::message::object_path;
@@ -148,8 +146,6 @@ class EthernetInterface : public Ifaces
     /** Set value of DHCPEnabled */
     bool dHCPEnabled(bool value) override;
 
-    /** Set value of LinkLocalAutoConf */
-    LinkLocalAutoConf linkLocalAutoConf(LinkLocalAutoConf value) override;
 
     /** @brief sets the MAC address.
      *  @param[in] value - MAC address which needs to be set on the system.
@@ -188,7 +184,6 @@ class EthernetInterface : public Ifaces
 
     using EthernetInterfaceIntf::dHCPEnabled;
     using EthernetInterfaceIntf::interfaceName;
-    using EthernetInterfaceIntf::linkLocalAutoConf;
     using MacAddressIntf::mACAddress;
     /** @brief Absolute path of the resolv conf file */
     static constexpr auto resolvConfFile = "/etc/resolv.conf";
@@ -268,11 +263,6 @@ class EthernetInterface : public Ifaces
      *
      */
     ServerList getNameServerFromConf();
-
-    /** @brief get the link local auto conf from the network conf
-     *
-     */
-    LinkLocalAutoConf getLinkLocalAutoConfFromConf();
 
     /** @brief Persistent sdbusplus DBus bus connection. */
     sdbusplus::bus::bus& bus;

--- a/network_config.cpp
+++ b/network_config.cpp
@@ -20,7 +20,7 @@ void writeDHCPDefault(const std::string& filename, const std::string& interface)
     filestream << "[Match]\nName=" << interface <<
                 "\n[Network]\nDHCP=true\n"
 #ifdef LINK_LOCAL_AUTOCONFIGURATION
-                "LinkLocalAddressing=fallback\n"
+                "LinkLocalAddressing=yes\n"
 #else
                 "LinkLocalAddressing=no\n"
 #endif


### PR DESCRIPTION
Linklocal fallback is not working in op940, so reverting fallback option changes