### PR TITLE
util: Fix mac truncation

### DIFF
--- a/src/util.hpp
+++ b/src/util.hpp
@@ -44,11 +44,7 @@ ether_addr getfromInventory(sdbusplus::bus::bus& bus,
  *  @returns A mac address in network byte order
  *  @throws std::runtime_error for bad mac
  */
-ether_addr fromString(const char* str);
-inline ether_addr fromString(const std::string& str)
-{
-    return fromString(str.c_str());
-}
+ether_addr fromString(std::string_view str);
 
 /** @brief Converts the given mac address bytes into a string
  *  @param[in] mac - The mac address

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -268,6 +268,13 @@ TEST(MacFromString, Bad)
 {
     EXPECT_THROW(fromString("0x:00:00:00:00:00"), std::invalid_argument);
     EXPECT_THROW(fromString("00:00:00:00:00"), std::invalid_argument);
+    EXPECT_THROW(fromString("00:00:00:00:00:"), std::invalid_argument);
+    EXPECT_THROW(fromString("00:00:00:00::00"), std::invalid_argument);
+    EXPECT_THROW(fromString(":00:00:00:00:00"), std::invalid_argument);
+    EXPECT_THROW(fromString("00::00:00:00:00"), std::invalid_argument);
+    EXPECT_THROW(fromString(":::::"), std::invalid_argument);
+    EXPECT_THROW(fromString("00:0:0:0:0"), std::invalid_argument);
+    EXPECT_THROW(fromString("00:00:00:00:00:00:00"), std::invalid_argument);
     EXPECT_THROW(fromString(""), std::invalid_argument);
 }
 


### PR DESCRIPTION
We don't want to allow MACs to be silently truncated.
This commit takes care that an error is thrown in case of out of range MAC address . 

