### PR TITLE
Set static & dhcp sent ntp server ip on ethernet obj

### DIFF
--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -98,6 +98,10 @@ class EthernetInterface : public Ifaces
                       DHCPConf dhcpEnabled, Manager& parent,
                       bool emitSignal = true);
 
+    /** @brief Function used to load the ntpservers
+     */
+    virtual void loadNTPServers();
+
     /** @brief Function used to load the nameservers.
      */
     virtual void loadNameServers();
@@ -202,6 +206,11 @@ class EthernetInterface : public Ifaces
      *  @param[in] value - vector of NTP servers.
      */
     ServerList ntpServers(ServerList value) override;
+
+    /** @brief sets the static NTP servers.
+     *  @param[in] value - vector of NTP servers.
+     */
+    ServerList staticNTPServers(ServerList value) override;
 
     /** @brief sets the DNS/nameservers.
      *  @param[in] value - vector of DNS servers.
@@ -314,10 +323,15 @@ class EthernetInterface : public Ifaces
     /** @brief write the dhcp section **/
     void writeDHCPSection(std::fstream& stream);
 
+    /** @brief get the NTP server list from the timsyncd dbus obj
+     *
+     */
+    virtual ServerList getNTPServerFromTimeSyncd();
+
     /** @brief get the NTP server list from the network conf
      *
      */
-    ServerList getNTPServersFromConf();
+    ServerList getstaticNTPServersFromConf();
 
     /** @brief get the name server details from the network conf
      *

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -159,6 +159,7 @@ void Manager::createInterfaces()
         intf->createIPAddressObjects();
         intf->createStaticNeighborObjects();
         intf->loadNameServers();
+        intf->loadNTPServers();
 
         this->interfaces.emplace(
             std::make_pair(std::move(interface), std::move(intf)));

--- a/test/mock_ethernet_interface.hpp
+++ b/test/mock_ethernet_interface.hpp
@@ -20,6 +20,7 @@ class MockEthernetInterface : public EthernetInterface
     }
 
     MOCK_METHOD((ServerList), getNameServerFromResolvd, (), (override));
+    MOCK_METHOD((ServerList), getNTPServerFromTimeSyncd, (), (override));
     friend class TestEthernetInterface;
 };
 } // namespace network

--- a/test/test_ethernet_interface.cpp
+++ b/test/test_ethernet_interface.cpp
@@ -190,11 +190,11 @@ TEST_F(TestEthernetInterface, getDynamicNameServers)
     EXPECT_EQ(interface.getNameServerFromResolvd(), servers);
 }
 
-TEST_F(TestEthernetInterface, addNTPServers)
+TEST_F(TestEthernetInterface, addStaticNTPServers)
 {
     ServerList servers = {"10.1.1.1", "10.2.2.2", "10.3.3.3"};
     EXPECT_CALL(manager, reloadConfigs());
-    interface.ntpServers(servers);
+    interface.staticNTPServers(servers);
     fs::path filePath = confDir;
     filePath /= "00-bmc-test0.network";
     config::Parser parser(filePath.string());
@@ -202,6 +202,21 @@ TEST_F(TestEthernetInterface, addNTPServers)
     config::ValueList values;
     std::tie(rc, values) = parser.getValues("Network", "NTP");
     EXPECT_EQ(servers, values);
+}
+
+TEST_F(TestEthernetInterface, addNTPServers)
+{
+    using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+    ServerList servers = {"10.1.1.1", "10.2.2.2", "10.3.3.3"};
+    EXPECT_THROW(interface.ntpServers(servers), NotAllowed);
+}
+
+TEST_F(TestEthernetInterface, getNTPServers)
+{
+    ServerList servers = {"10.1.1.1", "10.2.2.2", "10.3.3.3"};
+    EXPECT_CALL(interface, getNTPServerFromTimeSyncd())
+        .WillRepeatedly(testing::Return(servers));
+    EXPECT_EQ(interface.getNTPServerFromTimeSyncd(), servers);
 }
 
 TEST_F(TestEthernetInterface, addGateway)


### PR DESCRIPTION
Currently there is no way to differentiate between the Static
and DHCP assigned NTP servers at dbus

This commit adds StaticNTPServers peroperty to hold the static
configuration of NTP servers. This is a read-write property.
The existing NTPServer propery will hold both static and DHCP
assigned NTP servers. This is a read-only property.

The static and dhcp sent ntp server details are present in the
dbus object hosted by systemd-timesyncd service (mentioned in
Tested By section).

In this change, networkd fetches the ntp server details from the
timesyncd dbus object and set the "NTPServers" property with dhcp sent
ip and "StaticNTPServers" will be set from the configuration file.

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: If8b1b3ed2afb531f179e00da173f6f86a1bf0c18