### PR TITLE
Catch exception in non-NTP systems

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -729,10 +729,10 @@ ServerList EthernetInterface::getNTPServerFromTimeSyncd()
                                       PROPERTY_INTERFACE, METHOD_GET);
 
     method.append(TIMESYNCD_INTERFACE, "LinkNTPServers");
-    auto reply = bus.call(method);
 
     try
     {
+        auto reply = bus.call(method);
         std::variant<ServerList> response;
         reply.read(response);
         servers = std::get<ServerList>(response);
@@ -793,10 +793,9 @@ ServerList EthernetInterface::getNameServerFromResolvd()
                                       PROPERTY_INTERFACE, METHOD_GET);
 
     method.append(RESOLVED_INTERFACE, "DNS");
-    auto reply = bus.call(method);
-
     try
     {
+        auto reply = bus.call(method);
         reply.read(name);
     }
     catch (const sdbusplus::exception::SdBusError& e)


### PR DESCRIPTION
Non-NTP systems disable the time sync service. The code was calling to
query this service outside the try/catch block so the network service
would core dump and fail to start.
Move the method call inside the try/catch block.

Tested: On a system with the TimeSyncMethod set to Manual, the network
service does not fail to start anymore, and the error trace from the
catch is printed:

root@p10bmc:/var/persist/etc/systemd/system# systemctl status
xyz.openbmc_project.Network
● xyz.openbmc_project.Network.service - Phosphor Network Manager
     Loaded: loaded
(/lib/systemd/system/xyz.openbmc_project.Network.service; enabled;
vendor preset: enabled)
     Active: active (running) since Wed 2022-04-27 15:24:37 UTC; 3min
35s ago
   Main PID: 14371 (phosphor-networ)
     CGroup: /system.slice/xyz.openbmc_project.Network.service
             └─14371 phosphor-network-manager

Apr 27 15:24:37 p10bmc systemd[1]: Starting Phosphor Network
Manager...
Apr 27 15:24:37 p10bmc systemd[1]: Started Phosphor Network Manager.
Apr 27 15:24:38 p10bmc phosphor-network-manager[14371]: Failed to get
NTP server information from Systemd-Timesyncd
Apr 27 15:24:38 p10bmc phosphor-network-manager[14371]: Failed to get
NTP server information from Systemd-Timesyncd

Change-Id: I148feb42e842b94bc561aeae8715860e703df8f0
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>