### PR TITLE
BMC factory reset: Remove linklocal IP from eth1

### DIFF
--- a/src/network_config.cpp
+++ b/src/network_config.cpp
@@ -25,7 +25,22 @@ void writeDHCPDefault(const std::string& filename, const std::string& interface)
     // The new value is only assigned on first boot, when the default
     // file is not present, or after the default file has been
     // manually removed.
-    filestream << "[Match]\nName=" << interface <<
+    if (interface == "eth1")
+    {
+        filestream << "[Match]\nName=" << interface <<
+                "\n[Network]\nDHCP=true\n"
+                "LinkLocalAddressing=no\n"
+#ifdef ENABLE_IPV6_ACCEPT_RA
+                "IPv6AcceptRA=true\n"
+#else
+                "IPv6AcceptRA=false\n"
+
+#endif
+                "[DHCP]\nClientIdentifier=mac\nUseDNS=true\nUseDomains=true\nUseNTP=true\nUseHostname=true\nSendHostname=true\n";
+    }
+    else
+    {
+        filestream << "[Match]\nName=" << interface <<
                 "\n[Network]\nDHCP=true\n"
 #ifdef LINK_LOCAL_AUTOCONFIGURATION
                 "LinkLocalAddressing=yes\n"
@@ -39,7 +54,7 @@ void writeDHCPDefault(const std::string& filename, const std::string& interface)
 
 #endif
                 "[DHCP]\nClientIdentifier=mac\nUseDNS=true\nUseDomains=true\nUseNTP=true\nUseHostname=true\nSendHostname=true\n";
-
+    }
     filestream.close();
 }
 } // namespace bmc


### PR DESCRIPTION
When linklocal is set on both interfaces after a factory reset, the BMC
comes up with two default routes for eth0 and eth1 on same subnet. This
causes confusions in the initial routing table, when the physical cable
connection is made from a local laptop. The connection drops are random,
sometimes eth0 works and sometimes eth1 works.

This commit is a workaround to disable linklocal assignment to eth1.
This will get only eth0 interface up with a linklocal address after a
factory reset. The actual fix will be worked with systemd upstream
community.

Tested by:
1. Factory reset, and see eth1 is not assigned with any linklocal IP
   Only eth0 interface will get the linklocal assigned

Signed-off-by: Sunitha Harish <sunithaharish04@gmail.com>
Change-Id: I4997842d49c525f1609c63bb9ebeb7df330d2a30