### PR TITLE
ethernet_interface: Add UseDomains option to network file

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1057,6 +1057,7 @@ void EthernetInterface::writeDHCPSection(std::fstream& stream)
     {
         auto value = manager.getDHCPConf()->dnsEnabled() ? "true"s : "false"s;
         stream << "UseDNS="s + value + "\n";
+        stream << "UseDomains="s + value + "\n";
 
         value = manager.getDHCPConf()->ntpEnabled() ? "true"s : "false"s;
         stream << "UseNTP="s + value + "\n";


### PR DESCRIPTION
When the interface is DHCP enabled, domain-search value 119
is not requested by the DHCP client.

This commit adds the UseDomains option to network file
so that when the DNS is enabled, the domain-search option
is requested via DHCP REQUEST, and search list provided by DHCP
server are pulled to the DHCP lease and the resolv.conf

Fixes https://github.com/openbmc/phosphor-networkd/issues/47

Tested by:
  1.Enable DNS option at BMC and check the DHCP REQUEST packet for
    option 119
  2.Verify the list 'option domain-search' at the DHCP server is
    fetched by the DHCP lease file at BMC
  3.Verify the same list is added to the search list at resolv.conf

Signed-off-by: sunharis <sunharis@in.ibm.com>
Change-Id: I2f6ca7236bf3b5e7d3ded9294b8372d95ac50ac6