### PR TITLE
Create hypervisor ip objects when biostable is null

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -377,6 +377,39 @@ void HypEthInterface::createIPAddressObjects()
 
     auto biosTableAttrs = manager.getBIOSTableAttrs();
 
+    // The total number of vmi attributes in biosTableAttrs is 9
+    // 4 attributes of interface 0, 4 attributes of interface 1,
+    // and vmi_hostname attribute
+    if (biosTableAttrs.size() < 9)
+    {
+        log<level::INFO>("Creating ip address object with default values");
+        if (intfLabel == "if0")
+        {
+            // set the default values for interface 0 in the local
+            // copy of the bios table - biosTableAttrs
+            manager.setIf0DefaultBIOSTableAttrs();
+            addrs.emplace("eth0",
+                          std::make_shared<phosphor::network::HypIPAddress>(
+                              bus, (objectPath + "/ipv4/addr0").c_str(), *this,
+                              IP::Protocol::IPv4, "0.0.0.0",
+                              IP::AddressOrigin::Static, 0, "0.0.0.0",
+                              intfLabel));
+        }
+        else if (intfLabel == "if1")
+        {
+            // set the default values for interface 0 in the local
+            // copy of the bios table - biosTableAttrs
+            manager.setIf1DefaultBIOSTableAttrs();
+            addrs.emplace("eth1",
+                          std::make_shared<phosphor::network::HypIPAddress>(
+                              bus, (objectPath + "/ipv4/addr0").c_str(), *this,
+                              IP::Protocol::IPv4, "0.0.0.0",
+                              IP::AddressOrigin::Static, 0, "0.0.0.0",
+                              intfLabel));
+        }
+        return;
+    }
+
     for (std::string protocol : {"ipv4", "ipv6"})
     {
         std::string vmi_prefix = "vmi_" + intfLabel + "_" + protocol + "_";
@@ -424,7 +457,6 @@ void HypEthInterface::createIPAddressObjects()
             ipPrefixLength =
                 static_cast<uint8_t>(std::get<int64_t>(biosTableItr->second));
         }
-
         biosTableItr = biosTableAttrs.find(vmi_prefix + "gateway");
         if (biosTableItr != biosTableAttrs.end())
         {

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
@@ -81,6 +81,27 @@ void HypNetworkMgr::setBIOSTableAttr(
     }
 }
 
+void HypNetworkMgr::setIf0DefaultBIOSTableAttrs()
+{
+    biosTableAttrs.emplace("vmi_if0_ipv4_ipaddr", "0.0.0.0");
+    biosTableAttrs.emplace("vmi_if0_ipv4_gateway", "0.0.0.0");
+    biosTableAttrs.emplace("vmi_if0_ipv4_prefix_length", 0);
+    biosTableAttrs.emplace("vmi_if0_ipv4_method", "IPv4Static");
+}
+
+void HypNetworkMgr::setIf1DefaultBIOSTableAttrs()
+{
+    biosTableAttrs.emplace("vmi_if1_ipv4_ipaddr", "0.0.0.0");
+    biosTableAttrs.emplace("vmi_if1_ipv4_gateway", "0.0.0.0");
+    biosTableAttrs.emplace("vmi_if1_ipv4_prefix_length", 0);
+    biosTableAttrs.emplace("vmi_if1_ipv4_method", "IPv4Static");
+}
+
+void HypNetworkMgr::setDefaultHostnameInBIOSTableAttrs()
+{
+    biosTableAttrs.emplace("vmi_hostname", "");
+}
+
 void HypNetworkMgr::setBIOSTableAttrs()
 {
     try
@@ -214,6 +235,11 @@ ethIntfMapType HypNetworkMgr::getEthIntfList()
 void HypNetworkMgr::createIfObjects()
 {
     setBIOSTableAttrs();
+
+    if ((getBIOSTableAttrs()).size() == 0)
+    {
+        setDefaultHostnameInBIOSTableAttrs();
+    }
 
     // The hypervisor can support maximum of
     // 2 ethernet interfaces. Both eth0/1 objects are

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
@@ -105,6 +105,22 @@ class HypNetworkMgr
      */
     ethIntfMapType getEthIntfList();
 
+    /** @brief Method to set all the interface 0 attributes
+     *         to its default value in biosTableAttrs data member
+     */
+    void setIf0DefaultBIOSTableAttrs();
+
+    /** @brief Method to set all the interface 1 attributes
+     *         to its default value in biosTableAttrs data member
+     */
+    void setIf1DefaultBIOSTableAttrs();
+
+    /** @brief Method to set the hostname attribute
+     *         to its default value in biosTableAttrs
+     *         data member
+     */
+    void setDefaultHostnameInBIOSTableAttrs();
+
   private:
     /**
      * @brief get Dbus Prop


### PR DESCRIPTION
There wes a scenario where the hypervisor app starts
even before the pldm populates the biostable. In this
case, hypervisor app does not create any ip address
objects.

A solution to this is,
* to create the ip address objects with default values,
even if the biostable is empty;
* then wait for properties changed signal on bios table
and update the ip address dbus objects

Thus, with this change, hypervisor app never fails to create
ip dbus objects.

Fix for the defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW547404

Tested-By:

* Bios table is empty
  start the app, with pldm already running
  hypervisor dbus objects gets created

* Restart pldmd after the above testcase
  bios table gets initialised
  hyp app gets the properties changed signal

* Host is powered off
  after the above test case, configured ip through Redfish
  redfish static ip configuration - returns internal error,
                                    as biostable is empty

* Host powered off
  restart pldmd
  configure static ip through Redfish
  dbus object gets updated followed by bios table

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I07aaf396af7abd4871edfdaff2ba4fa7abae1c01