### PR TITLE
Remove ifcount support

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
@@ -171,10 +171,6 @@ void HypNetworkMgr::setBIOSTableAttrs()
                         &std::get<biosBaseCurrValue>(item.second));
                     if (currValue != nullptr)
                     {
-                        if (item.first == "vmi_if_count")
-                        {
-                            intfCount = *currValue;
-                        }
                         biosTableAttrs.emplace(item.first, *currValue);
                     }
                 }
@@ -205,11 +201,6 @@ void HypNetworkMgr::setBIOSTableAttrs()
     }
 }
 
-uint16_t HypNetworkMgr::getIntfCount()
-{
-    return intfCount;
-}
-
 biosTableType HypNetworkMgr::getBIOSTableAttrs()
 {
     return biosTableAttrs;
@@ -228,22 +219,14 @@ void HypNetworkMgr::createIfObjects()
     // 2 ethernet interfaces. Both eth0/1 objects are
     // created during init time to support the static
     // network configurations on the both.
-    if (intfCount == 1 || intfCount == 2)
-    {
-        // create eth0 and eth1 objects
-        log<level::INFO>("Creating eth0 and eth1 objects");
-        interfaces.emplace(
-            "eth0", std::make_shared<phosphor::network::HypEthInterface>(
-                        bus, (objectPath + "/eth0").c_str(), "eth0", *this));
-        interfaces.emplace(
-            "eth1", std::make_shared<phosphor::network::HypEthInterface>(
-                        bus, (objectPath + "/eth1").c_str(), "eth1", *this));
-    }
-    else
-    {
-        log<level::ERR>("More than 2 Interfaces");
-        return;
-    }
+    // create eth0 and eth1 objects
+    log<level::INFO>("Creating eth0 and eth1 objects");
+    interfaces.emplace("eth0",
+                       std::make_shared<phosphor::network::HypEthInterface>(
+                           bus, (objectPath + "/eth0").c_str(), "eth0", *this));
+    interfaces.emplace("eth1",
+                       std::make_shared<phosphor::network::HypEthInterface>(
+                           bus, (objectPath + "/eth1").c_str(), "eth1", *this));
 }
 
 void HypNetworkMgr::createSysConfObj()

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
@@ -136,12 +136,6 @@ class HypNetworkMgr
         return systemConf;
     }
 
-    /** @brief Get the hypervisor eth interfaces count
-     *
-     *  @return number of interfaces
-     */
-    uint16_t getIntfCount();
-
     /** @brief Setter method for biosTableAttrs data member
      *         GET operation on the BIOS table to
      *         read all the hyp attrbutes (name, value pair)
@@ -165,9 +159,6 @@ class HypNetworkMgr
      *         objects and their names
      */
     std::map<std::string, std::shared_ptr<HypEthInterface>> interfaces;
-
-    /** @brief interface count */
-    uint16_t intfCount;
 
     /** @brief map of bios table attrs and values */
     std::map<std::string, std::variant<int64_t, std::string>> biosTableAttrs;


### PR DESCRIPTION
This pr removes the support for vmi_if_count (which is used to
determine the number of vmi interfaces enabled) as it's deprecated
and phyp no longer consumes it.

Tested and is working as expected.

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I6a97d7a2013b1e4d5228e81d878ae88a570dc681