### PR TITLE
Set static & dhcp sent ntp server ip on ethernet obj

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -43,6 +43,11 @@ constexpr auto RESOLVED_SERVICE = "org.freedesktop.resolve1";
 constexpr auto RESOLVED_INTERFACE = "org.freedesktop.resolve1.Link";
 constexpr auto PROPERTY_INTERFACE = "org.freedesktop.DBus.Properties";
 constexpr auto RESOLVED_SERVICE_PATH = "/org/freedesktop/resolve1/link/";
+
+constexpr auto TIMESYNCD_SERVICE = "org.freedesktop.timesync1";
+constexpr auto TIMESYNCD_INTERFACE = "org.freedesktop.timesync1.Manager";
+constexpr auto TIMESYNCD_SERVICE_PATH = "/org/freedesktop/timesync1";
+
 constexpr auto METHOD_GET = "Get";
 
 struct EthernetIntfSocket
@@ -117,8 +122,6 @@ EthernetInterface::EthernetInterface(sdbusplus::bus::bus& bus,
     {
         MacAddressIntf::macAddress(getMACAddress(intfName));
     }
-    EthernetInterfaceIntf::ntpServers(getNTPServersFromConf());
-
     EthernetInterfaceIntf::linkUp(linkUp());
     EthernetInterfaceIntf::nicEnabled(nicEnabled());
 
@@ -689,10 +692,40 @@ ServerList EthernetInterface::staticNameServers(ServerList value)
     return EthernetInterfaceIntf::staticNameServers();
 }
 
+void EthernetInterface::loadNTPServers()
+{
+    EthernetInterfaceIntf::ntpServers(getNTPServerFromTimeSyncd());
+    EthernetInterfaceIntf::staticNTPServers(getstaticNTPServersFromConf());
+}
+
 void EthernetInterface::loadNameServers()
 {
     EthernetInterfaceIntf::nameservers(getNameServerFromResolvd());
     EthernetInterfaceIntf::staticNameServers(getstaticNameServerFromConf());
+}
+
+ServerList EthernetInterface::getNTPServerFromTimeSyncd()
+{
+    ServerList servers; // Variable to capture the NTP Server IPs
+    auto method = bus.new_method_call(TIMESYNCD_SERVICE, TIMESYNCD_SERVICE_PATH,
+                                      PROPERTY_INTERFACE, METHOD_GET);
+
+    method.append(TIMESYNCD_INTERFACE, "LinkNTPServers");
+    auto reply = bus.call(method);
+
+    try
+    {
+        std::variant<ServerList> response;
+        reply.read(response);
+        servers = std::get<ServerList>(response);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        log<level::ERR>(
+            "Failed to get NTP server information from Systemd-Timesyncd");
+    }
+
+    return servers;
 }
 
 ServerList EthernetInterface::getstaticNameServerFromConf()
@@ -859,7 +892,7 @@ bool EthernetInterface::getIPv6AcceptRAFromConf()
     return (values[0] == "true");
 }
 
-ServerList EthernetInterface::getNTPServersFromConf()
+ServerList EthernetInterface::getstaticNTPServersFromConf()
 {
     fs::path confPath = manager.getConfDir();
 
@@ -881,15 +914,25 @@ ServerList EthernetInterface::getNTPServersFromConf()
     return servers;
 }
 
-ServerList EthernetInterface::ntpServers(ServerList servers)
+ServerList EthernetInterface::staticNTPServers(ServerList value)
 {
-    auto ntpServers = EthernetInterfaceIntf::ntpServers(servers);
+    try
+    {
+        EthernetInterfaceIntf::staticNTPServers(value);
 
-    writeConfigurationFile();
-    // timesynchd reads the NTP server configuration from the
-    // network file.
-    manager.restartSystemdUnit(networkdService);
-    return ntpServers;
+        writeConfigurationFile();
+        manager.reloadConfigs();
+    }
+    catch (InternalFailure& e)
+    {
+        log<level::ERR>("Exception processing NTP entries");
+    }
+    return EthernetInterfaceIntf::staticNTPServers();
+}
+
+ServerList EthernetInterface::ntpServers(ServerList /*servers*/)
+{
+    elog<NotAllowed>(NotAllowedArgument::REASON("ReadOnly Property"));
 }
 // Need to merge the below function with the code which writes the
 // config file during factory reset.
@@ -961,7 +1004,7 @@ void EthernetInterface::writeConfigurationFile()
                << "\n";
     }
     // Add the NTP server
-    for (const auto& ntp : EthernetInterfaceIntf::ntpServers())
+    for (const auto& ntp : EthernetInterfaceIntf::staticNTPServers())
     {
         stream << "NTP=" << ntp << "\n";
     }

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -98,6 +98,10 @@ class EthernetInterface : public Ifaces
                       DHCPConf dhcpEnabled, Manager& parent,
                       bool emitSignal = true);
 
+    /** @brief Function used to load the ntpservers
+     */
+    virtual void loadNTPServers();
+
     /** @brief Function used to load the nameservers.
      */
     virtual void loadNameServers();
@@ -202,6 +206,11 @@ class EthernetInterface : public Ifaces
      *  @param[in] value - vector of NTP servers.
      */
     ServerList ntpServers(ServerList value) override;
+
+    /** @brief sets the static NTP servers.
+     *  @param[in] value - vector of NTP servers.
+     */
+    ServerList staticNTPServers(ServerList value) override;
 
     /** @brief sets the DNS/nameservers.
      *  @param[in] value - vector of DNS servers.
@@ -314,10 +323,15 @@ class EthernetInterface : public Ifaces
     /** @brief write the dhcp section **/
     void writeDHCPSection(std::fstream& stream);
 
+    /** @brief get the NTP server list from the timsyncd dbus obj
+     *
+     */
+    ServerList getNTPServerFromTimeSyncd();
+
     /** @brief get the NTP server list from the network conf
      *
      */
-    ServerList getNTPServersFromConf();
+    ServerList getstaticNTPServersFromConf();
 
     /** @brief get the name server details from the network conf
      *

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -154,6 +154,7 @@ void Manager::createInterfaces()
         intf->createIPAddressObjects();
         intf->createStaticNeighborObjects();
         intf->loadNameServers();
+        intf->loadNTPServers();
 
         this->interfaces.emplace(
             std::make_pair(std::move(interface), std::move(intf)));
@@ -242,6 +243,11 @@ void Manager::setFistBootMACOnInterface(
 }
 
 #endif
+
+void Manager::reloadConfigs()
+{
+    reloadTimer->restartOnce(reloadTimeout);
+}
 
 void Manager::restartTimers()
 {

--- a/src/network_manager.hpp
+++ b/src/network_manager.hpp
@@ -130,6 +130,11 @@ class Manager : public details::VLANCreateIface
     void setFistBootMACOnInterface(
         const std::pair<std::string, std::string>& ethPair);
 
+    /** @brief Arms a timer to tell systemd-network to reload all of the network
+     * configurations
+     */
+    virtual void reloadConfigs();
+
     /** @brief Restart the systemd unit
      *  @param[in] unit - systemd unit name which needs to be
      *                    restarted.


### PR DESCRIPTION
Currently there is no way to differentiate between the Static
and DHCP assigned NTP servers at dbus

This commit adds StaticNTPServers peroperty to hold the static
configuration of NTP servers. This is a read-write property.
The existing NTPServer propery will hold both static and DHCP
assigned NTP servers. This is a read-only property.

The static and dhcp sent ntp server details are present in the
dbus object hosted by systemd-timesyncd service.

In this change, networkd fetches the ntp server details from the
timesyncd dbus object and set the "NTPServers" property with dhcp sent
ip and "StaticNTPServers" will be set from the configuration file.

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: If8b1b3ed2afb531f179e00da173f6f86a1bf0c18