### PR TITLE
Sync hyp dbus obj w/ biostable on dhcp ip updation

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
@@ -27,6 +27,8 @@ using CreateIface = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Network::server::EthernetInterface,
     sdbusplus::xyz::openbmc_project::Network::IP::server::Create>;
 
+using biosTableRetAttrValueType = std::variant<std::string, int64_t>;
+
 using biosTableType = std::map<std::string, std::variant<int64_t, std::string>>;
 
 using PendingAttributesType =
@@ -68,7 +70,21 @@ class HypEthInterface : public CreateIface
         HypEthernetIntf::interfaceName(intfName);
 
         createIPAddressObjects();
+        watchBaseBiosTable();
     };
+
+    /* @brief Method to return the value of the input attribute
+     *        from the BaseBIOSTable
+     *  @param[in] attrName - name of the bios attribute
+     *  @param[out] - value of the bios attribute
+     */
+    biosTableRetAttrValueType getAttrFromBiosTable(const std::string& attrName);
+
+    /* @brief Function to watch the Base Bios Table for ip
+     *        address change from the host and refresh the hypervisor networkd
+     * service
+     */
+    void watchBaseBiosTable();
 
     /* @brief creates the IP dbus object
      */


### PR DESCRIPTION
Whenever there is a change in the range of ip address in the dhcp
configuration, the dhcp server assigns new ip & vmi sends back the
notification to pldm, also this ip will be updated in the bios table.
But the hypervisor networkd dbus object was not in sync with the
updated dhcp ip. It still contained the older one.

The change introduced in this pr, would listen on the properties
changed signal on BaseBIOSTable property of bios config manager
and in every dhcp ip updation, this service restarts thus refreshing
the dbus objects with the updated values in the bios table.

Fix the defect at: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW539707

Tested By:

* DHCP already configured on eth1
* Change the ip range in the dhcp conf file and restart the dhcpd
* Bios table will be updated with the new ip
* When the above updation happens, hyp networkd restarts
* introspect on the eth1 dbus object to see the updated ip

=> Before changing the range:

* busctl call  xyz.openbmc_project.BIOSConfigManager /xyz/openbmc_project/bios_config/manager
xyz.openbmc_project.BIOSConfig.Manager GetAttribute s vmi_if1_ipv4_ipaddr
svv "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.String" s "10.5.5.10" s ""

* busctl introspect xyz.openbmc_project.Network.Hypervisor /xyz/openbmc_project/network/hypervisor/eth1/ipv4/addr0
NAME                                TYPE      SIGNATURE RESULT/VALUE                             FLAGS
org.freedesktop.DBus.Introspectable interface -         -                                        -
.Introspect                         method    -         s                                        -
org.freedesktop.DBus.Peer           interface -         -                                        -
.GetMachineId                       method    -         s                                        -
.Ping                               method    -         -                                        -
org.freedesktop.DBus.Properties     interface -         -                                        -
.Get                                method    ss        v                                        -
.GetAll                             method    s         a{sv}                                    -
.Set                                method    ssv       -                                        -
.PropertiesChanged                  signal    sa{sv}as  -                                        -
xyz.openbmc_project.Network.IP      interface -         -                                        -
.Address                            property  s         "10.5.5.10"                              emits-change writable
.Gateway                            property  s         "10.5.5.1"                               emits-change writable
.Origin                             property  s         "xyz.openbmc_project.Network.IP.Address… emits-change writable
.PrefixLength                       property  y         24                                       emits-change writable
.Type                               property  s         "xyz.openbmc_project.Network.IP.Protoco… emits-change writable
xyz.openbmc_project.Object.Delete   interface -         -                                        -
.Delete                             method    -         -                                        -
xyz.openbmc_project.Object.Enable   interface -         -                                        -
.Enabled                            property  b         true                                     emits-change writable

=> Change the range and check bios table and dbus object

* busctl call  xyz.openbmc_project.BIOSConfigManager /xyz/openbmc_project/bios_config/manager
xyz.openbmc_project.BIOSConfig.Manager GetAttribute s vmi_if1_ipv4_ipaddr
svv "xyz.openbmc_project.BIOSConfig.Manager.AttributeType.String" s "10.5.5.23" s ""

* busctl introspect xyz.openbmc_project.Network.Hypervisor /xyz/openbmc_project/network/hypervisor/eth1/ipv4/addr0
NAME                                TYPE      SIGNATURE RESULT/VALUE                             FLAGS
org.freedesktop.DBus.Introspectable interface -         -                                        -
.Introspect                         method    -         s                                        -
org.freedesktop.DBus.Peer           interface -         -                                        -
.GetMachineId                       method    -         s                                        -
.Ping                               method    -         -                                        -
org.freedesktop.DBus.Properties     interface -         -                                        -
.Get                                method    ss        v                                        -
.GetAll                             method    s         a{sv}                                    -
.Set                                method    ssv       -                                        -
.PropertiesChanged                  signal    sa{sv}as  -                                        -
xyz.openbmc_project.Network.IP      interface -         -                                        -
.Address                            property  s         "10.5.5.23"                              emits-change writable
.Gateway                            property  s         "10.5.5.1"                               emits-change writable
.Origin                             property  s         "xyz.openbmc_project.Network.IP.Address… emits-change writable
.PrefixLength                       property  y         24                                       emits-change writable
.Type                               property  s         "xyz.openbmc_project.Network.IP.Protoco… emits-change writable
xyz.openbmc_project.Object.Delete   interface -         -                                        -
.Delete                             method    -         -                                        -
xyz.openbmc_project.Object.Enable   interface -         -                                        -
.Enabled                            property  b         true                                     emits-change writable

=> Redfish response:

Before range updation:

GET https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1
{
  "@odata.id": "/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1",
  "@odata.type": "#EthernetInterface.v1_5_1.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": true
  },
  "Description": "Hypervisor's Virtual Management Ethernet Interface",
  "HostName": "",
  "IPv4Addresses": [
    {
      "Address": "10.5.5.10",
      "AddressOrigin": "DHCP",
      "Gateway": "10.5.5.1",
      "SubnetMask": "255.255.255.0"
    }
  ],
  "IPv4StaticAddresses": [],
  "Id": "eth1",
  "InterfaceEnabled": true,
  "Name": "Hypervisor Ethernet Interface"
}

After range updation:

GET https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1
{
  "@odata.id": "/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1",
  "@odata.type": "#EthernetInterface.v1_5_1.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": true
  },
  "Description": "Hypervisor's Virtual Management Ethernet Interface",
  "HostName": "",
  "IPv4Addresses": [
    {
      "Address": "10.5.5.23",
      "AddressOrigin": "DHCP",
      "Gateway": "10.5.5.1",
      "SubnetMask": "255.255.255.0"
    }
  ],
  "IPv4StaticAddresses": [],
  "Id": "eth1",
  "InterfaceEnabled": true,
  "Name": "Hypervisor Ethernet Interface"
}

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I4a60fc3045e6c7a234991ac43f0f2fc1614e8b34