### PR TITLE
Ethernet interface eth1 setting

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1009,11 +1009,19 @@ void EthernetInterface::writeConfigurationFile()
 
     // write the network section
     stream << "[Network]\n";
+
+    // do not write eth1 linklocal as it adds routing confusions
+    // with eth0 route.
+    // https://github.com/systemd/systemd/issues/23595
+    // TODO: Remove this check once 23595 is resolved
+    if (interfaceName() != "eth1")
+    {
 #ifdef LINK_LOCAL_AUTOCONFIGURATION
-    stream << "LinkLocalAddressing=yes\n";
+        stream << "LinkLocalAddressing=yes\n";
 #else
-    stream << "LinkLocalAddressing=no\n";
+        stream << "LinkLocalAddressing=no\n";
 #endif
+    }
     stream << std::boolalpha
            << "IPv6AcceptRA=" << EthernetInterfaceIntf::ipv6AcceptRA() << "\n";
 


### PR DESCRIPTION
This commit removed the write eth1 linklocal while the network setting
is modified as it adds routing confusions with eth0 route.
Upstream issue: https://github.com/systemd/systemd/issues/23595

This is a workaround and needs to be removed once 23595 is resolved

Tested:
  1. Factory reset
  2. Static Network add and delete on both eth0 and eth1
  3. DHCP enable/disable on eth1

Signed-off-by: Sunitha Harish <sunithaharish04@gmail.com>
Change-Id: I3014783b340cb403658feb477f5a6650356d4403