### PR TITLE
Fix the networkd crash during creation of vlan

### DIFF
--- a/ethernet_interface.cpp
+++ b/ethernet_interface.cpp
@@ -48,7 +48,13 @@ EthernetInterface::EthernetInterface(sdbusplus::bus::bus& bus,
     std::replace(intfName.begin(), intfName.end(), '_', '.');
     interfaceName(intfName);
     EthernetInterfaceIntf::dHCPEnabled(dhcpEnabled);
-    MacAddressIntf::mACAddress(getMACAddress(intfName));
+    EthernetInterfaceIntf::iPv6AcceptRA(getIPv6AcceptRAFromConf());
+    // Don't get the mac address from the system as the mac address
+    // would be same as parent interface.
+    if (intfName.find(".") == std::string::npos)
+    {
+        MacAddressIntf::mACAddress(getMACAddress(intfName));
+    }
     EthernetInterfaceIntf::nTPServers(getNTPServersFromConf());
     EthernetInterfaceIntf::nameservers(getNameServerFromConf());
 


### PR DESCRIPTION
During creation of VLAN interface object, get the mac address
from the parent ethernet interface instead of getting it from the
system.

This commit fixes the above behaviour.

Change-Id: Iaba89b0da967c9c1bee27fc49d413364949d48b3
Signed-off-by: Ratan Gupta <ratagupt@linux.vnet.ibm.com>

Conflicts:
	ethernet_interface.cpp