### PR TITLE
Update dbus w.r.t bios settings patch req

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -127,6 +127,28 @@ void HypEthInterface::watchBaseBiosTable()
 
             std::shared_ptr<phosphor::network::HypEthInterface> ethObj =
                 findEthObj->second;
+
+            DHCPConf dhcpState = ethObj->dhcpEnabled();
+
+            if ((dhcpState == HypEthInterface::DHCPConf::none) &&
+                (dhcpEnabled == "IPv4DHCP"))
+            {
+                // There is a change in bios table method attribute (changed to
+                // dhcp) but dbus property contains static Change the dbus
+                // property to dhcp
+                log<level::INFO>("Setting dhcp on the dbus object");
+                ethObj->dhcpEnabled(HypEthInterface::DHCPConf::v4);
+            }
+            else if ((dhcpState != HypEthInterface::DHCPConf::none) &&
+                     (dhcpEnabled == "IPv4Static"))
+            {
+                // There is a change in bios table method attribute (changed to
+                // static) but dbus property contains dhcp Change the dbus
+                // property to static
+                log<level::INFO>("Setting static on the dbus object");
+                ethObj->dhcpEnabled(HypEthInterface::DHCPConf::none);
+            }
+
             auto ipAddrs = ethObj->addrs;
 
             std::string ipAddr;

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -71,7 +71,6 @@ void HypEthInterface::watchBaseBiosTable()
             // Return & continue to listen
             return;
         }
-        log<level::INFO>("BaseBIOSTable - property changed");
 
         // Check if the IP address has changed (i.e., if current ip address in
         // the biosTableAttrs data member and ip address in bios table are
@@ -173,7 +172,7 @@ void HypEthInterface::watchBaseBiosTable()
                         std::get<std::string>(getAttrFromBiosTable(i.first));
                     if (ipAddr != currIpAddr)
                     {
-                        log<level::INFO>("Ip address has changed");
+                        // Ip address has changed
                         isChanged = true;
                     }
                 }
@@ -192,7 +191,7 @@ void HypEthInterface::watchBaseBiosTable()
                         std::get<std::string>(getAttrFromBiosTable(i.first));
                     if (gateway != currGateway)
                     {
-                        log<level::INFO>("Gateway has changed");
+                        // Gateway has changed
                         isChanged = true;
                     }
                 }
@@ -206,7 +205,7 @@ void HypEthInterface::watchBaseBiosTable()
                         std::get<int64_t>(getAttrFromBiosTable(i.first)));
                     if (prefixLen != currPrefixLen)
                     {
-                        log<level::INFO>("Prefix length has changed");
+                        // Prefix length has changed"
                         isChanged = true;
                     }
                 }
@@ -337,7 +336,7 @@ void HypEthInterface::updateIPAddress(std::string ip, std::string updatedIp)
         auto ipObj = it->second;
         deleteObject(ip);
         addrs.emplace(updatedIp, ipObj);
-        log<level::INFO>("Successfully updated ip address");
+        // Successfully updated ip address
         return;
     }
 }
@@ -351,7 +350,7 @@ void HypEthInterface::deleteObject(const std::string& ipaddress)
         return;
     }
     addrs.erase(it);
-    log<level::INFO>("Successfully deleted the ip address object");
+    // Successfully deleted the ip address object
 }
 
 std::string HypEthInterface::getIntfLabel()

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -226,6 +226,7 @@ std::string HypIPAddress::address(std::string ipAddress)
         elog<NotAllowed>(NotAllowedArgument::REASON("Invalid Ip"));
     }
 
+    log<level::INFO>("IP updated"), entry("ADDRESS=%s", ipAddress.c_str());
     ipAddress = HypIP::address(ipAddress);
 
     // update the addrs map of parent object

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -55,7 +55,8 @@ void HypIPAddress::setEnabledProp()
 
 bool HypIPAddress::enabled(bool value)
 {
-    log<level::INFO>("Changing value of enabled property");
+    log<level::INFO>("Changing value of enabled property",
+                     entry("INTERFACE=%s", intf.c_str()));
 
     if (value == HypEnableIntf::enabled())
     {
@@ -284,7 +285,7 @@ std::string HypIPAddress::gateway(std::string gateway)
 
     if (gateway == gw)
     {
-        log<level::INFO>("This value is already existing");
+        // value is already existing
         return gw;
     }
     int addressFamily =
@@ -323,7 +324,7 @@ HypIP::AddressOrigin HypIPAddress::origin(HypIP::AddressOrigin origin)
     auto addrOrigin = HypIP::origin();
     if (origin == addrOrigin)
     {
-        log<level::INFO>("This value is already existing");
+        // value is already existing
         return addrOrigin;
     }
 


### PR DESCRIPTION
When a user fires a redfish patch request on bios settings to
change the ipv4 method to static/dhcp, the same is updated in the
bios table. But the hypervisor eth dbus object does not listen to
this property change signal in biostable and hence, it does not change
the DHCPEnabled property on the hypervisor eth object.
This causes wrong data to be sent in the redfish response.

This PR has the change to listen to that property change in bios
table and synchronizes the hypervisor dbus object.

This fixes: https://w3.rchland.ibm.com/projects/bestquest/?verb=view&id=SW541539

Tested By:

- Tested on a system where:
  * eth0 & eth1 are connected to a dhcp server each
  * only eth1 is connected to dhcp server

1. eth0:

PATCH -d '{"Attributes": {"vmi_if0_ipv4_method": "IPv4Static"}}' https://$bmc/redfish/v1/Systems/system/Bios/Settings

GET https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0{
  "@odata.id": "/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0",
  "@odata.type": "#EthernetInterface.v1_5_1.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": false
  },
  "Description": "Hypervisor's Virtual Management Ethernet Interface",
  "HostName": "",
  "IPv4Addresses": [],
  "IPv4StaticAddresses": [],
  "Id": "eth0",
  "InterfaceEnabled": true,
  "Name": "Hypervisor Ethernet Interface"
}

PATCH -d '{"Attributes": {"vmi_if0_ipv4_method": "IPv4DHCP"}}' https://$bmc/redfish/v1/Systems/system/Bios/Settings

GET https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0{
  "@odata.id": "/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0",
  "@odata.type": "#EthernetInterface.v1_5_1.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": true
  },
  "Description": "Hypervisor's Virtual Management Ethernet Interface",
  "HostName": "",
  "IPv4Addresses": [
    {
      "Address": "192.168.1.39",
      "AddressOrigin": "DHCP",
      "Gateway": "192.168.1.1",
      "SubnetMask": "255.255.255.0"
    }
  ],
  "IPv4StaticAddresses": [],
  "Id": "eth0",
  "InterfaceEnabled": true,
  "Name": "Hypervisor Ethernet Interface"
}

2. eth1:

PATCH -d '{"Attributes": {"vmi_if1_ipv4_method": "IPv4Static"}}' https://$bmc/redfish/v1/Systems/system/Bios/Settings

GET https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1
{
  "@odata.id": "/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1",
  "@odata.type": "#EthernetInterface.v1_5_1.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": false
  },
  "Description": "Hypervisor's Virtual Management Ethernet Interface",
  "HostName": "",
  "IPv4Addresses": [],
  "IPv4StaticAddresses": [],
  "Id": "eth1",
  "InterfaceEnabled": true,
  "Name": "Hypervisor Ethernet Interface"
}

PATCH -d '{"Attributes": {"vmi_if1_ipv4_method": "IPv4DHCP"}}' https://$bmc/redfish/v1/Systems/system/Bios/Settings

GET https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1
{
  "@odata.id": "/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1",
  "@odata.type": "#EthernetInterface.v1_5_1.EthernetInterface",
  "DHCPv4": {
    "DHCPEnabled": true
  },
  "Description": "Hypervisor's Virtual Management Ethernet Interface",
  "HostName": "",
  "IPv4Addresses": [
    {
      "Address": "192.168.1.30",
      "AddressOrigin": "DHCP",
      "Gateway": "192.168.1.1",
      "SubnetMask": "255.255.255.0"
    }
  ],
  "IPv4StaticAddresses": [],
  "Id": "eth1",
  "InterfaceEnabled": true,
  "Name": "Hypervisor Ethernet Interface"
}

Also cross-checked with the dollowing command, and it seems to work as expected:
* PATCH -d '{"DHCPv4": {"DHCPEnabled" :<false/true>}}' https://$bmc/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth<0/1>

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>