### PR TITLE
Journal log to show changed Bios values

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -173,6 +173,8 @@ void HypEthInterface::watchBaseBiosTable()
                     if (ipAddr != currIpAddr)
                     {
                         // Ip address has changed
+                        log<level::INFO>("Ip address has changed",
+                            entry("IP ADDRESS=%s", ipAddr.c_str()));
                         isChanged = true;
                     }
                 }
@@ -192,6 +194,8 @@ void HypEthInterface::watchBaseBiosTable()
                     if (gateway != currGateway)
                     {
                         // Gateway has changed
+                        log<level::INFO>("Gateway has changed",
+                            entry("GATEWAY=%s", gateway.c_str()));
                         isChanged = true;
                     }
                 }
@@ -206,6 +210,8 @@ void HypEthInterface::watchBaseBiosTable()
                     if (prefixLen != currPrefixLen)
                     {
                         // Prefix length has changed"
+                        log<level::INFO>("Prefix length has changed",
+                            entry("PREFIX_LENGTH=%s", prefixLen));
                         isChanged = true;
                     }
                 }

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -173,7 +173,8 @@ void HypEthInterface::watchBaseBiosTable()
                     if (ipAddr != currIpAddr)
                     {
                         // Ip address has changed
-                        log<level::INFO>("Ip address has changed",
+                        log<level::INFO>(
+                            "Ip address has changed",
                             entry("IP ADDRESS=%s", ipAddr.c_str()));
                         isChanged = true;
                     }
@@ -195,7 +196,7 @@ void HypEthInterface::watchBaseBiosTable()
                     {
                         // Gateway has changed
                         log<level::INFO>("Gateway has changed",
-                            entry("GATEWAY=%s", gateway.c_str()));
+                                         entry("GATEWAY=%s", gateway.c_str()));
                         isChanged = true;
                     }
                 }
@@ -211,7 +212,7 @@ void HypEthInterface::watchBaseBiosTable()
                     {
                         // Prefix length has changed"
                         log<level::INFO>("Prefix length has changed",
-                            entry("PREFIX_LENGTH=%s", prefixLen));
+                                         entry("PREFIX_LENGTH=%d", prefixLen));
                         isChanged = true;
                     }
                 }


### PR DESCRIPTION
Whenever the bios table value changes, the journal log now shows
the updated bios values. This is useful for debugging.