### PR TITLE
Delete DHCP IP object while moving from DHCP to static

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -288,6 +288,9 @@ ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
         log<level::INFO>("DHCP enabled on the interface"),
             entry("INTERFACE=%s", interfaceName().c_str());
         disableDHCP(protType);
+        // Delete the IP address object and that reloads the networkd
+        // to allow the same IP address to be set as Static IP
+        deleteObject(ipaddress);
     }
 
     IP::AddressOrigin origin = IP::AddressOrigin::Static;


### PR DESCRIPTION
Currently when DHCP is enabled, if user configures same DHCP IP
as static IP config then networkd disable DHCP, fails to add
static entry and return error to the client.

This issue only seen if user configures static IP which is same as
DHCP IP.

Tested by:
Configured same DHCP IP as static IP via redfish

Signed-off-by: Ravi Teja <raviteja28031990@gmail.com>
Change-Id: I7b703c0e70867f79212c3f8955d7f88d22b8328a