### PR TITLE
Resolve errors related to vmi n/w configuration

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -166,10 +166,19 @@ void HypEthInterface::createIPAddressObjects()
             if (ipType.find("Static") != std::string::npos)
             {
                 ipOrigin = IP::AddressOrigin::Static;
+                HypEthernetIntf::dhcpEnabled(HypEthInterface::DHCPConf::none);
             }
             else if (ipType.find("DHCP") != std::string::npos)
             {
                 ipOrigin = IP::AddressOrigin::DHCP;
+                if (protocol == "ipv4")
+                {
+                    HypEthernetIntf::dhcpEnabled(HypEthInterface::DHCPConf::v4);
+                }
+                else if (protocol == "ipv6")
+                {
+                    HypEthernetIntf::dhcpEnabled(HypEthInterface::DHCPConf::v6);
+                }
             }
             else
             {

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "hyp_ethernet_interface.hpp"
+#include "hyp_nw_config_serialize.hpp"
 #include "ipaddress.hpp"
 #include "util.hpp"
 
@@ -24,6 +25,7 @@ using HypIPIfaces = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Object::server::Enable>;
 
 using HypIP = sdbusplus::xyz::openbmc_project::Network::server::IP;
+using HypEnableIntf = sdbusplus::xyz::openbmc_project::Object::server::Enable;
 
 using PendingAttributesType =
     std::map<std::string,
@@ -112,6 +114,19 @@ class HypIPAddress : public HypIPIfaces
      */
     void resetBaseBiosTableAttrs();
 
+    /** @brief Method to set the enabled prop onto dbus from the
+     *         persisted file whenever the service starts
+     */
+    void setEnabledProp();
+
+    /** @brief Method to set the enabled prop.
+     *  @param[in] value - true/false indicating if the host consumes the ip
+     *  @result true/false
+     */
+    bool enabled(bool value) override;
+
+    using HypEnableIntf::enabled;
+
     using HypIP::address;
     using HypIP::gateway;
     using HypIP::origin;
@@ -123,6 +138,9 @@ class HypIPAddress : public HypIPIfaces
 
     /** @brief Hypervisor eth interface id. */
     std::string intf;
+
+    /** @brief List of the properties to be persisted */
+    persistdata::NwConfigPropMap nwIPConfigList;
 
     /** @brief Parent Object. */
     HypEthInterface& parent;

--- a/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.cpp
@@ -1,0 +1,132 @@
+#include "hyp_nw_config_serialize.hpp"
+
+//#include <fmt/core.h>
+
+//#include <cereal/archives/binary.hpp>
+//#include <cereal/types/set.hpp>
+#include <fstream>
+#include <phosphor-logging/log.hpp>
+//#include <sstream>
+
+namespace phosphor
+{
+namespace network
+{
+namespace persistdata
+{
+
+using namespace phosphor::logging;
+
+void serialize(const NwConfigPropMap& list, std::string intf)
+{
+    std::string filePath;
+    if (intf == "if0")
+    {
+        filePath = HYP_NW_CONFIG_PERSIST_PATH + "eth0_network";
+    }
+    else if (intf == "if1")
+    {
+        filePath = HYP_NW_CONFIG_PERSIST_PATH + "eth1_network";
+    }
+
+    // Create directory if it doesnot exist
+    if (!std::filesystem::exists(HYP_NW_CONFIG_PERSIST_PATH.c_str()))
+    {
+        log<level::INFO>(
+            "Creating directory to store hypervisor nw config data...");
+        std::filesystem::create_directory(HYP_NW_CONFIG_PERSIST_PATH.c_str());
+    }
+
+    std::ofstream serializeFile(filePath.c_str(), std::ios::out);
+    if (serializeFile)
+    {
+        for (auto itr = list.begin(); itr != list.end(); itr++)
+        {
+            if (auto value = std::get_if<bool>(&itr->second))
+            {
+                serializeFile << itr->first << " " << *value;
+            }
+            else if (auto value = std::get_if<std::string>(&itr->second))
+            {
+                serializeFile << itr->first << " " << *value;
+            }
+            else if (auto value = std::get_if<int64_t>(&itr->second))
+            {
+                serializeFile << itr->first << " " << *value;
+            }
+        }
+        serializeFile.close();
+    }
+    else
+    {
+        log<level::ERR>("Couldn't open file. Exiting serialization");
+    }
+}
+
+bool deserialize(NwConfigPropMap& list, std::string intf)
+{
+    std::string filePath;
+    if (intf == "if0")
+    {
+        filePath = HYP_NW_CONFIG_PERSIST_PATH + "eth0_network";
+    }
+    else if (intf == "if1")
+    {
+        filePath = HYP_NW_CONFIG_PERSIST_PATH + "eth1_network";
+    }
+
+    try
+    {
+        if (std::filesystem::exists(filePath))
+        {
+            std::ifstream deSerializeFile(filePath.c_str(), std::ifstream::in);
+            std::string fileEntry;
+
+            while (getline(deSerializeFile, fileEntry))
+            {
+                std::string key;
+                std::string value;
+                std::stringstream sStream(fileEntry);
+
+                sStream >> key >> value;
+
+                // Check for each key and extract the value acc to the data type
+                // It should be converted to int for boolean and int64_t
+                // properties
+                // TODO: Bool and string types are handled here. Int types to be
+                // handled when there is a property of type int is to be
+                // persisted
+                if (key == "Enabled")
+                {
+                    if (std::stoi(value))
+                    {
+                        list[key] = true;
+                    }
+                    else
+                    {
+                        list[key] = false;
+                    }
+                }
+                else
+                {
+                    // else - for all other properties of type string
+                    list[key] = value;
+                }
+            }
+            deSerializeFile.close();
+            return true;
+        }
+        return false;
+    }
+    catch (std::exception& e)
+    {
+        log<level::ERR>("Failed to deserialize, errormsg({})",
+                        entry("ERR:%s", e.what()));
+        std::filesystem::remove(filePath);
+        return false;
+    }
+}
+
+} // namespace persistdata
+} // namespace network
+} // namespace phosphor

--- a/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "config.h"
+
+#include "types.hpp"
+
+#include <filesystem>
+
+namespace phosphor
+{
+namespace network
+{
+namespace persistdata
+{
+using NwConfigPropMap =
+    std::map<std::string, std::variant<std::string, int64_t, bool>>;
+
+const std::string HYP_NW_CONFIG_PERSIST_PATH = "/var/lib/network/hypervisor/";
+
+/** @brief Serialize and persist list of n/w config properties.
+ *  @param[in] list - list of hypervisor n/w config properties.
+ *  @param[in] intf - hyp eth interface label (eth0/eth1).
+ */
+void serialize(const NwConfigPropMap& list, std::string intf);
+
+/** @brief Deserialze a persisted list of n/w config properties.
+ *  @param[out] list - list of n/w config properties.
+ *  @return intf - hyp eth interface label (eth0/eth1).
+ */
+bool deserialize(NwConfigPropMap& list, std::string intf);
+
+} // namespace persistdata
+} // namespace network
+} // namespace phosphor

--- a/src/ibm/hypervisor-network-mgr-src/meson.build
+++ b/src/ibm/hypervisor-network-mgr-src/meson.build
@@ -18,6 +18,7 @@ executable(
   'hyp_sys_config.cpp',
   'hyp_ethernet_interface.cpp',
   'hyp_ip_interface.cpp',
+  'hyp_nw_config_serialize.cpp',
   implicit_include_directories: false,
   dependencies: networkd_dep,
   install: true,


### PR DESCRIPTION
1. Resolve static vmiIp switch to dhcp after bmc reset

On a code update, or a bmc reboot, the "DHCPEnabled" prop
of the hypervisor eth network objects are switching to
dhcpEnabled as true by default.

Instead it has to be read from the bios table's "vmi_if<0/1>_ipv4_method"
property and update the dbus object, everytime this application
restarts. This solves the above problem.

Fix for:
https://w3.rchland.ibm.com/projects/bestquest/?defect=SW539415

Tested By:

* busctl call  xyz.openbmc_project.BIOSConfigManager
/xyz/openbmc_project/bios_config/manager xyz.openbmc_project.BIOSConfig.Manager
GetAttribute s vmi_if0_ipv4_method
=> svv "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Enumeration" s "IPv4DHCP" s ""

* busctl call  xyz.openbmc_project.BIOSConfigManager
/xyz/openbmc_project/bios_config/manager xyz.openbmc_project.BIOSConfig.Manager
GetAttribute s vmi_if1_ipv4_method
=> svv "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.Enumeration" s "IPv4Static" s ""

So, on every reboot/code update, this hyp nw config app restarts and
the "DHCPEnabled" property will be updated w.r.t bios table values (above):

* busctl get-property xyz.openbmc_project.Network.Hypervisor
/xyz/openbmc_project/network/hypervisor/eth0
xyz.openbmc_project.Network.EthernetInterface DHCPEnabled
=> s "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.v4"

* busctl get-property xyz.openbmc_project.Network.Hypervisor
/xyz/openbmc_project/network/hypervisor/eth1
xyz.openbmc_project.Network.EthernetInterface DHCPEnabled
=> s "xyz.openbmc_project.Network.EthernetInterface.DHCPConf.none"

2. Persist "Enabled" property accross reboot
    
The "Enabled" property of xyz.openbmc_project.Object.Enable
interface of the ip address object
(eg: /xyz/openbmc_project/network/hypervisor/eth<0/1>/ipv4/addr0)
will be set by pldm once the host consumes the ip address set by
the user. When the system reboots, this value is not persisted
and is defaulted to false.
Pldm will not be updating this value on reboot, it only sets it
when phyp sends the sensor event when the ip is consumed and
pldm receives this and sets the "Enabled" property.

busctl introspect xyz.openbmc_project.Network.Hypervisor /xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0
NAME                                TYPE      SIGNATURE RESULT/VALUE                             FLAGS
org.freedesktop.DBus.Introspectable interface -         -                                        -
.Introspect                         method    -         s                                        -
org.freedesktop.DBus.Peer           interface -         -                                        -
.GetMachineId                       method    -         s                                        -
.Ping                               method    -         -                                        -
org.freedesktop.DBus.Properties     interface -         -                                        -
.Get                                method    ss        v                                        -
.GetAll                             method    s         a{sv}                                    -
.Set                                method    ssv       -                                        -
.PropertiesChanged                  signal    sa{sv}as  -                                        -
xyz.openbmc_project.Network.IP      interface -         -                                        -
.Address                            property  s         "10.6.6.2"                               emits-change writable
.Gateway                            property  s         "10.6.6.1"                               emits-change writable
.Origin                             property  s         "xyz.openbmc_project.Network.IP.Address… emits-change writable
.PrefixLength                       property  y         22                                       emits-change writable
.Type                               property  s         "xyz.openbmc_project.Network.IP.Protoco… emits-change writable
xyz.openbmc_project.Object.Delete   interface -         -                                        -
.Delete                             method    -         -                                        -
xyz.openbmc_project.Object.Enable   interface -         -                                        -
.Enabled                            property  b         true                                     emits-change writable

The values will be stored under /var/lib/network/hypervisor/ path
with the file name being eth0_network/eth1_network.

Note:
Any prperty can be persisted with this change. For now, "Enabled"
property is only persisted, since there are no ther properties
that needs to be persisted, the reason being, all the other properties
are read from the bios table.

Tested By:

1. Set vmi ip through redfish command:
PATCH -D patch.txt -d '{"IPv4StaticAddresses":[{"Address": "10.6.6.2",
"SubnetMask": "255.255.252.0","Gateway":"10.6.6.1"}]}'
https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0

2. reboot the bmc
3. check if the enabled property is still true on the ip dbus object

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>