### PR TITLE
Creating eth0 and eth1 interface irrespective of vmi_if_count in bios table

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
@@ -219,15 +219,11 @@ void HypNetworkMgr::createIfObjects()
 {
     setBIOSTableAttrs();
 
-    if (intfCount == 1)
-    {
-        // create eth0 object
-        log<level::INFO>("Creating eth0 object");
-        interfaces.emplace(
-            "eth0", std::make_shared<phosphor::network::HypEthInterface>(
-                        bus, (objectPath + "/eth0").c_str(), "eth0", *this));
-    }
-    else if (intfCount == 2)
+    // The hypervisor can support maximum of
+    // 2 ethernet interfaces. Both eth0/1 objects are
+    // created during init time to support the static
+    // network configurations on the both.
+    if (intfCount == 1 || intfCount == 2)
     {
         // create eth0 and eth1 objects
         log<level::INFO>("Creating eth0 and eth1 objects");


### PR DESCRIPTION
This commit creates eth0/1 interfaces irrespective of
vmi_if_count value in the bios table.
Previously, it was implemented in such a way that
the interfaces will be created based on the if count
value in the bios table (if if_count is 1, the create eth0,
if if_count is 2, the  create eth0 & eth1) and hence, the
user was unable to create the eth1 interface at all (when
if_count is 1).

Also, itseems phyp doesnt take this bios property into account
and it has by default eth0 and eth1 interfaces.

Fixes the defect at: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW538415