### PR TITLE
Fix compilation issue

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -1,4 +1,5 @@
 #include "hyp_ethernet_interface.hpp"
+#include "util.hpp"
 
 class HypEthInterface;
 

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
@@ -28,6 +28,8 @@ using CreateIface = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Network::server::EthernetInterface,
     sdbusplus::xyz::openbmc_project::Network::IP::server::Create>;
 
+using biosTableRetAttrValueType = std::variant<std::string, int64_t>;
+
 using biosTableType = std::map<std::string, std::variant<int64_t, std::string>>;
 
 using HypEthernetIntf =

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -1,4 +1,5 @@
 #include "hyp_ip_interface.hpp"
+#include "util.hpp"
 
 #include <phosphor-logging/elog-errors.hpp>
 #include <phosphor-logging/elog.hpp>


### PR DESCRIPTION
This PR is to fix the compilation issue caused by not declaring a variable.

Reference:
[1] https://sys-openbmc-dev-jenkins.swg-devops.com/job/OpenBMC-Dev/job/build/job/github-private/job/openbmc-build-matrix-x86/label=x86-docker-builder,target=p10bmc/112/console

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>