### PR TITLE
Fix vmi dhcp issues

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -1,7 +1,5 @@
 #include "hyp_ethernet_interface.hpp"
 
-#include <fstream>
-
 class HypEthInterface;
 class HypIPAddress;
 

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -1,5 +1,7 @@
 #include "hyp_ethernet_interface.hpp"
 
+#include <fstream>
+
 class HypEthInterface;
 class HypIPAddress;
 
@@ -166,26 +168,31 @@ void HypEthInterface::watchBaseBiosTable()
                 {
                     for (auto addr : addrs)
                     {
-                        if (addr.first == currIpAddr)
+                        // dhcp server changes any/all of its properties
+                        auto ipObj = addr.second;
+                        ipObj->address(ipAddr);
+                        if (prefixLen == 0)
                         {
-                            auto ipObj = addr.second;
-                            ipObj->address(ipAddr);
-                            if (prefixLen == 0)
-                            {
-                                // The setter method in the ip class, doesnot
-                                // allow the user to set 0 as the prefix length.
-                                // Since, this setting of 0 is within the
-                                // implementation, setting the prefix length
-                                // directly here.
-                                ipObj->HypIP::prefixLength(prefixLen);
-                            }
-                            else
-                            {
-                                ipObj->prefixLength(prefixLen);
-                            }
-                            ipObj->gateway(gateway);
-                            break;
+                            // The setter method in the ip class, doesnot
+                            // allow the user to set 0 as the prefix length.
+                            // Since, this setting of 0 is within the
+                            // implementation, setting the prefix length
+                            // directly here.
+                            ipObj->HypIP::prefixLength(prefixLen);
+
+                            // Update the biosTableAttrs map with prefix
+                            // length because we are not calling the setter
+                            // method here.
+                            std::string attrName =
+                                ipObj->getHypPrefix() + "_prefix_length";
+                            setIpPropsInMap(attrName, prefixLen, "Integer");
                         }
+                        else
+                        {
+                            ipObj->prefixLength(prefixLen);
+                        }
+                        ipObj->gateway(gateway);
+                        break;
                     }
                 }
             }
@@ -517,14 +524,6 @@ ObjectPath HypEthInterface::ip(HypIP::Protocol protType, std::string ipaddress,
                               Argument::ARGUMENT_VALUE(ipaddress.c_str()));
     }
 
-    for (auto addr : addrs)
-    {
-        auto addrKey = addrs.extract(addr.first);
-        addrKey.key() = ipaddress;
-        auto ipObj = addr.second;
-        break;
-    }
-
     const std::string intfLabel = getIntfLabel();
     if (intfLabel == "")
     {
@@ -543,6 +542,26 @@ ObjectPath HypEthInterface::ip(HypIP::Protocol protType, std::string ipaddress,
     }
 
     std::string objPath = objectPath + "/" + protocol + "/" + ipObjId;
+
+    for (auto addr : addrs)
+    {
+        auto ipObj = addr.second;
+        std::string ipObjAddr = ipObj->address();
+        uint8_t ipObjPrefixLen = ipObj->prefixLength();
+        std::string ipObjGateway = ipObj->gateway();
+
+        if ((ipaddress == ipObjAddr) && (prefixLength == ipObjPrefixLen) &&
+            (gateway == ipObjGateway))
+        {
+            log<level::ERR>("Trying to set same ip properties");
+            // Return the existing object path
+            return objPath;
+        }
+        auto addrKey = addrs.extract(addr.first);
+        addrKey.key() = ipaddress;
+        break;
+    }
+
     addrs[ipaddress] = std::make_shared<phosphor::network::HypIPAddress>(
         bus, (objPath).c_str(), *this, protType, ipaddress, origin,
         prefixLength, gateway, intfLabel);

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -177,10 +177,26 @@ void HypIPAddress::resetIPObjProps()
 {
     // Reset the ip obj properties
     log<level::INFO>("Resetting the ip addr object properties");
-    HypIP::address("0.0.0.0");
-    HypIP::gateway("0.0.0.0");
+
+    std::string zeroIp = "0.0.0.0";
+    HypIP::address(zeroIp);
+    HypIP::gateway(zeroIp);
     HypIP::prefixLength(0);
     HypIP::origin(IP::AddressOrigin::Static);
+
+    std::string prefix = getHypPrefix();
+
+    std::string attrIpaddr = prefix + "ipaddr";
+    parent.setIpPropsInMap(attrIpaddr, zeroIp, "String");
+
+    std::string attrPrefixLen = prefix + "prefix_length";
+    parent.setIpPropsInMap(attrPrefixLen, 0, "Integer");
+
+    std::string attrGateway = prefix + "gateway";
+    parent.setIpPropsInMap(attrGateway, zeroIp, "String");
+
+    std::string attrMethod = prefix + "method";
+    parent.setIpPropsInMap(attrMethod, "IPv4Static", "String");
 }
 
 void HypIPAddress::resetBaseBiosTableAttrs()


### PR DESCRIPTION
There are two problems with the current code:
1. Setting dhcp to true is retaining earlier assigned static ip
   details and not showing 0.0.0.0
2. Push style events are generated when updating an existing VMI IP
   address

Solution for 1:
When there is no dhcp server configured, and if the user sets dhcp to
true, it should return all the default values to the ip properties and
this is done in the watchBiostable method in hyp_ethernet_interface.cpp
Defect url: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW540930

Solution for 2:
Whenever a user configures the vmi eth interface with the same ip
address, then the existing dbus object path is returned back
Defect url: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW540634

Tested By:

Problem 1:

PATCH -d '{"IPv4StaticAddresses":[{"Address": "9.3.197.4","SubnetMask": \
"255.255.255.0","Gateway":"9.3.197.1"}]}' \
https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1

GET https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1{
  "@odata.id": "/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1",
  "@odata.type": "#EthernetInterface.v1_5_1.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": false
  },
  "Description": "Hypervisor's Virtual Management Ethernet Interface",
  "HostName": "",
  "IPv4Addresses": [
    {
      "Address": "9.3.197.4",
      "AddressOrigin": "Static",
      "Gateway": "9.3.197.1",
      "SubnetMask": "255.255.255.0"
    }
  ],
  "IPv4StaticAddresses": [
    {
      "Address": "9.3.197.4",
      "AddressOrigin": "Static",
      "Gateway": "9.3.197.1",
      "SubnetMask": "255.255.255.0"
    }
  ],
  "Id": "eth1",
  "InterfaceEnabled": true,
  "Name": "Hypervisor Ethernet Interface"
}

PATCH -d '{"DHCPv4": {"DHCPEnabled" :true}}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1

GET https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1{
  "@odata.id": "/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1",
  "@odata.type": "#EthernetInterface.v1_5_1.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": true
  },
  "Description": "Hypervisor's Virtual Management Ethernet Interface",
  "HostName": "",
  "IPv4Addresses": [
    {
      "Address": "0.0.0.0",
      "AddressOrigin": "DHCP",
      "Gateway": "0.0.0.0",
      "SubnetMask": "0.0.0.0"
    }
  ],
  "IPv4StaticAddresses": [],
  "Id": "eth1",
  "InterfaceEnabled": true,
  "Name": "Hypervisor Ethernet Interface"
}

Problem 2:

PATCH -d '{"IPv4StaticAddresses":[{"Address": "9.3.197.4","SubnetMask": "255.255.255.0", \
"Gateway":"9.3.197.1"}]}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1

Console log:
    Dec 14 16:51:41 rain510 hyp-network-manager[2769]: Trying to set same ip properties

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I7f9cc4b744eacdd2705d675dfed6708e668b5a0c