### PR TITLE
Allow static config of same ip & enhance logs

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -553,14 +553,19 @@ ObjectPath HypEthInterface::ip(HypIP::Protocol protType, std::string ipaddress,
         if ((ipaddress == ipObjAddr) && (prefixLength == ipObjPrefixLen) &&
             (gateway == ipObjGateway))
         {
-            log<level::ERR>("Trying to set same ip properties");
-            // Return the existing object path
-            return objPath;
+            log<level::ERR>("INFO: Trying to set same ip properties");
         }
         auto addrKey = addrs.extract(addr.first);
         addrKey.key() = ipaddress;
         break;
     }
+
+    log<level::INFO>("Updating ip properties",
+                     entry("OBJPATH=%s", objPath.c_str()),
+                     entry("INTERFACE=%s", intfLabel.c_str()),
+                     entry("ADDRESS=%s", ipaddress.c_str()),
+                     entry("GATEWAY=%s", gateway.c_str()),
+                     entry("PREFIXLENGTH=%d", prefixLength));
 
     addrs[ipaddress] = std::make_shared<phosphor::network::HypIPAddress>(
         bus, (objPath).c_str(), *this, protType, ipaddress, origin,

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -55,10 +55,12 @@ void HypIPAddress::setEnabledProp()
 
 bool HypIPAddress::enabled(bool value)
 {
+    bool oldValue = HypEnableIntf::enabled();
     log<level::INFO>("Changing value of enabled property",
-                     entry("INTERFACE=%s", intf.c_str()));
+                     entry("INTERFACE=%s", intf.c_str()),
+                     entry("OLDVALUE=%d", oldValue), entry("VALUE=%d", value));
 
-    if (value == HypEnableIntf::enabled())
+    if (value == oldValue)
     {
         return value;
     }


### PR DESCRIPTION
There were scenarios where the host is not in
the required state to communicate ip configuration
details to the host. In that case, the dbus contains
the updated values but the enabled property will be
false and the client might try to reconfigure the
same ip, which will not be allowed in the hypervisor
app.
This PR will allow the client to configure the same ip
again, thus the hypervisor app will update the bios table
which will be communicated to the host when the host is
up.

This PR also enhances the log by printing the values of
the ip properties that were updated.

Tested By:

* Configure a static ip
* Reconfigure ip once again and see if the enabled  property
  on dbus is set
* Checked if the values are printed in the logs

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: Id56d71a998d38b3e2d8117b0519d537163c7f8c1