### PR TITLE
        STG Defect 396837:FTC1040:Everest:Duplicate entires get creat…

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1011,7 +1011,12 @@ void EthernetInterface::writeConfigurationFile()
         }
         {
             auto& dnss = network["DNS"];
-            for (const auto& dns : EthernetInterfaceIntf::staticNameServers())
+            // To remove the duplicate dns entries
+            const auto& dnsValues = EthernetInterfaceIntf::staticNameServers();
+            std::unordered_set<std::string> dnsServList(dnsValues.begin(),
+                                                        dnsValues.end());
+
+            for (const auto& dns : dnsServList)
             {
                 dnss.emplace_back(dns);
             }


### PR DESCRIPTION
…ed for same value in Static DNS instead of updating same value

        Fix for Duplicatte entries getting added for DNS.
        Currentlly, if we add same DNS ip multiple time then value DNS ip values were appears multiple time.

        Tested By:
                curl -k -H "X-Auth-Token: $bmc_token" -X PATCH -D patch.txt -d '{"StaticNameServers":["10.4.5.60", "10.4.5.60"]}'
                https://${bmc_ip}/redfish/v1/Managers/bmc/EthernetInterfaces/eth0

                curl -k -H "X-Auth-Token: $bmc_token" -X PATCH -D patch.txt -d '{"StaticNameServers":["10.4.5.50", "10.4.5.60"]}'
                https://${bmc_ip}/redfish/v1/Managers/bmc/EthernetInterfaces/eth0