### PR TITLE
Add support for IPv6 on hypervisor eth interfaces

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.hpp
@@ -81,7 +81,7 @@ class HypIPAddress : public HypIPIfaces
     /** @brief Method that maps the dbus object's properties
      *        with properties of the bios table.
      *  @param[in] dbusProp - dbus property name
-     * @result bios table property equivalent to the dbus property.
+     *  @result bios table property equivalent to the dbus property.
      */
     std::string mapDbusToBiosAttr(std::string dbusProp);
 
@@ -105,8 +105,9 @@ class HypIPAddress : public HypIPIfaces
     void resetIPObjProps();
 
     /** @brief Method to reset the base bios table attributes
+     *  @param[in] protocol - IPv4/IPv6
      */
-    void resetBaseBiosTableAttrs();
+    void resetBaseBiosTableAttrs(std::string protocol);
 
     /** @brief Method to set the enabled prop onto dbus from the
      *         persisted file whenever the service starts

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
@@ -77,12 +77,23 @@ void HypNetworkMgr::setBIOSTableAttr(
     }
 }
 
-void HypNetworkMgr::setDefaultBIOSTableAttrsOnIntf(const std::string& intf)
+void HypNetworkMgr::setDefaultBIOSTableAttrsOnIntf(const std::string& intf,
+                                                   const std::string& protocol)
 {
-    biosTableAttrs.emplace("vmi_" + intf + "_ipv4_ipaddr", "0.0.0.0");
-    biosTableAttrs.emplace("vmi_" + intf + "_ipv4_gateway", "0.0.0.0");
-    biosTableAttrs.emplace("vmi_" + intf + "_ipv4_prefix_length", 0);
-    biosTableAttrs.emplace("vmi_" + intf + "_ipv4_method", "IPv4Static");
+    if (protocol == "ipv4")
+    {
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv4_ipaddr", "0.0.0.0");
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv4_gateway", "0.0.0.0");
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv4_prefix_length", 0);
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv4_method", "IPv4Static");
+    }
+    else if (protocol == "ipv6")
+    {
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv6_ipaddr", "::");
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv6_gateway", "::");
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv6_prefix_length", 128);
+        biosTableAttrs.emplace("vmi_" + intf + "_ipv6_method", "IPv6Static");
+    }
 }
 
 void HypNetworkMgr::setDefaultHostnameInBIOSTableAttrs()

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
@@ -99,8 +99,11 @@ class HypNetworkMgr
 
     /** @brief Method to set all the interface 0 attributes
      *         to its default value in biosTableAttrs data member
+     *  @param[in] intf - interface if0/1
+     *  @param[in] protocol - ipv4/ipv6
      */
-    void setDefaultBIOSTableAttrsOnIntf(const std::string& intf);
+    void setDefaultBIOSTableAttrsOnIntf(const std::string& intf,
+                                        const std::string& protocol);
 
     /** @brief Method to set the hostname attribute
      *         to its default value in biosTableAttrs

--- a/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
+++ b/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
@@ -22,8 +22,10 @@ class TestHypEthernetInterface : public testing::Test
         manager(bus, "/xyz/openbmc_test/network/hypervisor"),
         interface(makeInterface(bus, manager))
     {
-        manager.setDefaultBIOSTableAttrsOnIntf("if0");
-        manager.setDefaultBIOSTableAttrsOnIntf("if1");
+        manager.setDefaultBIOSTableAttrsOnIntf("if0", "ipv4");
+        manager.setDefaultBIOSTableAttrsOnIntf("if0", "ipv6");
+        manager.setDefaultBIOSTableAttrsOnIntf("if1", "ipv4");
+        manager.setDefaultBIOSTableAttrsOnIntf("if1", "ipv6");
         manager.setDefaultHostnameInBIOSTableAttrs();
         interface.createIPAddrObj();
     }

--- a/test/ibm/hypervisor-network-mgr-test/test_hyp_network_manager.cpp
+++ b/test/ibm/hypervisor-network-mgr-test/test_hyp_network_manager.cpp
@@ -25,8 +25,10 @@ class TestHypNetworkManager : public testing::Test
         // method call to set default values in the local copy
         // of the bios attributes should be called for ipv6 as well
 
-        manager.setDefaultBIOSTableAttrsOnIntf("if0");
-        manager.setDefaultBIOSTableAttrsOnIntf("if1");
+        manager.setDefaultBIOSTableAttrsOnIntf("if0", "ipv4");
+        manager.setDefaultBIOSTableAttrsOnIntf("if0", "ipv6");
+        manager.setDefaultBIOSTableAttrsOnIntf("if1", "ipv4");
+        manager.setDefaultBIOSTableAttrsOnIntf("if1", "ipv6");
         manager.setDefaultHostnameInBIOSTableAttrs();
     }
 


### PR DESCRIPTION
This commit adds support for ipv6 addresses on the hypervisor ethernet interfaces.
It includes the following changes: 
[1] https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/54393 
[2] https://github.com/ibm-openbmc/phosphor-networkd/pull/46