### PR TITLE
Allow patching of zero prefix length

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -547,7 +547,7 @@ ObjectPath HypEthInterface::ip(HypIP::Protocol protType, std::string ipaddress,
     }
 
     if (!isValidPrefix(AF_INET, prefixLength) &&
-        !isValidPrefix(AF_INET6, prefixLength))
+        !isValidPrefix(AF_INET6, prefixLength) && prefixLength != 0)
     {
         log<level::ERR>("PrefixLength is not correct "),
             entry("PREFIXLENGTH=%" PRIu8, prefixLength);


### PR DESCRIPTION
Currently, when a user configures a zero ip (mentioned in Tested
By section), 500 Internal error would be sent back as the redfish
response. This commit allows patching of ip properties with the
default values.

Partially fixes the defect at: https://w3.rchland.ibm.com/projects/bestquest/?verb=view&id=SW553141

Tested By:
-X PATCH https://{$bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1 \
-d {"IPv4StaticAddresses":[{"Address":"0.0.0.0","Gateway":"0.0.0.0","SubnetMask":"0.0.0.0"}]}

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: Id032bf3933e19bb797a2d25a7255d3942b405984