### PR TITLE
Hypervisor network configuration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -70,6 +70,12 @@ networkd_dbus_dep = declare_dependency(
 
 subdir('src')
 
+if (get_option('hyp-nw-config') == true)
+  hyp_networkd_lib = [
+    hyp_networkd_lib
+  ]
+endif
+
 configure_file(
   input: '60-phosphor-networkd-default.network.in',
   output: '60-phosphor-networkd-default.network',

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -1,5 +1,7 @@
 #include "hyp_ethernet_interface.hpp"
 
+class HypEthInterface;
+
 namespace phosphor
 {
 namespace network
@@ -9,9 +11,205 @@ using namespace phosphor::logging;
 using namespace sdbusplus::xyz::openbmc_project::Common::Error;
 using Argument = xyz::openbmc_project::Common::InvalidArgument;
 
+constexpr auto BIOS_SERVICE = "xyz.openbmc_project.BIOSConfigManager";
+constexpr auto BIOS_OBJPATH = "/xyz/openbmc_project/bios_config/manager";
+constexpr auto BIOS_MGR_INTF = "xyz.openbmc_project.BIOSConfig.Manager";
+
+// The total number of vmi attributes defined in biosTableAttrs
+// currently is 9:
+// 4 attributes of interface 0
+// 4 attributes of interface 1
+// and 1 vmi_hostname attribute
+constexpr auto BIOS_ATTRS_SIZE = 9;
+
+void HypEthInterface::setIpPropsInMap(
+    std::string attrName, std::variant<std::string, int64_t> attrValue,
+    std::string attrType)
+{
+    manager.setBIOSTableAttr(attrName, attrValue, attrType);
+}
+
 biosTableType HypEthInterface::getBiosAttrsMap()
 {
     return manager.getBIOSTableAttrs();
+}
+
+void HypEthInterface::updateIPAddress(std::string ip, std::string updatedIp)
+{
+    auto it = addrs.find(ip);
+    if (it != addrs.end())
+    {
+        auto& ipObj = it->second;
+
+        // Delete the ip address from the local copy (addrs)
+        // and update it with the new ip and ip address object
+        if (deleteObject(ip))
+        {
+            addrs.emplace(updatedIp, std::move(ipObj));
+            log<level::INFO>("Successfully updated ip address");
+            return;
+        }
+        log<level::ERR>("Updation of ip address not successful");
+        return;
+    }
+}
+
+bool HypEthInterface::deleteObject(const std::string& ipaddress)
+{
+    auto it = addrs.find(ipaddress);
+    if (it == addrs.end())
+    {
+        log<level::ERR>("DeleteObject:Unable to find the object.");
+        return false;
+    }
+    addrs.erase(it);
+    log<level::INFO>("Successfully deleted the ip address object");
+    return true;
+}
+
+std::string HypEthInterface::getIntfLabel()
+{
+    // This method returns if0/if1 based on the eth
+    // interface label eth0/eth1 in the object path
+    const std::string ethIntfLabel =
+        objectPath.substr(objectPath.rfind("/") + 1);
+    if (ethIntfLabel == "eth0")
+    {
+        return "if0";
+    }
+    else if (ethIntfLabel == "eth1")
+    {
+        return "if1";
+    }
+    return "";
+}
+
+void HypEthInterface::createIPAddressObjects()
+{
+    // Access the biosTableAttrs of the parent object to create the ip address
+    // object
+    const std::string intfLabel = getIntfLabel();
+    if (intfLabel == "")
+    {
+        log<level::ERR>("Wrong interface name");
+        return;
+    }
+    std::string ipAddr;
+    HypIP::Protocol ipProtocol;
+    HypIP::AddressOrigin ipOrigin;
+    uint8_t ipPrefixLength;
+    std::string ipGateway;
+
+    auto biosTableAttrs = manager.getBIOSTableAttrs();
+
+    if (biosTableAttrs.size() < BIOS_ATTRS_SIZE)
+    {
+        log<level::INFO>("Creating ip address object with default values");
+        if (intfLabel == "if0")
+        {
+            // set the default values for interface 0 in the local
+            // copy of the bios table - biosTableAttrs
+            manager.setDefaultBIOSTableAttrsOnIntf(intfLabel);
+            addrs.emplace("eth0", std::make_unique<HypIPAddress>(
+                                      bus, (objectPath + "/ipv4/addr0").c_str(),
+                                      *this, HypIP::Protocol::IPv4, "0.0.0.0",
+                                      HypIP::AddressOrigin::Static, 0,
+                                      "0.0.0.0", intfLabel));
+        }
+        else if (intfLabel == "if1")
+        {
+            // set the default values for interface 0 in the local
+            // copy of the bios table - biosTableAttrs
+            manager.setDefaultBIOSTableAttrsOnIntf(intfLabel);
+            addrs.emplace("eth1", std::make_unique<HypIPAddress>(
+                                      bus, (objectPath + "/ipv4/addr0").c_str(),
+                                      *this, HypIP::Protocol::IPv4, "0.0.0.0",
+                                      HypIP::AddressOrigin::Static, 0,
+                                      "0.0.0.0", intfLabel));
+        }
+        return;
+    }
+
+    for (std::string protocol : {"ipv4", "ipv6"})
+    {
+        std::string vmi_prefix = "vmi_" + intfLabel + "_" + protocol + "_";
+
+        auto biosTableItr = biosTableAttrs.find(vmi_prefix + "method");
+        if (biosTableItr != biosTableAttrs.end())
+        {
+            std::string ipType = std::get<std::string>(biosTableItr->second);
+            if (ipType.find("Static") != std::string::npos)
+            {
+                ipOrigin = HypIP::AddressOrigin::Static;
+                // update the dhcp enabled property of the eth interface
+                if (protocol == "ipv4")
+                {
+                    dhcp4(false);
+                }
+                else if (protocol == "ipv6")
+                {
+                    dhcp6(false);
+                }
+            }
+            else if (ipType.find("DHCP") != std::string::npos)
+            {
+                ipOrigin = HypIP::AddressOrigin::DHCP;
+                // update the dhcp enabled property of the eth interface
+                if (protocol == "ipv4")
+                {
+                    dhcp4(true);
+                }
+                else if (protocol == "ipv6")
+                {
+                    dhcp6(true);
+                }
+            }
+            else
+            {
+                log<level::ERR>("Error - Neither Static/DHCP");
+            }
+        }
+        else
+        {
+            continue;
+        }
+
+        biosTableItr = biosTableAttrs.find(vmi_prefix + "ipaddr");
+        if (biosTableItr != biosTableAttrs.end())
+        {
+            ipAddr = std::get<std::string>(biosTableItr->second);
+        }
+
+        biosTableItr = biosTableAttrs.find(vmi_prefix + "prefix_length");
+        if (biosTableItr != biosTableAttrs.end())
+        {
+            ipPrefixLength =
+                static_cast<uint8_t>(std::get<int64_t>(biosTableItr->second));
+        }
+
+        biosTableItr = biosTableAttrs.find(vmi_prefix + "gateway");
+        if (biosTableItr != biosTableAttrs.end())
+        {
+            ipGateway = std::get<std::string>(biosTableItr->second);
+        }
+
+        std::string ipObjId = "addr0";
+        if (protocol == "ipv4")
+        {
+            ipProtocol = HypIP::Protocol::IPv4;
+        }
+        else if (protocol == "ipv6")
+        {
+            ipProtocol = HypIP::Protocol::IPv6;
+        }
+
+        addrs.emplace(ipAddr,
+                      std::make_unique<HypIPAddress>(
+                          bus,
+                          (objectPath + "/" + protocol + "/" + ipObjId).c_str(),
+                          *this, ipProtocol, ipAddr, ipOrigin, ipPrefixLength,
+                          ipGateway, intfLabel));
+    }
 }
 
 bool HypEthInterface::ipv6AcceptRA(bool value)
@@ -74,6 +272,7 @@ HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled(DHCPConf value)
     {
         HypEthernetIntf::dhcpEnabled(value);
     }
+
     return value;
 }
 

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -14,5 +14,81 @@ biosTableType HypEthInterface::getBiosAttrsMap()
     return manager.getBIOSTableAttrs();
 }
 
+bool HypEthInterface::ipv6AcceptRA(bool value)
+{
+    auto currValue = ipv6AcceptRA();
+    if (currValue != value)
+    {
+        HypEthernetIntf::ipv6AcceptRA(value);
+    }
+    return value;
+}
+
+bool HypEthInterface::dhcp4(bool value)
+{
+    auto currValue = dhcp4();
+    if (currValue != value)
+    {
+        HypEthernetIntf::dhcp4(value);
+    }
+    return value;
+}
+
+bool HypEthInterface::dhcp6(bool value)
+{
+    auto currValue = dhcp6();
+    if (currValue != value)
+    {
+        HypEthernetIntf::dhcp6(value);
+    }
+    return value;
+}
+
+bool HypEthInterface::dhcpIsEnabled(HypIP::Protocol family)
+{
+    switch (family)
+    {
+        case HypIP::Protocol::IPv6:
+            return dhcp6();
+        case HypIP::Protocol::IPv4:
+            return dhcp4();
+    }
+    throw std::logic_error("Unreachable");
+}
+
+HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled(DHCPConf value)
+{
+    auto old4 = HypEthernetIntf::dhcp4();
+    auto new4 = HypEthernetIntf::dhcp4(value == DHCPConf::v4 ||
+                                       value == DHCPConf::v4v6stateless ||
+                                       value == DHCPConf::both);
+    auto old6 = HypEthernetIntf::dhcp6();
+    auto new6 = HypEthernetIntf::dhcp6(value == DHCPConf::v6 ||
+                                       value == DHCPConf::both);
+    auto oldra = HypEthernetIntf::ipv6AcceptRA();
+    auto newra = HypEthernetIntf::ipv6AcceptRA(
+        value == DHCPConf::v6stateless || value == DHCPConf::v4v6stateless ||
+        value == DHCPConf::v6 || value == DHCPConf::both);
+
+    if (old4 != new4 || old6 != new6 || oldra != newra)
+    {
+        HypEthernetIntf::dhcpEnabled(value);
+    }
+    return value;
+}
+
+HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled() const
+{
+    if (dhcp6())
+    {
+        return dhcp4() ? DHCPConf::both : DHCPConf::v6;
+    }
+    else if (dhcp4())
+    {
+        return ipv6AcceptRA() ? DHCPConf::v4v6stateless : DHCPConf::v4;
+    }
+    return ipv6AcceptRA() ? DHCPConf::v6stateless : DHCPConf::none;
+}
+
 } // namespace network
 } // namespace phosphor

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -24,6 +24,224 @@ constexpr auto BIOS_MGR_INTF = "xyz.openbmc_project.BIOSConfig.Manager";
 // and 1 vmi_hostname attribute
 constexpr auto BIOS_ATTRS_SIZE = 9;
 
+biosTableRetAttrValueType
+    HypEthInterface::getAttrFromBiosTable(const std::string& attrName)
+{
+    try
+    {
+        using getAttrRetType =
+            std::tuple<std::string, std::variant<std::string, int64_t>,
+                       std::variant<std::string, int64_t>>;
+        getAttrRetType ip;
+        auto method = bus.new_method_call(BIOS_SERVICE, BIOS_OBJPATH,
+                                          BIOS_MGR_INTF, "GetAttribute");
+
+        method.append(attrName);
+
+        auto reply = bus.call(method);
+
+        std::string type;
+        std::variant<std::string, int64_t> currValue;
+        std::variant<std::string, int64_t> defValue;
+        reply.read(type, currValue, defValue);
+        return currValue;
+    }
+    catch (const sdbusplus::exception::SdBusError& ex)
+    {
+        log<level::ERR>("Failed to get the attribute value from bios table",
+                        entry("ERR=%s", ex.what()));
+    }
+    return "";
+}
+
+void HypEthInterface::watchBaseBiosTable()
+{
+    auto BIOSAttrUpdate = [this](sdbusplus::message::message& m) {
+        std::map<std::string, std::variant<BiosBaseTableType>>
+            interfacesProperties;
+
+        std::string objName;
+        m.read(objName, interfacesProperties);
+
+        // Check if the property change signal is for BaseBIOSTable property
+        // If found, proceed; else, continue to listen
+        if (!interfacesProperties.contains("BaseBIOSTable"))
+        {
+            // Return & continue to listen
+            return;
+        }
+
+        // Check if the IP address has changed (i.e., if current ip address in
+        // the biosTableAttrs data member and ip address in bios table are
+        // different)
+
+        // the no. of interface supported is two
+        constexpr auto MAX_INTF_SUPPORTED = 2;
+        for (auto i = 0; i < MAX_INTF_SUPPORTED; i++)
+        {
+            std::string intf = "if" + std::to_string(i);
+
+            std::string dhcpEnabled = std::get<std::string>(
+                getAttrFromBiosTable("vmi_" + intf + "_ipv4_method"));
+
+            // This method was intended to watch the bios table
+            // property change signal and update the dbus object
+            // whenever the dhcp server has provided an
+            // IP from different range or changed its gateway/subnet mask (or)
+            // when user updates the bios table ip attributes -
+            // patch on /redfish/v1/Systems/system/Bios/Settings
+            // Because, in all other cases,
+            // user configures ip properties that will be set in the dbus
+            // object, followed by bios table updation. In this dhcp case,
+            // the dbus will not be having the updated ip address which
+            // is in bios table, also in the second case, where one patches
+            // bios table attributes, the dbus object will not have the updated
+            // values. This method is to sync the ip addresses
+            // between the bios table & dbus object.
+
+            // Get corresponding ethernet interface object
+            std::string ethIntfLabel;
+            if (intf == "if0")
+            {
+                ethIntfLabel = "eth0";
+            }
+            else
+            {
+                ethIntfLabel = "eth1";
+            }
+
+            // Get the list of all ethernet interfaces from the parent
+            // data member to get the eth object corresponding to the
+            // eth interface label above
+            const auto& ethIntfList = manager.getEthIntfList();
+            auto findEthObj = ethIntfList.find(ethIntfLabel);
+
+            if (findEthObj == ethIntfList.end())
+            {
+                log<level::ERR>("Cannot find ethernet object");
+                return;
+            }
+
+            const auto& ethObj = std::move(findEthObj->second);
+
+            DHCPConf dhcpState = ethObj->dhcpEnabled();
+
+            if ((dhcpState == HypEthInterface::DHCPConf::none) &&
+                (dhcpEnabled == "IPv4DHCP"))
+            {
+                // There is a change in bios table method attribute (changed to
+                // dhcp) but dbus property contains static Change the dbus
+                // property to dhcp
+                log<level::INFO>("Setting dhcp on the dbus object");
+                ethObj->dhcpEnabled(HypEthInterface::DHCPConf::v4);
+            }
+            else if ((dhcpState != HypEthInterface::DHCPConf::none) &&
+                     (dhcpEnabled == "IPv4Static"))
+            {
+                // There is a change in bios table method attribute (changed to
+                // static) but dbus property contains dhcp Change the dbus
+                // property to static
+                log<level::INFO>("Setting static on the dbus object");
+                ethObj->dhcpEnabled(HypEthInterface::DHCPConf::none);
+            }
+
+            const auto& ipAddrs = ethObj->addrs;
+
+            std::string ipAddr;
+            std::string currIpAddr;
+            std::string gateway;
+            uint8_t prefixLen = 0;
+
+            auto biosTableAttrs = manager.getBIOSTableAttrs();
+            for (const auto& attr : biosTableAttrs)
+            {
+                // Get ip address
+                if ((attr.first).ends_with(intf + "_ipv4_ipaddr"))
+                {
+                    currIpAddr = std::get<std::string>(attr.second);
+                    if (currIpAddr.empty())
+                    {
+                        log<level::INFO>(
+                            "Current IP in biosAttrs copy is empty");
+                        return;
+                    }
+                    ipAddr =
+                        std::get<std::string>(getAttrFromBiosTable(attr.first));
+                    if (ipAddr != currIpAddr)
+                    {
+                        // Ip address has changed
+                        for (auto& addrs : ipAddrs)
+                        {
+                            auto& ipObj = addrs.second;
+                            ipObj->HypIP::address(ipAddr);
+                            setIpPropsInMap(attr.first, ipAddr, "String");
+                            break;
+                        }
+                        return;
+                    }
+                }
+
+                // Get gateway
+                if ((attr.first).ends_with(intf + "_ipv4_gateway"))
+                {
+                    std::string currGateway =
+                        std::get<std::string>(attr.second);
+                    if (currGateway.empty())
+                    {
+                        log<level::INFO>(
+                            "Current Gateway in biosAttrs copy is empty");
+                        return;
+                    }
+                    gateway =
+                        std::get<std::string>(getAttrFromBiosTable(attr.first));
+                    if (gateway != currGateway)
+                    {
+                        // Gateway has changed
+                        for (auto& addrs : ipAddrs)
+                        {
+                            auto& ipObj = addrs.second;
+                            ipObj->HypIP::gateway(gateway);
+                            setIpPropsInMap(attr.first, gateway, "String");
+                            break;
+                        }
+                        return;
+                    }
+                }
+
+                // Get prefix length
+                if ((attr.first).ends_with(intf + "_ipv4_prefix_length"))
+                {
+                    uint8_t currPrefixLen =
+                        static_cast<uint8_t>(std::get<int64_t>(attr.second));
+                    prefixLen = static_cast<uint8_t>(
+                        std::get<int64_t>(getAttrFromBiosTable(attr.first)));
+                    if (prefixLen != currPrefixLen)
+                    {
+                        // Prefix length has changed"
+                        for (auto& addrs : ipAddrs)
+                        {
+                            auto& ipObj = addrs.second;
+                            ipObj->HypIP::prefixLength(prefixLen);
+                            setIpPropsInMap(attr.first, prefixLen, "Integer");
+                            break;
+                        }
+                        return;
+                    }
+                }
+            }
+        }
+        return;
+    };
+
+    phosphor::network::matchBIOSAttrUpdate = std::make_unique<
+        sdbusplus::bus::match::match>(
+        bus,
+        "type='signal',member='PropertiesChanged',interface='org.freedesktop."
+        "DBus.Properties',arg0namespace='xyz.openbmc_project.BIOSConfig."
+        "Manager'",
+        BIOSAttrUpdate);
+}
+
 void HypEthInterface::setIpPropsInMap(
     std::string attrName, std::variant<std::string, int64_t> attrValue,
     std::string attrType)

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -10,6 +10,8 @@ namespace network
 using namespace phosphor::logging;
 using namespace sdbusplus::xyz::openbmc_project::Common::Error;
 using Argument = xyz::openbmc_project::Common::InvalidArgument;
+using BIOSConfigManager =
+    sdbusplus::xyz::openbmc_project::BIOSConfig::server::Manager;
 
 constexpr auto BIOS_SERVICE = "xyz.openbmc_project.BIOSConfigManager";
 constexpr auto BIOS_OBJPATH = "/xyz/openbmc_project/bios_config/manager";
@@ -254,6 +256,127 @@ bool HypEthInterface::dhcpIsEnabled(HypIP::Protocol family)
     throw std::logic_error("Unreachable");
 }
 
+ObjectPath HypEthInterface::ip(HypIP::Protocol protType, std::string ipaddress,
+                               uint8_t prefixLength, std::string gateway)
+{
+    if (dhcpIsEnabled(protType))
+    {
+        log<level::INFO>("Disabling DHCP on the interface"),
+            entry("INTERFACE=%s", interfaceName().c_str());
+        switch (protType)
+        {
+            case HypIP::Protocol::IPv4:
+                dhcp4(false);
+                break;
+            case HypIP::Protocol::IPv6:
+                dhcp6(false);
+                break;
+        }
+    }
+
+    HypIP::AddressOrigin origin = HypIP::AddressOrigin::Static;
+
+    if (!isValidIP(AF_INET, ipaddress) && !isValidIP(AF_INET6, ipaddress))
+    {
+        log<level::ERR>("Not a valid IP address"),
+            entry("ADDRESS=%s", ipaddress.c_str());
+        elog<InvalidArgument>(Argument::ARGUMENT_NAME("Address"),
+                              Argument::ARGUMENT_VALUE(ipaddress.c_str()));
+        return sdbusplus::message::details::string_path_wrapper();
+    }
+
+    if (!isValidIP(AF_INET, gateway) && !isValidIP(AF_INET6, gateway))
+    {
+        log<level::ERR>("Not a valid gateway"),
+            entry("ADDRESS=%s", gateway.c_str());
+        elog<InvalidArgument>(Argument::ARGUMENT_NAME("Gateway"),
+                              Argument::ARGUMENT_VALUE(ipaddress.c_str()));
+        return sdbusplus::message::details::string_path_wrapper();
+    }
+
+    if (!isValidPrefix(AF_INET, prefixLength) &&
+        !isValidPrefix(AF_INET6, prefixLength))
+    {
+        log<level::ERR>("Prefix length is not correct "),
+            entry("PREFIXLENGTH=%" PRIu8, prefixLength);
+        elog<InvalidArgument>(
+            Argument::ARGUMENT_NAME("prefixLength"),
+            Argument::ARGUMENT_VALUE(std::to_string(prefixLength).c_str()));
+        return sdbusplus::message::details::string_path_wrapper();
+    }
+
+    const std::string intfLabel = getIntfLabel();
+    if (intfLabel == "")
+    {
+        log<level::ERR>("Wrong interface name");
+        return sdbusplus::message::details::string_path_wrapper();
+    }
+
+    const std::string ipObjId = "addr0";
+    std::string protocol;
+    if (protType == HypIP::Protocol::IPv4)
+    {
+        protocol = "ipv4";
+    }
+    else if (protType == HypIP::Protocol::IPv6)
+    {
+        protocol = "ipv6";
+    }
+
+    std::string objPath = objectPath + "/" + protocol + "/" + ipObjId;
+
+    for (auto& addr : addrs)
+    {
+        auto& ipObj = addr.second;
+        std::string ipObjAddr = ipObj->address();
+        uint8_t ipObjPrefixLen = ipObj->prefixLength();
+        std::string ipObjGateway = ipObj->gateway();
+
+        if ((ipaddress == ipObjAddr) && (prefixLength == ipObjPrefixLen) &&
+            (gateway == ipObjGateway))
+        {
+            log<level::INFO>("Trying to set same IP properties");
+        }
+        auto addrKey = addrs.extract(addr.first);
+        addrKey.key() = ipaddress;
+        break;
+    }
+
+    log<level::INFO>("Updating IP properties",
+                     entry("OBJPATH=%s", objPath.c_str()),
+                     entry("INTERFACE=%s", intfLabel.c_str()),
+                     entry("ADDRESS=%s", ipaddress.c_str()),
+                     entry("GATEWAY=%s", gateway.c_str()),
+                     entry("PREFIXLENGTH=%d", prefixLength));
+
+    addrs[ipaddress] = std::make_unique<HypIPAddress>(
+        bus, (objPath).c_str(), *this, protType, ipaddress, origin,
+        prefixLength, gateway, intfLabel);
+
+    PendingAttributesType pendingAttributes;
+
+    auto& ipObj = addrs[ipaddress];
+    pendingAttributes.insert_or_assign(
+        ipObj->mapDbusToBiosAttr("address"),
+        std::make_tuple(BIOSConfigManager::convertAttributeTypeToString(
+                            BIOSConfigManager::AttributeType::String),
+                        ipaddress));
+    pendingAttributes.insert_or_assign(
+        ipObj->mapDbusToBiosAttr("gateway"),
+        std::make_tuple(BIOSConfigManager::convertAttributeTypeToString(
+                            BIOSConfigManager::AttributeType::String),
+                        gateway));
+    pendingAttributes.insert_or_assign(
+        ipObj->mapDbusToBiosAttr("prefixLength"),
+        std::make_tuple(BIOSConfigManager::convertAttributeTypeToString(
+                            BIOSConfigManager::AttributeType::Integer),
+                        prefixLength));
+
+    ipObj->updateBiosPendingAttrs(pendingAttributes);
+
+    return objPath;
+}
+
 HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled(DHCPConf value)
 {
     auto old4 = HypEthernetIntf::dhcp4();
@@ -268,10 +391,62 @@ HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled(DHCPConf value)
         value == DHCPConf::v6stateless || value == DHCPConf::v4v6stateless ||
         value == DHCPConf::v6 || value == DHCPConf::both);
 
-    if (old4 != new4 || old6 != new6 || oldra != newra)
+    if (old4 == new4 || old6 == new6 || oldra == newra)
     {
-        HypEthernetIntf::dhcpEnabled(value);
+        // if new value is the same as old value
+        return value;
     }
+
+    HypEthernetIntf::dhcpEnabled(value);
+
+    std::unique_ptr<HypIPAddress> ipObj;
+    std::string method;
+
+    if (value != HypEthernetIntf::DHCPConf::none)
+    {
+        for (auto& itr : addrs)
+        {
+            ipObj = std::move(itr.second);
+
+            std::string method;
+            if (ipObj->type() == HypIP::Protocol::IPv4)
+            {
+                method = "IPv4DHCP";
+            }
+            else if (ipObj->type() == HypIP::Protocol::IPv6)
+            {
+                method = "IPv6DHCP";
+            }
+            break;
+        }
+    }
+    else
+    {
+        for (auto& itr : addrs)
+        {
+            ipObj = std::move(itr.second);
+
+            std::string method;
+            if (ipObj->type() == HypIP::Protocol::IPv4)
+            {
+                method = "IPv4Static";
+            }
+            else if (ipObj->type() == HypIP::Protocol::IPv6)
+            {
+                method = "IPv6Static";
+            }
+            break;
+        }
+    }
+
+    PendingAttributesType pendingAttributes;
+    pendingAttributes.insert_or_assign(
+        ipObj->mapDbusToBiosAttr("origin"),
+        std::make_tuple(BIOSConfigManager::convertAttributeTypeToString(
+                            BIOSConfigManager::AttributeType::Enumeration),
+                        method));
+    ipObj->updateBiosPendingAttrs(pendingAttributes);
+    log<level::INFO>("Updating the ip address properties");
 
     return value;
 }

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -1,0 +1,18 @@
+#include "hyp_ethernet_interface.hpp"
+
+namespace phosphor
+{
+namespace network
+{
+
+using namespace phosphor::logging;
+using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+using Argument = xyz::openbmc_project::Common::InvalidArgument;
+
+biosTableType HypEthInterface::getBiosAttrsMap()
+{
+    return manager.getBIOSTableAttrs();
+}
+
+} // namespace network
+} // namespace phosphor

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
+#include "hyp_ip_interface.hpp"
 #include "hyp_network_manager.hpp"
-#include "xyz/openbmc_project/Network/IP/Create/server.hpp"
+#include "types.hpp"
 
 #include <phosphor-logging/elog-errors.hpp>
 #include <phosphor-logging/elog.hpp>
@@ -9,6 +10,7 @@
 #include <sdbusplus/bus.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 #include <xyz/openbmc_project/Network/EthernetInterface/server.hpp>
+#include <xyz/openbmc_project/Network/IP/Create/server.hpp>
 
 namespace phosphor
 {
@@ -17,8 +19,9 @@ namespace network
 
 class HypNetworkMgr; // forward declaration of hypervisor network manager.
 
+class HypIPAddress;
+
 using namespace phosphor::logging;
-using HypIP = sdbusplus::xyz::openbmc_project::Network::server::IP;
 
 using CreateIface = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Network::server::EthernetInterface,
@@ -29,7 +32,11 @@ using biosTableType = std::map<std::string, std::variant<int64_t, std::string>>;
 using HypEthernetIntf =
     sdbusplus::xyz::openbmc_project::Network::server::EthernetInterface;
 
+using HypIP = sdbusplus::xyz::openbmc_project::Network::server::IP;
+
 using ObjectPath = sdbusplus::message::object_path;
+
+using ipAddrMapType = string_umap<std::unique_ptr<HypIPAddress>>;
 
 static std::shared_ptr<sdbusplus::bus::match::match> matchBIOSAttrUpdate;
 
@@ -60,6 +67,10 @@ class HypEthInterface : public CreateIface
         emit_object_added();
     };
 
+    /* @brief creates the IP dbus object
+     */
+    virtual void createIPAddressObjects();
+
     /** @brief Function to create ipAddress dbus object.
      *  @param[in] addressType - Type of ip address.
      *  @param[in] ipAddress- IP address.
@@ -73,9 +84,40 @@ class HypEthInterface : public CreateIface
         return std::string();
     };
 
+    /* @brief Function to delete the IP dbus object
+     *  @param[in] ipaddress - ipaddress to delete.
+     */
+    bool deleteObject(const std::string& ipaddress);
+
+    /* @brief Returns interface id
+     * @param[out] - if0/if1
+     */
+    std::string getIntfLabel();
+
+    /* @brief Function to update the ip address property in
+              the dbus object
+     * @detail if there is a change in ip address in bios
+               table, the ip is updated in the dbus obj path
+     * @param[in] updatedIp - ip to update
+     */
+    void updateIPAddress(std::string ip, std::string updatedIp);
+
     /* @brief Function that returns parent's bios attrs map
      */
     biosTableType getBiosAttrsMap();
+
+    /* @brief Function to set ip address properties in
+              the parent's bios attrs map
+     * @detail if there is a change in any properties either in bios
+               table or on the dbus object, the bios attrs map data member
+               of the parent should be updated with the latest value
+     * @param[in] attrName - attrName for which there is a change in value
+     * @param[in] attrValue - updated value
+     * @param[in] attrType - type of the attrValue (string/integer)
+     */
+    void setIpPropsInMap(std::string attrName,
+                         std::variant<std::string, int64_t> attrValue,
+                         std::string attrType);
 
     /* @brief Returns the dhcp enabled property
      * @param[in] protocol - ipv4/ipv6
@@ -109,12 +151,15 @@ class HypEthInterface : public CreateIface
     /** @brief Parent of this object */
     HypNetworkMgr& manager;
 
-  private:
-    /** @brief Determines if DHCP is active for the IP::Protocol supplied.
+  protected:
+    /** @brief Determines if DHCP is active for the HypIP::Protocol supplied.
      *  @param[in] protocol - Either IPv4 or IPv6
      *  @returns true/false value if DHCP is active for the input protocol
      */
     bool dhcpIsEnabled(HypIP::Protocol protocol);
+
+    /** @brief List of the ipaddress and the ip dbus objects */
+    ipAddrMapType addrs;
 };
 
 } // namespace network

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "hyp_network_manager.hpp"
+#include "xyz/openbmc_project/Network/IP/Create/server.hpp"
+
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/elog.hpp>
+#include <phosphor-logging/log.hpp>
+#include <sdbusplus/bus.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+#include <xyz/openbmc_project/Network/EthernetInterface/server.hpp>
+
+namespace phosphor
+{
+namespace network
+{
+
+class HypNetworkMgr; // forward declaration of hypervisor network manager.
+
+using namespace phosphor::logging;
+using HypIP = sdbusplus::xyz::openbmc_project::Network::server::IP;
+
+using CreateIface = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Network::server::EthernetInterface,
+    sdbusplus::xyz::openbmc_project::Network::IP::server::Create>;
+
+using biosTableType = std::map<std::string, std::variant<int64_t, std::string>>;
+
+using HypEthernetIntf =
+    sdbusplus::xyz::openbmc_project::Network::server::EthernetInterface;
+
+using ObjectPath = sdbusplus::message::object_path;
+
+static std::shared_ptr<sdbusplus::bus::match::match> matchBIOSAttrUpdate;
+
+/** @class HypEthernetInterface
+ *  @brief Hypervisor Ethernet Interface implementation.
+ */
+class HypEthInterface : public CreateIface
+{
+  public:
+    HypEthInterface() = delete;
+    HypEthInterface(const HypEthInterface&) = delete;
+    HypEthInterface& operator=(const HypEthInterface&) = delete;
+    HypEthInterface(HypEthInterface&&) = delete;
+    HypEthInterface& operator=(HypEthInterface&&) = delete;
+    virtual ~HypEthInterface() = default;
+
+    /** @brief Constructor to put object onto bus at a dbus path.
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] path - Path to attach at.
+     *  @param[in] parent - parent object.
+     */
+    HypEthInterface(sdbusplus::bus::bus& bus, const char* path,
+                    std::string_view intfName, HypNetworkMgr& parent) :
+        CreateIface(bus, path, CreateIface::action::defer_emit),
+        bus(bus), objectPath(path), manager(parent)
+    {
+        HypEthernetIntf::interfaceName(intfName.data(), true);
+        emit_object_added();
+    };
+
+    /** @brief Function to create ipAddress dbus object.
+     *  @param[in] addressType - Type of ip address.
+     *  @param[in] ipAddress- IP address.
+     *  @param[in] prefixLength - Length of prefix.
+     *  @param[in] gateway - Gateway ip address.
+     */
+
+    ObjectPath ip(HypIP::Protocol /*addressType*/, std::string /*ipAddress*/,
+                  uint8_t /*prefixLength*/, std::string /*gateway*/) override
+    {
+        return std::string();
+    };
+
+    /* @brief Function that returns parent's bios attrs map
+     */
+    biosTableType getBiosAttrsMap();
+
+    using HypEthernetIntf::interfaceName;
+
+  protected:
+    /** @brief sdbusplus DBus bus connection. */
+    sdbusplus::bus::bus& bus;
+
+    /** @brief object path */
+    std::string objectPath;
+
+    /** @brief Parent of this object */
+    HypNetworkMgr& manager;
+};
+
+} // namespace network
+} // namespace phosphor

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
@@ -68,6 +68,19 @@ class HypEthInterface : public CreateIface
         emit_object_added();
     };
 
+    /* @brief Method to return the value of the input attribute
+     *        from the BaseBIOSTable
+     *  @param[in] attrName - name of the bios attribute
+     *  @param[out] - value of the bios attribute
+     */
+    biosTableRetAttrValueType getAttrFromBiosTable(const std::string& attrName);
+
+    /* @brief Function to watch the Base Bios Table for ip
+     *        address change from the host and refresh the hypervisor networkd
+     * service
+     */
+    void watchBaseBiosTable();
+
     /* @brief creates the IP dbus object
      */
     virtual void createIPAddressObjects();

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
@@ -77,6 +77,26 @@ class HypEthInterface : public CreateIface
      */
     biosTableType getBiosAttrsMap();
 
+    /* @brief Returns the dhcp enabled property
+     * @param[in] protocol - ipv4/ipv6
+     * @return bool - true if dhcpEnabled
+     */
+    bool isDHCPEnabled(HypIP::Protocol protocol);
+
+    /** Set value of DHCPEnabled */
+    HypEthernetIntf::DHCPConf dhcpEnabled() const override;
+    HypEthernetIntf::DHCPConf dhcpEnabled(DHCPConf value) override;
+    using HypEthernetIntf::dhcp4;
+    bool dhcp4(bool value) override;
+    using HypEthernetIntf::dhcp6;
+    bool dhcp6(bool value) override;
+
+    /** @brief check conf file for Router Advertisements
+     *
+     */
+    bool ipv6AcceptRA(bool value) override;
+    using HypEthernetIntf::ipv6AcceptRA;
+
     using HypEthernetIntf::interfaceName;
 
   protected:
@@ -88,6 +108,13 @@ class HypEthInterface : public CreateIface
 
     /** @brief Parent of this object */
     HypNetworkMgr& manager;
+
+  private:
+    /** @brief Determines if DHCP is active for the IP::Protocol supplied.
+     *  @param[in] protocol - Either IPv4 or IPv6
+     *  @returns true/false value if DHCP is active for the input protocol
+     */
+    bool dhcpIsEnabled(HypIP::Protocol protocol);
 };
 
 } // namespace network

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
@@ -9,6 +9,7 @@
 #include <phosphor-logging/log.hpp>
 #include <sdbusplus/bus.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
+#include <xyz/openbmc_project/BIOSConfig/Manager/server.hpp>
 #include <xyz/openbmc_project/Network/EthernetInterface/server.hpp>
 #include <xyz/openbmc_project/Network/IP/Create/server.hpp>
 
@@ -78,11 +79,8 @@ class HypEthInterface : public CreateIface
      *  @param[in] gateway - Gateway ip address.
      */
 
-    ObjectPath ip(HypIP::Protocol /*addressType*/, std::string /*ipAddress*/,
-                  uint8_t /*prefixLength*/, std::string /*gateway*/) override
-    {
-        return std::string();
-    };
+    ObjectPath ip(HypIP::Protocol addressType, std::string ipAddress,
+                  uint8_t prefixLength, std::string gateway) override;
 
     /* @brief Function to delete the IP dbus object
      *  @param[in] ipaddress - ipaddress to delete.

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -1,0 +1,68 @@
+#include "hyp_ip_interface.hpp"
+
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/elog.hpp>
+#include <phosphor-logging/log.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+
+class HypIPAddress;
+
+namespace phosphor
+{
+namespace network
+{
+
+using namespace phosphor::logging;
+using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+using NotAllowed = sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
+using NotAllowedArgument = xyz::openbmc_project::Common::NotAllowed;
+using Reason = xyz::openbmc_project::Common::NotAllowed::REASON;
+using Argument = xyz::openbmc_project::Common::InvalidArgument;
+
+HypIPAddress::HypIPAddress(sdbusplus::bus::bus& bus, const char* objPath,
+                           HypEthInterface& parent, HypIP::Protocol type,
+                           const std::string& ipaddress,
+                           HypIP::AddressOrigin origin, uint8_t prefixLength,
+                           const std::string& gateway,
+                           const std::string& intf) :
+    HypIPIfaces(bus, objPath, HypIPIfaces::action::defer_emit),
+    parent(parent)
+{
+    HypIP::address(ipaddress);
+    HypIP::prefixLength(prefixLength);
+    HypIP::gateway(gateway);
+    HypIP::type(type);
+    HypIP::origin(origin);
+
+    this->objectPath = objPath;
+    this->intf = intf;
+    emit_object_added();
+}
+
+std::string HypIPAddress::address(std::string /*ipAddress*/)
+{
+    elog<NotAllowed>(Reason("Property update is not allowed"));
+}
+
+uint8_t HypIPAddress::prefixLength(uint8_t /*value*/)
+{
+    elog<NotAllowed>(Reason("Property update is not allowed"));
+}
+
+std::string HypIPAddress::gateway(std::string /*gateway*/)
+{
+    elog<NotAllowed>(Reason("Property update is not allowed"));
+}
+
+HypIP::Protocol HypIPAddress::type(HypIP::Protocol /*type*/)
+{
+    elog<NotAllowed>(Reason("Property update is not allowed"));
+}
+
+HypIP::AddressOrigin HypIPAddress::origin(HypIP::AddressOrigin /*origin*/)
+{
+    elog<NotAllowed>(Reason("Property update is not allowed"));
+}
+
+} // namespace network
+} // namespace phosphor

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -39,19 +39,230 @@ HypIPAddress::HypIPAddress(sdbusplus::bus::bus& bus, const char* objPath,
     emit_object_added();
 }
 
-std::string HypIPAddress::address(std::string /*ipAddress*/)
+std::string HypIPAddress::getHypPrefix()
 {
-    elog<NotAllowed>(Reason("Property update is not allowed"));
+    std::string protocol = convertProtocolToString(HypIP::type());
+    protocol = protocol.substr(protocol.rfind(".") + 1);
+
+    if (protocol == "IPv4")
+    {
+        return "vmi_" + this->intf + "_ipv4_";
+    }
+    else if (protocol == "IPv6")
+    {
+        return "vmi_" + this->intf + "_ipv6_";
+    }
+    return "";
 }
 
-uint8_t HypIPAddress::prefixLength(uint8_t /*value*/)
+std::string HypIPAddress::mapDbusToBiosAttr(std::string dbusProp)
 {
-    elog<NotAllowed>(Reason("Property update is not allowed"));
+    std::string prefix = getHypPrefix();
+
+    if (prefix == "")
+    {
+        log<level::ERR>("Not a valid prefix"),
+            entry("ADDRESS=%s", prefix.c_str());
+        elog<InvalidArgument>(Argument::ARGUMENT_NAME("Prefix"),
+                              Argument::ARGUMENT_VALUE(prefix.c_str()));
+    }
+
+    if (dbusProp == "address")
+    {
+        prefix = prefix + "ipaddr";
+    }
+    else if (dbusProp == "gateway")
+    {
+        prefix = prefix + "gateway";
+    }
+    else if (dbusProp == "origin")
+    {
+        prefix = prefix + "method";
+    }
+    else if (dbusProp == "prefixLength")
+    {
+        prefix = prefix + "prefix_length";
+    }
+    return prefix;
 }
 
-std::string HypIPAddress::gateway(std::string /*gateway*/)
+void HypIPAddress::updateBaseBiosTable(
+    std::string attribute, std::variant<std::string, int64_t> attributeValue)
 {
-    elog<NotAllowed>(Reason("Property update is not allowed"));
+    auto bus = sdbusplus::bus::new_default();
+    auto properties = bus.new_method_call(
+        "xyz.openbmc_project.BIOSConfigManager",
+        "/xyz/openbmc_project/bios_config/manager",
+        "xyz.openbmc_project.BIOSConfig.Manager", "SetAttribute");
+    properties.append(attribute);
+    properties.append(attributeValue);
+    auto result = bus.call(properties);
+
+    if (result.is_method_error())
+    {
+        throw std::runtime_error("Set attribute api failed");
+    }
+}
+
+void HypIPAddress::updateBiosPendingAttrs(
+    PendingAttributesType pendingAttributes)
+{
+    auto bus = sdbusplus::bus::new_default();
+
+    auto properties =
+        bus.new_method_call("xyz.openbmc_project.BIOSConfigManager",
+                            "/xyz/openbmc_project/bios_config/manager",
+                            "org.freedesktop.DBus.Properties", "Set");
+    properties.append("xyz.openbmc_project.BIOSConfig.Manager");
+    properties.append("PendingAttributes");
+    properties.append(std::variant<PendingAttributesType>(pendingAttributes));
+    auto result = bus.call(properties);
+
+    if (result.is_method_error())
+    {
+        throw std::runtime_error("Set attribute api failed");
+    }
+}
+
+void HypIPAddress::resetIPObjProps()
+{
+    // Reset the ip obj properties
+    log<level::INFO>("Resetting the ip addr object properties");
+
+    std::string zeroIp = "0.0.0.0";
+    HypIP::address(zeroIp);
+    HypIP::gateway(zeroIp);
+    HypIP::prefixLength(0);
+    HypIP::origin(IP::AddressOrigin::Static);
+
+    std::string prefix = getHypPrefix();
+
+    std::string attrIpaddr = prefix + "ipaddr";
+    parent.setIpPropsInMap(attrIpaddr, zeroIp, "String");
+
+    std::string attrPrefixLen = prefix + "prefix_length";
+    parent.setIpPropsInMap(attrPrefixLen, 0, "Integer");
+
+    std::string attrGateway = prefix + "gateway";
+    parent.setIpPropsInMap(attrGateway, zeroIp, "String");
+
+    std::string attrMethod = prefix + "method";
+    parent.setIpPropsInMap(attrMethod, "IPv4Static", "String");
+}
+
+void HypIPAddress::resetBaseBiosTableAttrs()
+{
+    // clear all the entries
+    log<level::INFO>("Resetting the bios table attrs of the ip object");
+    updateBaseBiosTable(mapDbusToBiosAttr("address"), "0.0.0.0");
+    updateBaseBiosTable(mapDbusToBiosAttr("gateway"), "0.0.0.0");
+    updateBaseBiosTable(mapDbusToBiosAttr("prefixLength"), 0);
+}
+
+std::string HypIPAddress::address(std::string ipAddress)
+{
+    std::string ip = HypIP::address();
+    if (ip == ipAddress)
+    {
+        return ip;
+    }
+
+    int addressFamily =
+        (HypIP::type() == HypIP::Protocol::IPv4) ? AF_INET : AF_INET6;
+    if (!isValidIP(addressFamily, ipAddress))
+    {
+        log<level::ERR>("Not a valid IP address"),
+            entry("ADDRESS=%s", ipAddress.c_str());
+        elog<NotAllowed>(NotAllowedArgument::REASON("Invalid Ip"));
+    }
+
+    ipAddress = HypIP::address(ipAddress);
+
+    // update the addrs map of parent object
+    parent.updateIPAddress(ip, ipAddress);
+
+    // update parent biosTableAttrs
+    const std::string ipAttrName = "ipaddr";
+    for (auto& it : parent.getBiosAttrsMap())
+    {
+        if ((it.first.compare(it.first.size() - ipAttrName.size(),
+                              ipAttrName.size(), ipAttrName) == 0) &&
+            (std::get<std::string>(it.second) == ip))
+        {
+            parent.setIpPropsInMap(it.first, ipAddress, "String");
+        }
+    }
+
+    log<level::INFO>("IP updated"), entry("ADDRESS=%s", ipAddress.c_str());
+    return ipAddress;
+}
+
+uint8_t HypIPAddress::prefixLength(uint8_t value)
+{
+    auto length = HypIP::prefixLength();
+    if (value == length)
+    {
+        return length;
+    }
+    int addressFamily =
+        (HypIP::type() == HypIP::Protocol::IPv4) ? AF_INET : AF_INET6;
+    if (!isValidPrefix(addressFamily, value))
+    {
+        log<level::ERR>("PrefixLength is not correct "),
+            entry("PREFIXLENGTH=%" PRIu8, value);
+        elog<NotAllowed>(NotAllowedArgument::REASON("Invalid Prefixlength"));
+    }
+    value = HypIP::prefixLength(value);
+
+    // update parent biosTableAttrs
+    const std::string prefixLenAttrName = "length";
+    for (auto& it : parent.getBiosAttrsMap())
+    {
+        if ((it.first.compare(it.first.size() - prefixLenAttrName.size(),
+                              prefixLenAttrName.size(),
+                              prefixLenAttrName) == 0) &&
+            (std::get<int64_t>(it.second) == length))
+        {
+            parent.setIpPropsInMap(it.first, value, "Integer");
+        }
+    }
+
+    return value;
+}
+
+std::string HypIPAddress::gateway(std::string gateway)
+{
+    auto gw = HypIP::gateway();
+
+    if (gateway == gw)
+    {
+        // value is already existing
+        return gw;
+    }
+    int addressFamily =
+        (HypIP::type() == IP::Protocol::IPv4) ? AF_INET : AF_INET6;
+    if (!isValidIP(addressFamily, gateway))
+    {
+        log<level::ERR>("Not a valid gateway"),
+            entry("ADDRESS=%s", gateway.c_str());
+        elog<NotAllowed>(NotAllowedArgument::REASON("Invalid Gateway"));
+    }
+
+    gateway = HypIP::gateway(gateway);
+
+    // update parent biosTableAttrs
+    const std::string gatewayAttrName = "gateway";
+    for (auto& it : parent.getBiosAttrsMap())
+    {
+        if ((it.first.compare(it.first.size() - gatewayAttrName.size(),
+                              gatewayAttrName.size(), gatewayAttrName) == 0) &&
+            (std::get<std::string>(it.second) == gw))
+        {
+            parent.setIpPropsInMap(it.first, gateway, "String");
+        }
+    }
+
+    return gateway;
 }
 
 HypIP::Protocol HypIPAddress::type(HypIP::Protocol /*type*/)
@@ -59,9 +270,80 @@ HypIP::Protocol HypIPAddress::type(HypIP::Protocol /*type*/)
     elog<NotAllowed>(Reason("Property update is not allowed"));
 }
 
-HypIP::AddressOrigin HypIPAddress::origin(HypIP::AddressOrigin /*origin*/)
+HypIP::AddressOrigin HypIPAddress::origin(HypIP::AddressOrigin origin)
 {
-    elog<NotAllowed>(Reason("Property update is not allowed"));
+    auto addrOrigin = HypIP::origin();
+    if (origin == addrOrigin)
+    {
+        // value is already existing
+        return addrOrigin;
+    }
+
+    std::string originStr = convertAddressOriginToString(origin);
+    std::string dhcpStr =
+        convertAddressOriginToString(HypIP::AddressOrigin::DHCP);
+    std::string staticStr =
+        convertAddressOriginToString(HypIP::AddressOrigin::Static);
+
+    if (originStr != dhcpStr && originStr != staticStr)
+    {
+        log<level::ERR>("Not a valid origin");
+        elog<NotAllowed>(NotAllowedArgument::REASON("Invalid Origin"));
+    }
+
+    std::string originBiosAttr;
+    if (originStr.substr(originStr.rfind(".") + 1) == "Static")
+    {
+        originBiosAttr = "IPv4Static";
+    }
+    else if (originStr.substr(originStr.rfind(".") + 1) == "DHCP")
+    {
+        originBiosAttr = "IPv4DHCP";
+    }
+
+    std::string currOriginValue;
+    if (addrOrigin == HypIP::AddressOrigin::Static)
+    {
+        currOriginValue = "IPv4Static";
+    }
+    else if (addrOrigin == HypIP::AddressOrigin::DHCP)
+    {
+        currOriginValue = "IPv4DHCP";
+    }
+
+    origin = HypIP::origin(origin);
+
+    // update parent biosTableAttrs
+    const std::string originAttrName = "method";
+    for (auto& it : parent.getBiosAttrsMap())
+    {
+        if ((it.first.compare(it.first.size() - originAttrName.size(),
+                              originAttrName.size(), originAttrName) == 0) &&
+            (std::get<std::string>(it.second) == currOriginValue))
+        {
+            parent.setIpPropsInMap(it.first, originBiosAttr, "String");
+        }
+    }
+
+    return origin;
+}
+
+void HypIPAddress::delete_()
+{
+    if (HypIP::origin() != HypIP::AddressOrigin::Static)
+    {
+        log<level::ERR>("Tried to delete a non-static address"),
+            entry("ADDRESS=%s", this->address().c_str()),
+            entry("PREFIX=%" PRIu8, this->prefixLength()),
+            entry("INTERFACE=%s", this->parent.interfaceName().c_str());
+        elog<InternalFailure>();
+    }
+
+    // update the ip address obj properties to null
+    resetIPObjProps();
+
+    // update bios table attrs to default
+    resetBaseBiosTableAttrs();
 }
 
 } // namespace network

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -37,6 +37,52 @@ HypIPAddress::HypIPAddress(sdbusplus::bus::bus& bus, const char* objPath,
     this->objectPath = objPath;
     this->intf = intf;
     emit_object_added();
+
+    // De-serialize the persisted data and set the dbus property
+    persistdata::deserialize(nwIPConfigList, intf);
+    setEnabledProp();
+}
+
+void HypIPAddress::setEnabledProp()
+{
+    auto itr = nwIPConfigList.find("Enabled");
+    if (itr != nwIPConfigList.end())
+    {
+        HypIPAddress::enabled(std::get<bool>(itr->second));
+    }
+}
+
+bool HypIPAddress::enabled(bool value)
+{
+    bool oldValue = HypEnableIntf::enabled();
+    log<level::INFO>("Changing value of enabled property",
+                     entry("INTERFACE=%s", intf.c_str()),
+                     entry("OLDVALUE=%d", oldValue), entry("VALUE=%d", value));
+
+    if (value == oldValue)
+    {
+        return value;
+    }
+
+    HypEnableIntf::enabled(value);
+
+    std::string propName = "Enabled";
+
+    auto mapItr = nwIPConfigList.find(propName);
+
+    if (mapItr != nwIPConfigList.end())
+    {
+        // Update the value of the key (Enabled) to true
+        mapItr->second = value;
+    }
+    else
+    {
+        // Insert the key value pair (Enabled, true)
+        nwIPConfigList.insert(std::pair<std::string, bool>(propName, value));
+    }
+    // serialize the data
+    persistdata::serialize(nwIPConfigList, intf);
+    return value;
 }
 
 std::string HypIPAddress::getHypPrefix()

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "hyp_ethernet_interface.hpp"
+#include "util.hpp"
+
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/log.hpp>
+#include <xyz/openbmc_project/Network/IP/server.hpp>
+#include <xyz/openbmc_project/Object/Delete/server.hpp>
+#include <xyz/openbmc_project/Object/Enable/server.hpp>
+
+namespace phosphor
+{
+namespace network
+{
+class HypEthInterface;
+
+using namespace phosphor::logging;
+
+using HypIPIfaces = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Network::server::IP,
+    sdbusplus::xyz::openbmc_project::Object::server::Delete,
+    sdbusplus::xyz::openbmc_project::Object::server::Enable>;
+
+using HypIP = sdbusplus::xyz::openbmc_project::Network::server::IP;
+
+using PendingAttributesType =
+    std::map<std::string,
+             std::tuple<std::string, std::variant<int64_t, std::string>>>;
+
+/** @class HypIPAddress
+ *  @brief Hypervisor IPAddress implementation.
+ *  @details A concrete implementation for the
+ *  xyz.openbmc_project.Network.IPProtocol
+ *  xyz.openbmc_project.Network.IP Dbus interfaces. for hypervisor
+ */
+class HypIPAddress : public HypIPIfaces
+{
+  public:
+    HypIPAddress() = delete;
+    HypIPAddress(const HypIPAddress&) = delete;
+    HypIPAddress& operator=(const HypIPAddress&) = delete;
+    HypIPAddress(HypIPAddress&&) = delete;
+    HypIPAddress& operator=(HypIPAddress&&) = delete;
+    virtual ~HypIPAddress() = default;
+
+    /** @brief Constructor to put object onto bus at a dbus path.
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] objPath - Path to attach at.
+     *  @param[in] parent - Parent object.
+     *  @param[in] type - ipaddress type(v4/v6).
+     *  @param[in] ipAddress - ipadress.
+     *  @param[in] origin - origin of ipaddress(dhcp/static).
+     *  @param[in] prefixLength - Length of prefix.
+     *  @param[in] gateway - gateway address.
+     */
+    HypIPAddress(sdbusplus::bus::bus& bus, const char* objPath,
+                 HypEthInterface& parent, HypIP::Protocol type,
+                 const std::string& ipaddress, HypIP::AddressOrigin origin,
+                 uint8_t prefixLength, const std::string& gateway,
+                 const std::string& intf);
+
+    std::string address(std::string ipAddress) override;
+    uint8_t prefixLength(uint8_t) override;
+    std::string gateway(std::string gateway) override;
+    HypIP::Protocol type(HypIP::Protocol type) override;
+    HypIP::AddressOrigin origin(HypIP::AddressOrigin origin) override;
+
+    /** @brief Delete this d-bus object.
+     */
+    void delete_() override
+    {
+    }
+
+    using HypIP::address;
+    using HypIP::gateway;
+    using HypIP::origin;
+    using HypIP::prefixLength;
+    using HypIP::type;
+
+  private:
+    std::string objectPath;
+
+    /** @brief Hypervisor eth interface id. */
+    std::string intf;
+
+    /** @brief Parent Object. */
+    HypEthInterface& parent;
+};
+
+} // namespace network
+} // namespace phosphor

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.hpp
@@ -68,9 +68,43 @@ class HypIPAddress : public HypIPIfaces
 
     /** @brief Delete this d-bus object.
      */
-    void delete_() override
-    {
-    }
+    void delete_() override;
+
+    /** @brief Get bios table property's prefix based
+     *         on the protocol.
+     *  @result prefix of bios table properties
+     */
+    std::string getHypPrefix();
+
+    /** @brief Method that maps the dbus object's properties
+     *        with properties of the bios table.
+     *  @param[in] dbusProp - dbus property name
+     * @result bios table property equivalent to the dbus property.
+     */
+    std::string mapDbusToBiosAttr(std::string dbusProp);
+
+    /** @brief Method to update the bios table property
+     *  @param[in] attribute - bios attribute
+     *  @param[in] attributeValue - bios attribute value
+     */
+    void updateBaseBiosTable(std::string attribute,
+                             std::variant<std::string, int64_t> attributeValue);
+
+    /** @brief Method to update the pending attributes property
+     *         bios config manager
+     *  @param[in] pendingAttributes - list of all attr, attr value and attr
+     * types
+     */
+    void updateBiosPendingAttrs(PendingAttributesType pendingAttributes);
+
+    /** @brief Method to reset all the properties
+     *         of the ip addr object
+     */
+    void resetIPObjProps();
+
+    /** @brief Method to reset the base bios table attributes
+     */
+    void resetBaseBiosTableAttrs();
 
     using HypIP::address;
     using HypIP::gateway;

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "hyp_ethernet_interface.hpp"
+#include "hyp_nw_config_serialize.hpp"
 #include "util.hpp"
 
 #include <phosphor-logging/elog-errors.hpp>
@@ -23,6 +24,7 @@ using HypIPIfaces = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Object::server::Enable>;
 
 using HypIP = sdbusplus::xyz::openbmc_project::Network::server::IP;
+using HypEnableIntf = sdbusplus::xyz::openbmc_project::Object::server::Enable;
 
 using PendingAttributesType =
     std::map<std::string,
@@ -106,6 +108,20 @@ class HypIPAddress : public HypIPIfaces
      */
     void resetBaseBiosTableAttrs();
 
+    /** @brief Method to set the enabled prop onto dbus from the
+     *         persisted file whenever the service starts
+     */
+    void setEnabledProp();
+
+    /** @brief Method to set the enabled prop. xyz.openbmc_project.Object.Enable
+     *         interface consists of "Enabled" property.
+     *  @param[in] value - true/false indicating if the host consumes the ip
+     *  @result true/false
+     */
+    bool enabled(bool value) override;
+
+    using HypEnableIntf::enabled;
+
     using HypIP::address;
     using HypIP::gateway;
     using HypIP::origin;
@@ -117,6 +133,9 @@ class HypIPAddress : public HypIPIfaces
 
     /** @brief Hypervisor eth interface id. */
     std::string intf;
+
+    /** @brief List of the properties to be persisted */
+    persistdata::NwConfigPropMap nwIPConfigList;
 
     /** @brief Parent Object. */
     HypEthInterface& parent;

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
@@ -235,6 +235,10 @@ void HypNetworkMgr::createIfObjects()
     interfaces.emplace("eth1",
                        std::make_unique<HypEthInterface>(
                            bus, (objectPath + "/eth1").c_str(), "eth1", *this));
+
+    // Create ip address objects for each ethernet interface
+    interfaces["eth0"]->createIPAddressObjects();
+    interfaces["eth1"]->createIPAddressObjects();
 }
 
 void HypNetworkMgr::createSysConfObj()

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
@@ -9,8 +9,6 @@
 
 using sdbusplus::exception::SdBusError;
 
-class HypNetworkMgr;
-
 namespace phosphor
 {
 namespace network
@@ -216,11 +214,6 @@ void HypNetworkMgr::setBIOSTableAttrs()
     }
 }
 
-biosTableType HypNetworkMgr::getBIOSTableAttrs()
-{
-    return biosTableAttrs;
-}
-
 void HypNetworkMgr::createIfObjects()
 {
     setBIOSTableAttrs();
@@ -235,14 +228,20 @@ void HypNetworkMgr::createIfObjects()
     // created during init time to support the static
     // network configurations on the both.
     // create eth0 and eth1 objects
-    log<level::INFO>("Create eth0 and eth1 objects");
+    log<level::INFO>("Creating eth0 and eth1 objects");
+    interfaces.emplace("eth0",
+                       std::make_unique<HypEthInterface>(
+                           bus, (objectPath + "/eth0").c_str(), "eth0", *this));
+    interfaces.emplace("eth1",
+                       std::make_unique<HypEthInterface>(
+                           bus, (objectPath + "/eth1").c_str(), "eth1", *this));
 }
 
 void HypNetworkMgr::createSysConfObj()
 {
     systemConf.reset(nullptr);
-    this->systemConf = std::make_unique<phosphor::network::HypSysConfig>(
-        bus, objectPath + "/config", *this);
+    this->systemConf =
+        std::make_unique<HypSysConfig>(bus, objectPath + "/config", *this);
 }
 
 } // namespace network

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
@@ -214,6 +214,11 @@ void HypNetworkMgr::setBIOSTableAttrs()
     }
 }
 
+const ethIntfMapType& HypNetworkMgr::getEthIntfList()
+{
+    return interfaces;
+}
+
 void HypNetworkMgr::createIfObjects()
 {
     setBIOSTableAttrs();
@@ -239,6 +244,10 @@ void HypNetworkMgr::createIfObjects()
     // Create ip address objects for each ethernet interface
     interfaces["eth0"]->createIPAddressObjects();
     interfaces["eth1"]->createIPAddressObjects();
+
+    // Call watch method to register for properties changed signal
+    // This method can be called only once
+    interfaces["eth0"]->watchBaseBiosTable();
 }
 
 void HypNetworkMgr::createSysConfObj()

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
@@ -1,5 +1,8 @@
 #pragma once
+
+#include "hyp_ethernet_interface.hpp"
 #include "hyp_sys_config.hpp"
+#include "types.hpp"
 
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
@@ -44,6 +47,7 @@ enum BiosBaseTableIndex
 };
 
 using SystemConfPtr = std::unique_ptr<HypSysConfig>;
+using ethIntfMapType = string_umap<std::unique_ptr<HypEthInterface>>;
 
 /** @class Manager
  *  @brief Implementation for the
@@ -70,7 +74,10 @@ class HypNetworkMgr
      *
      * @return attributes list
      */
-    biosTableType getBIOSTableAttrs();
+    inline biosTableType getBIOSTableAttrs()
+    {
+        return biosTableAttrs;
+    }
 
     /** @brief Set specific attribute and its value to
      *         the biosTableAttrs data member
@@ -83,6 +90,15 @@ class HypNetworkMgr
     void setBIOSTableAttr(std::string attrName,
                           std::variant<std::string, int64_t> attrValue,
                           std::string attrType);
+
+    /** @brief Get the ethernet interfaces list data member
+     *
+     * @return ethernet interfaces list
+     */
+    inline const auto& getEthIntfList()
+    {
+        return interfaces;
+    }
 
     /** @brief Method to set all the interface 0 attributes
      *         to its default value in biosTableAttrs data member
@@ -145,7 +161,7 @@ class HypNetworkMgr
     /** @brief Persistent map of EthernetInterface dbus
      *         objects and their names
      */
-    std::map<std::string, std::shared_ptr<HypEthInterface>> interfaces;
+    ethIntfMapType interfaces;
 
     /** @brief map of bios table attrs and values */
     std::map<biosAttrName, biosAttrCurrValue> biosTableAttrs;

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
@@ -95,10 +95,7 @@ class HypNetworkMgr
      *
      * @return ethernet interfaces list
      */
-    inline const auto& getEthIntfList()
-    {
-        return interfaces;
-    }
+    const ethIntfMapType& getEthIntfList();
 
     /** @brief Method to set all the interface 0 attributes
      *         to its default value in biosTableAttrs data member

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager_main.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager_main.cpp
@@ -1,13 +1,25 @@
 #include "hyp_network_manager.hpp"
 
+#include <fmt/format.h>
+
+#include <phosphor-logging/log.hpp>
 #include <sdeventplus/event.hpp>
+
+using phosphor::logging::entry;
+using phosphor::logging::level;
+using phosphor::logging::log;
 
 constexpr char DEFAULT_HYP_NW_OBJPATH[] =
     "/xyz/openbmc_project/network/hypervisor";
 constexpr char HYP_DEFAULT_NETWORK_BUSNAME[] =
     "xyz.openbmc_project.Network.Hypervisor";
 
-int main(int /*argc*/, char** /*argv*/)
+namespace phosphor
+{
+namespace network
+{
+
+int main()
 {
     auto bus = sdbusplus::bus::new_default();
 
@@ -21,19 +33,35 @@ int main(int /*argc*/, char** /*argv*/)
     bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
 
     // Create hypervisor network manager dbus object
-    phosphor::network::HypNetworkMgr manager(bus, DEFAULT_HYP_NW_OBJPATH);
+    std::unique_ptr<HypNetworkMgr> manager =
+        std::make_unique<HypNetworkMgr>(bus, DEFAULT_HYP_NW_OBJPATH);
 
     // Create the hypervisor eth interface objects
-    manager.createIfObjects();
+    manager->createIfObjects();
 
     // Create the hypervisor system config object
-    manager.createSysConfObj();
-    const phosphor::network::SystemConfPtr& systemConfigObj =
-        manager.getSystemConf();
+    manager->createSysConfObj();
+    const SystemConfPtr& systemConfigObj = manager->getSystemConf();
     systemConfigObj->setHostName();
 
     bus.request_name(HYP_DEFAULT_NETWORK_BUSNAME);
 
-    event.loop();
-    return 0;
+    return event.loop();
+}
+
+} // namespace network
+} // namespace phosphor
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    try
+    {
+        return phosphor::network::main();
+    }
+    catch (const std::exception& e)
+    {
+        fmt::print(stderr, "FAILED: {}", e.what());
+        fflush(stderr);
+        return 1;
+    }
 }

--- a/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.cpp
@@ -1,0 +1,110 @@
+#include "hyp_nw_config_serialize.hpp"
+
+#include <fstream>
+#include <phosphor-logging/log.hpp>
+
+namespace phosphor
+{
+namespace network
+{
+namespace persistdata
+{
+
+using namespace phosphor::logging;
+
+void serialize(const NwConfigPropMap& list, std::string intf)
+{
+    std::string filePath = HYP_NW_CONFIG_PERSIST_PATH + intf + "_network";
+
+    // Create directory if it doesnot exist
+    if (!std::filesystem::exists(HYP_NW_CONFIG_PERSIST_PATH.c_str()))
+    {
+        log<level::INFO>(
+            "Creating directory to store hypervisor nw config data...");
+        std::filesystem::create_directory(HYP_NW_CONFIG_PERSIST_PATH.c_str());
+    }
+
+    std::ofstream serializeFile(filePath.c_str(), std::ios::out);
+    if (serializeFile)
+    {
+        for (auto itr = list.begin(); itr != list.end(); itr++)
+        {
+            if (auto value = std::get_if<bool>(&itr->second))
+            {
+                serializeFile << itr->first << " " << *value;
+            }
+            else if (auto value = std::get_if<std::string>(&itr->second))
+            {
+                serializeFile << itr->first << " " << *value;
+            }
+            else if (auto value = std::get_if<int64_t>(&itr->second))
+            {
+                serializeFile << itr->first << " " << *value;
+            }
+        }
+        serializeFile.close();
+    }
+    else
+    {
+        log<level::ERR>("Couldn't open file. Exiting serialization");
+    }
+}
+
+bool deserialize(NwConfigPropMap& list, std::string intf)
+{
+    std::string filePath = HYP_NW_CONFIG_PERSIST_PATH + intf + "_network";
+
+    try
+    {
+        if (std::filesystem::exists(filePath))
+        {
+            std::ifstream deSerializeFile(filePath.c_str(), std::ifstream::in);
+            std::string fileEntry;
+
+            while (getline(deSerializeFile, fileEntry))
+            {
+                std::string key;
+                std::string value;
+                std::stringstream sStream(fileEntry);
+
+                sStream >> key >> value;
+
+                // Check for each key and extract the value acc to the data type
+                // It should be converted to int for boolean and int64_t
+                // properties
+                // Bool and string types are handled here. This can be extended
+                // to properties of other types.
+                if (key == "Enabled")
+                {
+                    if (std::stoi(value))
+                    {
+                        list[key] = true;
+                    }
+                    else
+                    {
+                        list[key] = false;
+                    }
+                }
+                else
+                {
+                    // else - for all other properties of type string
+                    list[key] = value;
+                }
+            }
+            deSerializeFile.close();
+            return true;
+        }
+        return false;
+    }
+    catch (std::exception& e)
+    {
+        log<level::ERR>("Failed to deserialize, errormsg({})",
+                        entry("ERR:%s", e.what()));
+        std::filesystem::remove(filePath);
+        return false;
+    }
+}
+
+} // namespace persistdata
+} // namespace network
+} // namespace phosphor

--- a/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "config.h"
+
+#include "types.hpp"
+
+#include <filesystem>
+#include <map>
+
+namespace phosphor
+{
+namespace network
+{
+namespace persistdata
+{
+using NwConfigPropMap =
+    std::map<std::string, std::variant<std::string, int64_t, bool>>;
+
+const std::string HYP_NW_CONFIG_PERSIST_PATH = "/var/lib/network/hypervisor/";
+
+/** @brief Serialize and persist list of n/w config properties.
+ *  @param[in] list - list of hypervisor n/w config properties.
+ *  @param[in] intf - hyp eth interface label (eth0/eth1).
+ */
+void serialize(const NwConfigPropMap& list, std::string intf);
+
+/** @brief Deserialze a persisted list of n/w config properties.
+ *  @param[out] list - list of n/w config properties.
+ *  @return intf - hyp eth interface label (eth0/eth1).
+ */
+bool deserialize(NwConfigPropMap& list, std::string intf);
+
+} // namespace persistdata
+} // namespace network
+} // namespace phosphor

--- a/src/ibm/hypervisor-network-mgr-src/hyp_sys_config.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_sys_config.cpp
@@ -1,7 +1,5 @@
 #include "hyp_sys_config.hpp"
 
-#include "hyp_network_manager.hpp"
-
 #include <phosphor-logging/elog-errors.hpp>
 #include <phosphor-logging/log.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>

--- a/src/ibm/hypervisor-network-mgr-src/meson.build
+++ b/src/ibm/hypervisor-network-mgr-src/meson.build
@@ -18,6 +18,7 @@ hyp_networkd_lib = static_library(
   'hyp_network_manager.cpp',
   'hyp_sys_config.cpp',
   'hyp_ethernet_interface.cpp',
+  'hyp_ip_interface.cpp',
   implicit_include_directories: false,
   include_directories: [src_includes, hyp_src_includes],
   dependencies: networkd_deps)

--- a/src/ibm/hypervisor-network-mgr-src/meson.build
+++ b/src/ibm/hypervisor-network-mgr-src/meson.build
@@ -19,6 +19,7 @@ hyp_networkd_lib = static_library(
   'hyp_sys_config.cpp',
   'hyp_ethernet_interface.cpp',
   'hyp_ip_interface.cpp',
+  'hyp_nw_config_serialize.cpp',
   implicit_include_directories: false,
   include_directories: [src_includes, hyp_src_includes],
   dependencies: networkd_deps)

--- a/src/ibm/hypervisor-network-mgr-src/meson.build
+++ b/src/ibm/hypervisor-network-mgr-src/meson.build
@@ -11,11 +11,21 @@ configure_file(
   install_dir: dependency('systemd').get_variable(
     pkgconfig: 'systemdsystemunitdir'))
 
+hyp_src_includes = include_directories('.')
+
+hyp_networkd_lib = static_library(
+  'hyp-networkd',
+  'hyp_network_manager.cpp',
+  'hyp_sys_config.cpp',
+  'hyp_ethernet_interface.cpp',
+  implicit_include_directories: false,
+  include_directories: [src_includes, hyp_src_includes],
+  dependencies: networkd_deps)
+
 executable(
   'hyp-network-manager',
   'hyp_network_manager_main.cpp',
-  'hyp_network_manager.cpp',
-  'hyp_sys_config.cpp',
+  link_with: hyp_networkd_lib,
   implicit_include_directories: false,
   dependencies: [
     networkd_dep,
@@ -23,4 +33,3 @@ executable(
   ],
   install: true,
   install_dir: get_option('bindir'))
-

--- a/test/ibm/hypervisor-network-mgr-test/meson.build
+++ b/test/ibm/hypervisor-network-mgr-test/meson.build
@@ -1,8 +1,9 @@
-inc_dir = include_directories('../../../src/ibm/hypervisor-network-mgr-src/')
+inc_dir = include_directories('.', '../../../src/ibm/hypervisor-network-mgr-src/')
 
 hyp_tests = [
   'hyp_network_manager',
   'hyp_sys_config',
+  'hyp_ethernet_interface',
 ]
 
 foreach t : hyp_tests

--- a/test/ibm/hypervisor-network-mgr-test/meson.build
+++ b/test/ibm/hypervisor-network-mgr-test/meson.build
@@ -5,11 +5,6 @@ hyp_tests = [
   'hyp_sys_config',
 ]
 
-hyp_test_src = declare_dependency(
-              sources: [
-                '../../../src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp',
-                '../../../src/ibm/hypervisor-network-mgr-src/hyp_sys_config.cpp'])
-
 foreach t : hyp_tests
   test(
     t,
@@ -18,5 +13,6 @@ foreach t : hyp_tests
       'test_' + t + '.cpp',
       implicit_include_directories: false,
       include_directories: inc_dir,
-      dependencies: [test_dep, hyp_test_src]))
+      link_with: hyp_networkd_lib,
+      dependencies: test_dep))
 endforeach

--- a/test/ibm/hypervisor-network-mgr-test/meson.build
+++ b/test/ibm/hypervisor-network-mgr-test/meson.build
@@ -6,6 +6,14 @@ hyp_tests = [
   'hyp_ethernet_interface',
 ]
 
+hyp_test_src = declare_dependency(
+              sources: [
+                '../../../src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp',
+                '../../../src/ibm/hypervisor-network-mgr-src/hyp_sys_config.cpp',
+                '../../../src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp',
+                '../../../src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp',
+                '../../../src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.cpp'])
+
 foreach t : hyp_tests
   test(
     t,

--- a/test/ibm/hypervisor-network-mgr-test/mock_hyp_ethernet_interface.hpp
+++ b/test/ibm/hypervisor-network-mgr-test/mock_hyp_ethernet_interface.hpp
@@ -34,6 +34,65 @@ class MockHypEthernetInterface : public HypEthInterface
                 HypIP::AddressOrigin::Static, 0, "8.8.8.1", "if1"));
     }
 
+    bool createIP(MockHypEthernetInterface& interface, std::string intfLabel,
+                  HypIP::Protocol protType, const std::string& ipaddress,
+                  uint8_t prefixLength, const std::string& gateway)
+    {
+        if (interface.dhcpIsEnabled(protType))
+        {
+            switch (protType)
+            {
+                case HypIP::Protocol::IPv4:
+                    interface.dhcp4(false);
+                    break;
+                case HypIP::Protocol::IPv6:
+                    interface.dhcp6(false);
+                    break;
+            }
+        }
+
+        HypIP::AddressOrigin origin = HypIP::AddressOrigin::Static;
+
+        if (!isValidIP(AF_INET, ipaddress) && !isValidIP(AF_INET6, ipaddress))
+        {
+            // Not a valid IP address
+            return false;
+        }
+
+        if (!isValidIP(AF_INET, gateway) && !isValidIP(AF_INET6, gateway))
+        {
+            // Not a valid gateway
+            return false;
+        }
+
+        if (!isValidPrefix(AF_INET, prefixLength) &&
+            !isValidPrefix(AF_INET6, prefixLength))
+        {
+            // PrefixLength is not correct
+            return false;
+        }
+
+        const std::string ipObjId = "addr0";
+        std::string protocol;
+        if (protType == HypIP::Protocol::IPv4)
+        {
+            protocol = "ipv4";
+        }
+        else if (protType == HypIP::Protocol::IPv6)
+        {
+            protocol = "ipv6";
+        }
+
+        std::string objPath = objectPath + "/" + protocol + "/" + ipObjId;
+
+        addrs.erase(intfLabel);
+
+        addrs[intfLabel] = std::make_unique<HypIPAddress>(
+            bus, (objPath).c_str(), *this, protType, ipaddress, origin,
+            prefixLength, gateway, "if0");
+        return true;
+    }
+
     friend class TestHypEthernetInterface;
 };
 } // namespace network

--- a/test/ibm/hypervisor-network-mgr-test/mock_hyp_ethernet_interface.hpp
+++ b/test/ibm/hypervisor-network-mgr-test/mock_hyp_ethernet_interface.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "hyp_ethernet_interface.hpp"
+#include "hyp_ip_interface.hpp"
+
+namespace phosphor
+{
+namespace network
+{
+
+class MockHypEthernetInterface : public HypEthInterface
+{
+  public:
+    MockHypEthernetInterface(sdbusplus::bus::bus& bus, const char* path,
+                             const std::string& intfName,
+                             HypNetworkMgr& parent) :
+        HypEthInterface(bus, path, intfName, parent)
+    {
+    }
+
+    void createIPAddrObj()
+    {
+        addrs.emplace(
+            "eth0",
+            std::make_unique<HypIPAddress>(
+                bus, "/xyz/openbmc_test/network/hypervisor/eth0/ipv4/addr0",
+                *this, HypIP::Protocol::IPv4, "9.9.9.9",
+                HypIP::AddressOrigin::Static, 0, "9.9.9.1", "if0"));
+        addrs.emplace(
+            "eth1",
+            std::make_unique<HypIPAddress>(
+                bus, "/xyz/openbmc_test/network/hypervisor/eth1/ipv4/addr0",
+                *this, HypIP::Protocol::IPv4, "8.8.8.8",
+                HypIP::AddressOrigin::Static, 0, "8.8.8.1", "if1"));
+    }
+
+    friend class TestHypEthernetInterface;
+};
+} // namespace network
+} // namespace phosphor

--- a/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
+++ b/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
@@ -1,0 +1,60 @@
+#include "mock_hyp_ethernet_interface.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+
+#include <gtest/gtest.h>
+
+namespace phosphor
+{
+namespace network
+{
+
+class TestHypEthernetInterface : public testing::Test
+{
+  public:
+    sdbusplus::bus::bus bus;
+    HypNetworkMgr manager;
+    sdeventplus::Event event = sdeventplus::Event::get_default();
+
+    MockHypEthernetInterface interface;
+    TestHypEthernetInterface() :
+        bus(sdbusplus::bus::new_default()),
+        manager(bus, event, "/xyz/openbmc_test/network/hypervisor"),
+        interface(makeInterface(bus, manager))
+    {
+        manager.setDefaultBIOSTableAttrsOnIntf("if0");
+        manager.setDefaultBIOSTableAttrsOnIntf("if1");
+        manager.setDefaultHostnameInBIOSTableAttrs();
+        interface.createIPAddrObj();
+    }
+
+    static MockHypEthernetInterface makeInterface(sdbusplus::bus::bus& bus,
+                                                  HypNetworkMgr& manager)
+    {
+        return {bus, "/xyz/openbmc_test/network/hypervisor/eth0", "eth0",
+                manager};
+    }
+
+    bool isIPObjExist(const std::string& intf, const std::string& ipaddress)
+    {
+        auto it = interface.addrs.find(intf);
+        if (it != interface.addrs.end())
+        {
+            if (ipaddress == (it->second)->address())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+TEST_F(TestHypEthernetInterface, CheckIPAddress)
+{
+    EXPECT_EQ(true, isIPObjExist("eth0", "9.9.9.9"));
+    EXPECT_EQ(false, isIPObjExist("eth0", "10.10.10.10"));
+}
+
+} // namespace network
+} // namespace phosphor

--- a/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
+++ b/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
@@ -48,12 +48,79 @@ class TestHypEthernetInterface : public testing::Test
         }
         return false;
     }
+
+    bool deleteIPObj(const std::string& intf, const std::string& ipaddress)
+    {
+        auto it = interface.addrs.find(intf);
+        if (it == interface.addrs.end())
+        {
+            return false;
+        }
+
+        if (ipaddress == (it->second)->address())
+        {
+            interface.addrs.erase(intf);
+            return true;
+        }
+        return false;
+    }
 };
 
 TEST_F(TestHypEthernetInterface, CheckIPAddress)
 {
     EXPECT_EQ(true, isIPObjExist("eth0", "9.9.9.9"));
     EXPECT_EQ(false, isIPObjExist("eth0", "10.10.10.10"));
+}
+
+TEST_F(TestHypEthernetInterface, AddIPAddress)
+{
+    IP::Protocol addressType = IP::Protocol::IPv4;
+    bool createip = interface.createIP(interface, "eth0", addressType,
+                                       "10.10.10.10", 16, "10.10.10.1");
+    if (createip)
+    {
+        EXPECT_EQ(true, isIPObjExist("eth0", "10.10.10.10"));
+    }
+}
+
+TEST_F(TestHypEthernetInterface, AddMultipleAddress)
+{
+    IP::Protocol addressType = IP::Protocol::IPv4;
+    bool createip1 = interface.createIP(interface, "eth0", addressType,
+                                        "10.10.10.10", 16, "10.10.10.1");
+    if (createip1)
+    {
+        bool createip2 = interface.createIP(interface, "eth0", addressType,
+                                            "20.20.20.20", 16, "20.20.20.1");
+        if (createip2)
+        {
+            EXPECT_EQ(false, isIPObjExist("eth0", "10.10.10.10"));
+            EXPECT_EQ(true, isIPObjExist("eth0", "20.20.20.20"));
+        }
+    }
+}
+
+TEST_F(TestHypEthernetInterface, DeleteIPAddress)
+{
+    IP::Protocol addressType = IP::Protocol::IPv4;
+    bool createip = interface.createIP(interface, "eth0", addressType,
+                                       "20.20.20.20", 16, "20.20.20.1");
+    if (createip)
+    {
+        EXPECT_EQ(true, deleteIPObj("eth0", "20.20.20.20"));
+        EXPECT_EQ(false, isIPObjExist("eth0", "20.20.20.20"));
+    }
+}
+
+TEST_F(TestHypEthernetInterface, DeleteNonConfiguredIPAddr)
+{
+    IP::Protocol addressType = IP::Protocol::IPv4;
+    bool createip = interface.createIP(interface, "eth0", addressType,
+                                       "20.20.20.20", 16, "20.20.20.1");
+    if (createip)
+    {
+        EXPECT_EQ(false, deleteIPObj("eth0", "10.10.10.10"));
+    }
 }
 
 } // namespace network

--- a/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
+++ b/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
@@ -15,12 +15,11 @@ class TestHypEthernetInterface : public testing::Test
   public:
     sdbusplus::bus::bus bus;
     HypNetworkMgr manager;
-    sdeventplus::Event event = sdeventplus::Event::get_default();
 
     MockHypEthernetInterface interface;
     TestHypEthernetInterface() :
         bus(sdbusplus::bus::new_default()),
-        manager(bus, event, "/xyz/openbmc_test/network/hypervisor"),
+        manager(bus, "/xyz/openbmc_test/network/hypervisor"),
         interface(makeInterface(bus, manager))
     {
         manager.setDefaultBIOSTableAttrsOnIntf("if0");
@@ -74,7 +73,7 @@ TEST_F(TestHypEthernetInterface, CheckIPAddress)
 
 TEST_F(TestHypEthernetInterface, AddIPAddress)
 {
-    IP::Protocol addressType = IP::Protocol::IPv4;
+    HypIP::Protocol addressType = HypIP::Protocol::IPv4;
     bool createip = interface.createIP(interface, "eth0", addressType,
                                        "10.10.10.10", 16, "10.10.10.1");
     if (createip)
@@ -85,7 +84,7 @@ TEST_F(TestHypEthernetInterface, AddIPAddress)
 
 TEST_F(TestHypEthernetInterface, AddMultipleAddress)
 {
-    IP::Protocol addressType = IP::Protocol::IPv4;
+    HypIP::Protocol addressType = HypIP::Protocol::IPv4;
     bool createip1 = interface.createIP(interface, "eth0", addressType,
                                         "10.10.10.10", 16, "10.10.10.1");
     if (createip1)
@@ -102,7 +101,7 @@ TEST_F(TestHypEthernetInterface, AddMultipleAddress)
 
 TEST_F(TestHypEthernetInterface, DeleteIPAddress)
 {
-    IP::Protocol addressType = IP::Protocol::IPv4;
+    HypIP::Protocol addressType = HypIP::Protocol::IPv4;
     bool createip = interface.createIP(interface, "eth0", addressType,
                                        "20.20.20.20", 16, "20.20.20.1");
     if (createip)
@@ -114,7 +113,7 @@ TEST_F(TestHypEthernetInterface, DeleteIPAddress)
 
 TEST_F(TestHypEthernetInterface, DeleteNonConfiguredIPAddr)
 {
-    IP::Protocol addressType = IP::Protocol::IPv4;
+    HypIP::Protocol addressType = HypIP::Protocol::IPv4;
     bool createip = interface.createIP(interface, "eth0", addressType,
                                        "20.20.20.20", 16, "20.20.20.1");
     if (createip)


### PR DESCRIPTION
This PR pulls multiple commits from the following gerrit commit, that
* Creates ethernet and ip address dbus objects
* Adds synchronization between the dbus objects and the bios table
* Adds persistency support for "Enabled" Property

Gerrit commit: https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/43869/60