### PR TITLE
Add ipv6 support in hypervisor app

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -82,151 +82,182 @@ void HypEthInterface::watchBaseBiosTable()
         {
             std::string intf = "if" + std::to_string(i);
 
-            std::string dhcpEnabled = std::get<std::string>(
-                getAttrFromBiosTable("vmi_" + intf + "_ipv4_method"));
-
-            // This method was intended to watch the bios table
-            // property change signal and update the dbus object
-            // whenever the dhcp server has provided an
-            // IP from different range or changed its gateway/subnet mask (or)
-            // when user updates the bios table ip attributes -
-            // patch on /redfish/v1/Systems/system/Bios/Settings
-            // Because, in all other cases,
-            // user configures ip properties that will be set in the dbus
-            // object, followed by bios table updation. In this dhcp case,
-            // the dbus will not be having the updated ip address which
-            // is in bios table, also in the second case, where one patches
-            // bios table attributes, the dbus object will not have the updated
-            // values. This method is to sync the ip addresses
-            // between the bios table & dbus object.
-
-            // Get corresponding ethernet interface object
-            std::string ethIntfLabel;
-            if (intf == "if0")
+            for (std::string protocol : {"ipv4", "ipv6"})
             {
-                ethIntfLabel = "eth0";
-            }
-            else
-            {
-                ethIntfLabel = "eth1";
-            }
 
-            // Get the list of all ethernet interfaces from the parent
-            // data member to get the eth object corresponding to the
-            // eth interface label above
-            auto ethIntfList = manager.getEthIntfList();
-            auto findEthObj = ethIntfList.find(ethIntfLabel);
+                std::string dhcpEnabled =
+                    std::get<std::string>(getAttrFromBiosTable(
+                        "vmi_" + intf + "_" + protocol + "_method"));
 
-            if (findEthObj == ethIntfList.end())
-            {
-                log<level::ERR>("Cannot find ethernet object");
-                return;
-            }
+                // This method was intended to watch the bios table
+                // property change signal and update the dbus object
+                // whenever the dhcp server has provided an
+                // IP from different range or changed its gateway/subnet mask
+                // (or) when user updates the bios table ip attributes - patch
+                // on /redfish/v1/Systems/system/Bios/Settings Because, in all
+                // other cases, user configures ip properties that will be set
+                // in the dbus object, followed by bios table updation. In this
+                // dhcp case, the dbus will not be having the updated ip address
+                // which is in bios table, also in the second case, where one
+                // patches bios table attributes, the dbus object will not have
+                // the updated values. This method is to sync the ip addresses
+                // between the bios table & dbus object.
 
-            std::shared_ptr<phosphor::network::HypEthInterface> ethObj =
-                findEthObj->second;
-
-            DHCPConf dhcpState = ethObj->dhcpEnabled();
-
-            if ((dhcpState == HypEthInterface::DHCPConf::none) &&
-                (dhcpEnabled == "IPv4DHCP"))
-            {
-                // There is a change in bios table method attribute (changed to
-                // dhcp) but dbus property contains static Change the dbus
-                // property to dhcp
-                log<level::INFO>("Setting dhcp on the dbus object");
-                ethObj->dhcpEnabled(HypEthInterface::DHCPConf::v4);
-            }
-            else if ((dhcpState != HypEthInterface::DHCPConf::none) &&
-                     (dhcpEnabled == "IPv4Static"))
-            {
-                // There is a change in bios table method attribute (changed to
-                // static) but dbus property contains dhcp Change the dbus
-                // property to static
-                log<level::INFO>("Setting static on the dbus object");
-                ethObj->dhcpEnabled(HypEthInterface::DHCPConf::none);
-            }
-
-            auto ipAddrs = ethObj->addrs;
-
-            std::string ipAddr;
-            std::string currIpAddr;
-            std::string gateway;
-            uint8_t prefixLen = 0;
-
-            auto biosTableAttrs = manager.getBIOSTableAttrs();
-            for (const auto& i : biosTableAttrs)
-            {
-                // Get ip address
-                if ((i.first).ends_with(intf + "_ipv4_ipaddr"))
+                // Get corresponding ethernet interface object
+                std::string ethIntfLabel;
+                if (intf == "if0")
                 {
-                    currIpAddr = std::get<std::string>(i.second);
-                    if (currIpAddr.empty())
-                    {
-                        log<level::INFO>(
-                            "Current IP in biosAttrs copy is empty");
-                        return;
-                    }
-                    ipAddr =
-                        std::get<std::string>(getAttrFromBiosTable(i.first));
-                    if (ipAddr != currIpAddr)
-                    {
-                        // Ip address has changed
-                        for (auto addrs : ipAddrs)
-                        {
-                            auto ipObj = addrs.second;
-                            ipObj->HypIP::address(ipAddr);
-                            setIpPropsInMap(i.first, ipAddr, "String");
-                            break;
-                        }
-                        return;
-                    }
+                    ethIntfLabel = "eth0";
+                }
+                else
+                {
+                    ethIntfLabel = "eth1";
                 }
 
-                // Get gateway
-                if ((i.first).ends_with(intf + "_ipv4_gateway"))
+                // Get the list of all ethernet interfaces from the parent
+                // data member to get the eth object corresponding to the
+                // eth interface label above
+                auto ethIntfList = manager.getEthIntfList();
+                auto findEthObj = ethIntfList.find(ethIntfLabel);
+
+                if (findEthObj == ethIntfList.end())
                 {
-                    std::string currGateway = std::get<std::string>(i.second);
-                    if (currGateway.empty())
-                    {
-                        log<level::INFO>(
-                            "Current Gateway in biosAttrs copy is empty");
-                        return;
-                    }
-                    gateway =
-                        std::get<std::string>(getAttrFromBiosTable(i.first));
-                    if (gateway != currGateway)
-                    {
-                        // Gateway has changed
-                        for (auto addrs : ipAddrs)
-                        {
-                            auto ipObj = addrs.second;
-                            ipObj->HypIP::gateway(gateway);
-                            setIpPropsInMap(i.first, gateway, "String");
-                            break;
-                        }
-                        return;
-                    }
+                    log<level::ERR>("Cannot find ethernet object");
+                    return;
                 }
 
-                // Get prefix length
-                if ((i.first).ends_with(intf + "_ipv4_prefix_length"))
+                std::shared_ptr<phosphor::network::HypEthInterface> ethObj =
+                    findEthObj->second;
+
+                DHCPConf dhcpState = ethObj->dhcpEnabled();
+
+                if ((dhcpState == HypEthInterface::DHCPConf::none) &&
+                    (dhcpEnabled == "IPv4DHCP"))
                 {
-                    uint8_t currPrefixLen =
-                        static_cast<uint8_t>(std::get<int64_t>(i.second));
-                    prefixLen = static_cast<uint8_t>(
-                        std::get<int64_t>(getAttrFromBiosTable(i.first)));
-                    if (prefixLen != currPrefixLen)
+                    // There is a change in bios table method attribute (changed
+                    // to dhcp) but dbus property contains static Change the
+                    // dbus property to dhcp
+                    log<level::INFO>("Setting dhcp on the dbus object");
+                    ethObj->dhcpEnabled(HypEthInterface::DHCPConf::v4);
+                }
+                else if ((dhcpState != HypEthInterface::DHCPConf::none) &&
+                         (dhcpEnabled == "IPv4Static"))
+                {
+                    // There is a change in bios table method attribute (changed
+                    // to static) but dbus property contains dhcp Change the
+                    // dbus property to static
+                    log<level::INFO>("Setting static on the dbus object");
+                    ethObj->dhcpEnabled(HypEthInterface::DHCPConf::none);
+                }
+
+                auto ipAddrs = ethObj->addrs;
+
+                std::string ipAddr;
+                std::string currIpAddr;
+                std::string gateway;
+                uint8_t prefixLen = 0;
+
+                auto biosTableAttrs = manager.getBIOSTableAttrs();
+                for (const auto& i : biosTableAttrs)
+                {
+                    // Get ip address
+                    if ((i.first).ends_with(intf + "_" + protocol + "_ipaddr"))
                     {
-                        // Prefix length has changed"
-                        for (auto addrs : ipAddrs)
+                        currIpAddr = std::get<std::string>(i.second);
+                        if (currIpAddr.empty())
                         {
-                            auto ipObj = addrs.second;
-                            ipObj->HypIP::prefixLength(prefixLen);
-                            setIpPropsInMap(i.first, prefixLen, "Integer");
-                            break;
+                            log<level::INFO>(
+                                "Current IP in biosAttrs copy is empty");
+                            return;
                         }
-                        return;
+                        ipAddr = std::get<std::string>(
+                            getAttrFromBiosTable(i.first));
+                        if (ipAddr != currIpAddr)
+                        {
+                            // Ip address has changed
+                            for (auto addrs : ipAddrs)
+                            {
+                                if ((((protocol == "ipv4") &&
+                                      ((addrs.first).find('.') !=
+                                       std::string::npos)) ||
+                                     ((protocol == "ipv6") &&
+                                      ((addrs.first).find("::") !=
+                                       std::string::npos))))
+                                {
+                                    auto ipObj = addrs.second;
+                                    ipObj->HypIP::address(ipAddr);
+                                    setIpPropsInMap(i.first, ipAddr, "String");
+                                    break;
+                                }
+                            }
+                            return;
+                        }
+                    }
+
+                    // Get gateway
+                    if ((i.first).ends_with(intf + "_" + protocol + "_gateway"))
+                    {
+                        std::string currGateway =
+                            std::get<std::string>(i.second);
+                        if (currGateway.empty())
+                        {
+                            log<level::INFO>(
+                                "Current Gateway in biosAttrs copy is empty");
+                            return;
+                        }
+                        gateway = std::get<std::string>(
+                            getAttrFromBiosTable(i.first));
+                        if (gateway != currGateway)
+                        {
+                            // Gateway has changed
+                            for (auto addrs : ipAddrs)
+                            {
+                                if ((((protocol == "ipv4") &&
+                                      ((addrs.first).find('.') !=
+                                       std::string::npos)) ||
+                                     ((protocol == "ipv6") &&
+                                      ((addrs.first).find("::") !=
+                                       std::string::npos))))
+                                {
+                                    auto ipObj = addrs.second;
+                                    ipObj->HypIP::gateway(gateway);
+                                    setIpPropsInMap(i.first, gateway, "String");
+                                    break;
+                                }
+                            }
+                            return;
+                        }
+                    }
+
+                    // Get prefix length
+                    if ((i.first).ends_with(intf + "_" + protocol +
+                                            "_prefix_length"))
+                    {
+                        uint8_t currPrefixLen =
+                            static_cast<uint8_t>(std::get<int64_t>(i.second));
+                        prefixLen = static_cast<uint8_t>(
+                            std::get<int64_t>(getAttrFromBiosTable(i.first)));
+                        if (prefixLen != currPrefixLen)
+                        {
+                            // Prefix length has changed"
+                            for (auto addrs : ipAddrs)
+                            {
+                                if ((((protocol == "ipv4") &&
+                                      ((addrs.first).find('.') !=
+                                       std::string::npos)) ||
+                                     ((protocol == "ipv6") &&
+                                      ((addrs.first).find("::") !=
+                                       std::string::npos))))
+                                {
+                                    auto ipObj = addrs.second;
+                                    ipObj->HypIP::prefixLength(prefixLen);
+                                    setIpPropsInMap(i.first, prefixLen,
+                                                    "Integer");
+                                    break;
+                                }
+                            }
+                            return;
+                        }
                     }
                 }
             }
@@ -344,7 +375,7 @@ void HypEthInterface::deleteObject(const std::string& ipaddress)
 std::string HypEthInterface::getIntfLabel()
 {
     // The bios table attributes will be named in the following format:
-    // vmi_if0_ipv4_<attrName>. Hence, this method returns if0/if1
+    // vmi_if0_ipv4/ipv6_<attrName>. Hence, this method returns if0/if1
     // based on the eth interface label eth0/eth1 in the object path
     const std::string ethIntfLabel =
         objectPath.substr(objectPath.rfind("/") + 1);
@@ -380,32 +411,54 @@ void HypEthInterface::createIPAddressObjects()
     // The total number of vmi attributes in biosTableAttrs is 9
     // 4 attributes of interface 0, 4 attributes of interface 1,
     // and vmi_hostname attribute
-    if (biosTableAttrs.size() < 9)
+
+    // The total number of vmi attributes in biosTableAttrs is 17
+    // 4 attributes of interface 0 - ipv4 address
+    // 4 attributes of interface 0 - ipv6 address
+    // 4 attributes of interface 1 - ipv4 address
+    // 4 attributes of interface 1 - ipv6 address
+    if (biosTableAttrs.size() < 17)
     {
         log<level::INFO>("Creating ip address object with default values");
         if (intfLabel == "if0")
         {
             // set the default values for interface 0 in the local
             // copy of the bios table - biosTableAttrs
-            manager.setIf0DefaultBIOSTableAttrs();
-            addrs.emplace("eth0",
+            manager.setDefaultBIOSTableAttrsOnIntf(intfLabel, "ipv4");
+            addrs.emplace("eth0/v4",
                           std::make_shared<phosphor::network::HypIPAddress>(
                               bus, (objectPath + "/ipv4/addr0").c_str(), *this,
-                              IP::Protocol::IPv4, "0.0.0.0",
-                              IP::AddressOrigin::Static, 0, "0.0.0.0",
+                              HypIP::Protocol::IPv4, "0.0.0.0",
+                              HypIP::AddressOrigin::Static, 0, "0.0.0.0",
                               intfLabel));
+
+            manager.setDefaultBIOSTableAttrsOnIntf(intfLabel, "ipv6");
+            addrs.emplace("eth0/v6",
+                          std::make_shared<phosphor::network::HypIPAddress>(
+                              bus, (objectPath + "/ipv6/addr0").c_str(), *this,
+                              HypIP::Protocol::IPv6,
+                              "::", HypIP::AddressOrigin::Static, 128,
+                              "::", intfLabel));
         }
         else if (intfLabel == "if1")
         {
             // set the default values for interface 0 in the local
             // copy of the bios table - biosTableAttrs
-            manager.setIf1DefaultBIOSTableAttrs();
-            addrs.emplace("eth1",
+            manager.setDefaultBIOSTableAttrsOnIntf(intfLabel, "ipv4");
+            addrs.emplace("eth1/v4",
                           std::make_shared<phosphor::network::HypIPAddress>(
                               bus, (objectPath + "/ipv4/addr0").c_str(), *this,
-                              IP::Protocol::IPv4, "0.0.0.0",
-                              IP::AddressOrigin::Static, 0, "0.0.0.0",
+                              HypIP::Protocol::IPv4, "0.0.0.0",
+                              HypIP::AddressOrigin::Static, 0, "0.0.0.0",
                               intfLabel));
+
+            manager.setDefaultBIOSTableAttrsOnIntf(intfLabel, "ipv6");
+            addrs.emplace("eth1/v6",
+                          std::make_shared<phosphor::network::HypIPAddress>(
+                              bus, (objectPath + "/ipv6/addr0").c_str(), *this,
+                              HypIP::Protocol::IPv6,
+                              "::", HypIP::AddressOrigin::Static, 128,
+                              "::", intfLabel));
         }
         return;
     }
@@ -530,15 +583,17 @@ ObjectPath HypEthInterface::ip(HypIP::Protocol protType, std::string ipaddress,
 
     HypIP::AddressOrigin origin = IP::AddressOrigin::Static;
 
-    if (!isValidIP(AF_INET, ipaddress) && !isValidIP(AF_INET6, ipaddress))
+    int addressFamily = (protType == IP::Protocol::IPv4) ? AF_INET : AF_INET6;
+
+    if (!isValidIP(addressFamily, ipaddress))
     {
         log<level::ERR>("Not a valid IP address"),
             entry("ADDRESS=%s", ipaddress.c_str());
-        elog<InvalidArgument>(Argument::ARGUMENT_NAME("Address"),
+        elog<InvalidArgument>(Argument::ARGUMENT_NAME("ipaddress"),
                               Argument::ARGUMENT_VALUE(ipaddress.c_str()));
     }
 
-    if (!isValidIP(AF_INET, gateway) && !isValidIP(AF_INET6, gateway))
+    if (!isValidIP(addressFamily, gateway))
     {
         log<level::ERR>("Not a valid gateway"),
             entry("ADDRESS=%s", ipaddress.c_str());
@@ -546,8 +601,7 @@ ObjectPath HypEthInterface::ip(HypIP::Protocol protType, std::string ipaddress,
                               Argument::ARGUMENT_VALUE(ipaddress.c_str()));
     }
 
-    if (!isValidPrefix(AF_INET, prefixLength) &&
-        !isValidPrefix(AF_INET6, prefixLength))
+    if (!isValidPrefix(addressFamily, prefixLength))
     {
         log<level::ERR>("PrefixLength is not correct "),
             entry("PREFIXLENGTH=%" PRIu8, prefixLength);
@@ -578,6 +632,11 @@ ObjectPath HypEthInterface::ip(HypIP::Protocol protType, std::string ipaddress,
     for (auto addr : addrs)
     {
         auto ipObj = addr.second;
+        if (ipObj->type() != protType)
+        {
+            continue;
+        }
+
         std::string ipObjAddr = ipObj->address();
         uint8_t ipObjPrefixLen = ipObj->prefixLength();
         std::string ipObjGateway = ipObj->gateway();
@@ -634,10 +693,21 @@ HypEthernetIntf::DHCPConf
         for (auto itr : addrs)
         {
             auto ipObj = itr.second;
+
+            std::string method;
+            if (ipObj->type() == HypIP::Protocol::IPv4)
+            {
+                method = "IPv4DHCP";
+            }
+            else if (ipObj->type() == HypIP::Protocol::IPv6)
+            {
+                method = "IPv6DHCP";
+            }
+
             PendingAttributesType pendingAttributes;
             pendingAttributes.insert_or_assign(
                 ipObj->mapDbusToBiosAttr("origin"),
-                std::make_tuple(biosEnumType, "IPv4DHCP"));
+                std::make_tuple(biosEnumType, method));
             ipObj->updateBiosPendingAttrs(pendingAttributes);
             log<level::INFO>("Updating the ip address properties");
             break;
@@ -648,10 +718,21 @@ HypEthernetIntf::DHCPConf
         for (auto itr : addrs)
         {
             auto ipObj = itr.second;
+
+            std::string method;
+            if (ipObj->type() == HypIP::Protocol::IPv4)
+            {
+                method = "IPv4Static";
+            }
+            else if (ipObj->type() == HypIP::Protocol::IPv6)
+            {
+                method = "IPv6Static";
+            }
+
             PendingAttributesType pendingAttributes;
             pendingAttributes.insert_or_assign(
                 ipObj->mapDbusToBiosAttr("origin"),
-                std::make_tuple(biosEnumType, "IPv4Static"));
+                std::make_tuple(biosEnumType, method));
             ipObj->updateBiosPendingAttrs(pendingAttributes);
             ipObj->resetBaseBiosTableAttrs();
 

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -199,16 +199,40 @@ void HypIPAddress::resetIPObjProps()
     parent.setIpPropsInMap(attrGateway, zeroIp, "String");
 
     std::string attrMethod = prefix + "method";
-    parent.setIpPropsInMap(attrMethod, "IPv4Static", "String");
+    if (HypIP::type() == HypIP::Protocol::IPv4)
+    {
+        parent.setIpPropsInMap(attrMethod, "IPv4Static", "String");
+    }
+    else if (HypIP::type() == HypIP::Protocol::IPv6)
+    {
+        parent.setIpPropsInMap(attrMethod, "IPv6Static", "String");
+    }
 }
 
 void HypIPAddress::resetBaseBiosTableAttrs()
 {
     // clear all the entries
     log<level::INFO>("Resetting the bios table attrs of the ip object");
-    updateBaseBiosTable(mapDbusToBiosAttr("address"), "0.0.0.0");
-    updateBaseBiosTable(mapDbusToBiosAttr("gateway"), "0.0.0.0");
-    updateBaseBiosTable(mapDbusToBiosAttr("prefixLength"), 0);
+
+    std::string defaulAddr;
+    std::string defaultGateway;
+    int64_t defaultPrefLen;
+
+    if (HypIP::type() == HypIP::Protocol::IPv4)
+    {
+        defaulAddr = "0.0.0.0";
+        defaultGateway = "0.0.0.0";
+        defaultPrefLen = 0;
+    }
+    else if (HypIP::type() == HypIP::Protocol::IPv6)
+    {
+        defaulAddr = "::";
+        defaultGateway = "::";
+        defaultPrefLen = 128;
+    }
+    updateBaseBiosTable(mapDbusToBiosAttr("address"), defaulAddr);
+    updateBaseBiosTable(mapDbusToBiosAttr("gateway"), defaultGateway);
+    updateBaseBiosTable(mapDbusToBiosAttr("prefixLength"), defaultPrefLen);
 }
 
 std::string HypIPAddress::address(std::string ipAddress)
@@ -346,21 +370,49 @@ HypIP::AddressOrigin HypIPAddress::origin(HypIP::AddressOrigin origin)
     std::string originBiosAttr;
     if (originStr.substr(originStr.rfind(".") + 1) == "Static")
     {
-        originBiosAttr = "IPv4Static";
+        if (HypIP::type() == HypIP::Protocol::IPv4)
+        {
+            originBiosAttr = "IPv4Static";
+        }
+        else if (HypIP::type() == HypIP::Protocol::IPv6)
+        {
+            originBiosAttr = "IPv6Static";
+        }
     }
     else if (originStr.substr(originStr.rfind(".") + 1) == "DHCP")
     {
-        originBiosAttr = "IPv4DHCP";
+        if (HypIP::type() == HypIP::Protocol::IPv4)
+        {
+            originBiosAttr = "IPv4DHCP";
+        }
+        else if (HypIP::type() == HypIP::Protocol::IPv6)
+        {
+            originBiosAttr = "IPv6DHCP";
+        }
     }
 
     std::string currOriginValue;
     if (addrOrigin == HypIP::AddressOrigin::Static)
     {
-        currOriginValue = "IPv4Static";
+        if (HypIP::type() == HypIP::Protocol::IPv4)
+        {
+            currOriginValue = "IPv4Static";
+        }
+        else if (HypIP::type() == HypIP::Protocol::IPv6)
+        {
+            currOriginValue = "IPv6Static";
+        }
     }
     else if (addrOrigin == HypIP::AddressOrigin::DHCP)
     {
-        currOriginValue = "IPv4DHCP";
+        if (HypIP::type() == HypIP::Protocol::IPv4)
+        {
+            currOriginValue = "IPv4DHCP";
+        }
+        else if (HypIP::type() == HypIP::Protocol::IPv6)
+        {
+            currOriginValue = "IPv6DHCP";
+        }
     }
 
     origin = HypIP::origin(origin);

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
@@ -81,20 +81,23 @@ void HypNetworkMgr::setBIOSTableAttr(
     }
 }
 
-void HypNetworkMgr::setIf0DefaultBIOSTableAttrs()
+void HypNetworkMgr::setDefaultBIOSTableAttrsOnIntf(const std::string& intf,
+                                                   const std::string& protocol)
 {
-    biosTableAttrs.emplace("vmi_if0_ipv4_ipaddr", "0.0.0.0");
-    biosTableAttrs.emplace("vmi_if0_ipv4_gateway", "0.0.0.0");
-    biosTableAttrs.emplace("vmi_if0_ipv4_prefix_length", 0);
-    biosTableAttrs.emplace("vmi_if0_ipv4_method", "IPv4Static");
-}
-
-void HypNetworkMgr::setIf1DefaultBIOSTableAttrs()
-{
-    biosTableAttrs.emplace("vmi_if1_ipv4_ipaddr", "0.0.0.0");
-    biosTableAttrs.emplace("vmi_if1_ipv4_gateway", "0.0.0.0");
-    biosTableAttrs.emplace("vmi_if1_ipv4_prefix_length", 0);
-    biosTableAttrs.emplace("vmi_if1_ipv4_method", "IPv4Static");
+    if (protocol == "ipv4")
+    {
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv4_ipaddr", "0.0.0.0");
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv4_gateway", "0.0.0.0");
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv4_prefix_length", 0);
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv4_method", "IPv4Static");
+    }
+    else if (protocol == "ipv6")
+    {
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv6_ipaddr", "::");
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv6_gateway", "::");
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv6_prefix_length", 128);
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv6_method", "IPv6Static");
+    }
 }
 
 void HypNetworkMgr::setDefaultHostnameInBIOSTableAttrs()

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
@@ -108,12 +108,8 @@ class HypNetworkMgr
     /** @brief Method to set all the interface 0 attributes
      *         to its default value in biosTableAttrs data member
      */
-    void setIf0DefaultBIOSTableAttrs();
-
-    /** @brief Method to set all the interface 1 attributes
-     *         to its default value in biosTableAttrs data member
-     */
-    void setIf1DefaultBIOSTableAttrs();
+    void setDefaultBIOSTableAttrsOnIntf(const std::string& intf,
+                                        const std::string& protocol);
 
     /** @brief Method to set the hostname attribute
      *         to its default value in biosTableAttrs

--- a/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
+++ b/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
@@ -1,0 +1,122 @@
+#include "mock_hyp_ethernet_interface.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+
+#include <gtest/gtest.h>
+
+namespace phosphor
+{
+namespace network
+{
+
+class TestHypEthernetInterface : public testing::Test
+{
+  public:
+    sdbusplus::bus::bus bus;
+    HypNetworkMgr manager;
+    sdeventplus::Event event = sdeventplus::Event::get_default();
+
+    MockHypEthernetInterface interface;
+    TestHypEthernetInterface() :
+        bus(sdbusplus::bus::new_default()),
+        manager(bus, event, "/xyz/openbmc_test/network/hypervisor"),
+        interface(makeInterface(bus, manager))
+    {
+        manager.setDefaultBIOSTableAttrsOnIntf("if0", "ipv4");
+        manager.setDefaultBIOSTableAttrsOnIntf("if0", "ipv6");
+        manager.setDefaultBIOSTableAttrsOnIntf("if1", "ipv4");
+        manager.setDefaultBIOSTableAttrsOnIntf("if1", "ipv6");
+        manager.setDefaultHostnameInBIOSTableAttrs();
+        interface.createIPAddrObj();
+    }
+
+    static MockHypEthernetInterface makeInterface(sdbusplus::bus::bus& bus,
+                                                  HypNetworkMgr& manager)
+    {
+        return {bus, "/xyz/openbmc_test/network/hypervisor/eth0", "eth0",
+                manager};
+    }
+
+    bool isIPObjExist(const std::string& intf, const std::string& ipaddress)
+    {
+        auto it = interface.addrs.find(intf);
+        if (it != interface.addrs.end())
+        {
+            if (ipaddress == (it->second)->address())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool deleteIPObj(const std::string& intf, const std::string& ipaddress)
+    {
+        auto it = interface.addrs.find(intf);
+        if (it == interface.addrs.end())
+        {
+            return false;
+        }
+
+        if (ipaddress == (it->second)->address())
+        {
+            interface.addrs.erase(intf);
+            return true;
+        }
+        return false;
+    }
+};
+
+TEST_F(TestHypEthernetInterface, AddIPAddress)
+{
+    IP::Protocol addressType = IP::Protocol::IPv4;
+    bool createip = interface.createIP(interface, "eth0", addressType,
+                                       "10.10.10.10", 16, "10.10.10.1");
+    if (createip)
+    {
+        EXPECT_EQ(true, isIPObjExist("eth0", "10.10.10.10"));
+    }
+}
+
+TEST_F(TestHypEthernetInterface, AddMultipleAddress)
+{
+    IP::Protocol addressType = IP::Protocol::IPv4;
+    bool createip1 = interface.createIP(interface, "eth0", addressType,
+                                        "10.10.10.10", 16, "10.10.10.1");
+    if (createip1)
+    {
+        bool createip2 = interface.createIP(interface, "eth0", addressType,
+                                            "20.20.20.20", 16, "20.20.20.1");
+        if (createip2)
+        {
+            EXPECT_EQ(false, isIPObjExist("eth0", "10.10.10.10"));
+            EXPECT_EQ(true, isIPObjExist("eth0", "20.20.20.20"));
+        }
+    }
+}
+
+TEST_F(TestHypEthernetInterface, DeleteIPAddress)
+{
+    IP::Protocol addressType = IP::Protocol::IPv4;
+    bool createip = interface.createIP(interface, "eth0", addressType,
+                                       "20.20.20.20", 16, "20.20.20.1");
+    if (createip)
+    {
+        EXPECT_EQ(true, deleteIPObj("eth0", "20.20.20.20"));
+        EXPECT_EQ(false, isIPObjExist("eth0", "20.20.20.20"));
+    }
+}
+
+TEST_F(TestHypEthernetInterface, DeleteNonConfiguredIPAddr)
+{
+    IP::Protocol addressType = IP::Protocol::IPv4;
+    bool createip = interface.createIP(interface, "eth0", addressType,
+                                       "20.20.20.20", 16, "20.20.20.1");
+    if (createip)
+    {
+        EXPECT_EQ(false, deleteIPObj("eth0", "10.10.10.10"));
+    }
+}
+} // namespace network
+} // namespace phosphor

--- a/test/ibm/hypervisor-network-mgr-test/test_hyp_network_manager.cpp
+++ b/test/ibm/hypervisor-network-mgr-test/test_hyp_network_manager.cpp
@@ -1,0 +1,65 @@
+#include "hyp_network_manager.hpp"
+
+#include <net/if.h>
+
+#include <sdbusplus/bus.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+
+#include <gtest/gtest.h>
+
+namespace phosphor
+{
+namespace network
+{
+
+class TestHypNetworkManager : public testing::Test
+{
+  public:
+    sdbusplus::bus::bus bus;
+    HypNetworkMgr manager;
+    sdeventplus::Event event = sdeventplus::Event::get_default();
+    TestHypNetworkManager() :
+        bus(sdbusplus::bus::new_default()),
+        manager(bus, event, "/xyz/openbmc_test/network/hypervisor")
+    {
+        // TODO: Once the support for ipv6 has been added, the below
+        // method call to set default values in the local copy
+        // of the bios attributes should be called for ipv6 as well
+
+        manager.setDefaultBIOSTableAttrsOnIntf("if0", "ipv4");
+        manager.setDefaultBIOSTableAttrsOnIntf("if0", "ipv6");
+        manager.setDefaultBIOSTableAttrsOnIntf("if1", "ipv4");
+        manager.setDefaultBIOSTableAttrsOnIntf("if1", "ipv6");
+        manager.setDefaultHostnameInBIOSTableAttrs();
+    }
+
+    ~TestHypNetworkManager() = default;
+};
+
+TEST_F(TestHypNetworkManager, getDefaultBiosTableAttr)
+{
+    biosTableType biosAttrs = manager.getBIOSTableAttrs();
+    auto itr = biosAttrs.find("vmi_if0_ipv4_method");
+    if (itr != biosAttrs.end())
+    {
+        std::string biosAttrValue = std::get<std::string>(itr->second);
+        EXPECT_EQ(biosAttrValue, "IPv4Static");
+    }
+}
+
+TEST_F(TestHypNetworkManager, setHostnameInBiosTableAndGet)
+{
+    std::string attribute = "vmi_hostname";
+    std::string value = "testHostname";
+    manager.setBIOSTableAttr(attribute, value, "String");
+    biosTableType biosAttrs = manager.getBIOSTableAttrs();
+    auto itr = biosAttrs.find("vmi_hostname");
+    if (itr != biosAttrs.end())
+    {
+        std::string biosAttrValue = std::get<std::string>(itr->second);
+        EXPECT_EQ(biosAttrValue, value);
+    }
+}
+
+} // namespace network
+} // namespace phosphor


### PR DESCRIPTION
Currently, there is no support for ipv6 in the hypervisor
application.
This commit adds ipv6 support, and the changes mainly includes
creation of ipv4 & ipv6 dbus objects when the application starts;
adding support in watch method where ipv6 property changes are
also monitored; setting default values for ipv6 properties in
the bios.

Tested By:

* Created IPv6 dbus objects along with ipv4

busctl tree xyz.openbmc_project.Network.Hypervisor
└─/xyz
  └─/xyz/openbmc_project
    └─/xyz/openbmc_project/network
      └─/xyz/openbmc_project/network/hypervisor
        ├─/xyz/openbmc_project/network/hypervisor/config
        ├─/xyz/openbmc_project/network/hypervisor/eth0
        │ ├─/xyz/openbmc_project/network/hypervisor/eth0/ipv4
        │ │ └─/xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0
        │ └─/xyz/openbmc_project/network/hypervisor/eth0/ipv6
        │   └─/xyz/openbmc_project/network/hypervisor/eth0/ipv6/addr0
        └─/xyz/openbmc_project/network/hypervisor/eth1
          ├─/xyz/openbmc_project/network/hypervisor/eth1/ipv4
          │ └─/xyz/openbmc_project/network/hypervisor/eth1/ipv4/addr0
          └─/xyz/openbmc_project/network/hypervisor/eth1/ipv6
            └─/xyz/openbmc_project/network/hypervisor/eth1/ipv6/addr0

* IP Create worked for both ipv4/6 on both interfaces

* IP delete worked for both ipv4/6 on both interfaces

* Corresponding bios table attribute values updation done

* Change in bios table value is reflected in the dbus object

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I25fd59355560be31a93aa8f0aee45a3572a25efd