### PR TITLE
network_config: Enable [DHCP] option parameters by default

### DIFF
--- a/src/network_config.cpp
+++ b/src/network_config.cpp
@@ -38,7 +38,8 @@ void writeDHCPDefault(const std::string& filename, const std::string& interface)
                 "IPv6AcceptRA=false\n"
 
 #endif
-                "[DHCP]\nClientIdentifier=mac\n";
+                "[DHCP]\nClientIdentifier=mac\nUseDNS=true\nUseDomains=true\nUseNTP=true\nUseHostname=true\nSendHostname=true\n";
+
     filestream.close();
 }
 } // namespace bmc


### PR DESCRIPTION
After factory reset, ethernet interfaces are set to DHCP as
expected. But the DNS and NTP servers are not requested.

This commit adds the [DHCP] options to the default network
file so that the DHCP REQUEST asks for the required options
from the DHCP server when fetching the fresh lease

Tested by:
 1. Factory reset the BMC and check if the DHCP request is sent
 for DNS and NTP etc
 2. Verify the default network file

Signed-off-by: sunharis <sunharis@in.ibm.com>
Change-Id: I082694834a427400bfbfe2b2b0f871b0ecaee47b