### PR TITLE
Donot reset vmi ip properties on origin change

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -609,7 +609,6 @@ HypEthernetIntf::DHCPConf
         for (auto itr : addrs)
         {
             auto ipObj = itr.second;
-            ipObj->resetIPObjProps();
             PendingAttributesType pendingAttributes;
             pendingAttributes.insert_or_assign(
                 ipObj->mapDbusToBiosAttr("origin"),
@@ -630,7 +629,7 @@ HypEthernetIntf::DHCPConf
                 std::make_tuple(biosEnumType, "IPv4Static"));
             ipObj->updateBiosPendingAttrs(pendingAttributes);
             ipObj->resetBaseBiosTableAttrs();
-            ipObj->resetIPObjProps();
+
             break;
         }
     }


### PR DESCRIPTION
When the origin is changed to static/dhcp, the corresponding
attribute in the biostable (vmi_if<0/1>_ipv4_method) will be updated
with the same and this takes care of updating the new values
that are sent down from vmi in the hypervisor netword dbus object.
The call to reset ip properties is causing additional updation
of the properties with 0s, which is not necessary here.

This is one of the fixes for:
https://w3.rchland.ibm.com/projects/bestquest/?verb=view&id=SW542548
The other fix is in bmcweb:
https://github.com/ibm-openbmc/bmcweb/pull/255


Tested By:

* Set dhcp to true on an ethernet interface:
PATCH -d '{"DHCPv4": {"DHCPEnabled" :true}}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1

* Checked the biostable ip values and checked if the hypervisor ip
dbus object is in sync with bios table.

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>