### PR TITLE
Avoid looking for NTP servers from Systemd-Timesyncd in Manual mode

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -466,9 +466,33 @@ ServerList EthernetInterface::staticNameServers(ServerList value)
 
 void EthernetInterface::loadNTPServers(const config::Parser& config)
 {
-    EthernetInterfaceIntf::ntpServers(getNTPServerFromTimeSyncd());
-    EthernetInterfaceIntf::staticNTPServers(
-        config.map.getValueStrings("Network", "NTP"));
+    std::string timeSyncMethod{};
+    auto method = bus.new_method_call("xyz.openbmc_project.Settings",
+                                      "/xyz/openbmc_project/time/sync_method",
+                                      PROPERTY_INTERFACE, METHOD_GET);
+
+    method.append("xyz.openbmc_project.Time.Synchronization", "TimeSyncMethod");
+
+    try
+    {
+        auto reply = bus.call(method);
+        std::variant<std::string> response;
+        reply.read(response);
+        timeSyncMethod = std::get<std::string>(response);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        log<level::ERR>(
+            "Failed to get NTP TimeSyncMethod from Systemd Settings");
+    }
+
+    // Read NTP servers from TimeSyncd only when NTP mode enabled.
+    // This check is needed to avoid TimeSyncd calls when Manual mode set.
+    if (timeSyncMethod == "xyz.openbmc_project.Time.Synchronization.Method.NTP")
+    {
+        EthernetInterfaceIntf::ntpServers(getNTPServerFromTimeSyncd());
+    }
+    EthernetInterfaceIntf::staticNTPServers(config.map.getValueStrings("Network", "NTP"));
 }
 
 void EthernetInterface::loadNameServers(const config::Parser& config)


### PR DESCRIPTION
Its a part of 1050 rebase, changes from https://github.com/ibm-openbmc/phosphor-networkd/commit/a1e534ba86b5ddb9aada1ec760282b38e01142fd

Avoid looking for NTP servers from Systemd-Timesyncd in Manual mode (https://github.com/ibm-openbmc/phosphor-networkd/pull/45
)

Currently Network Manager is continuously looking up for NTP servers from
Systemd-Timesyncd when manual mode is set.

This commit fixes this behaviour and avoids reading NTP servers from
Systemd-Timesyncd in Manual mode