### PR TITLE
Add standalone DHCPv6 configuration support

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -393,8 +393,7 @@ EthernetInterface::DHCPConf EthernetInterface::dhcpEnabled(DHCPConf value)
                                              value == DHCPConf::both);
     auto oldra = EthernetInterfaceIntf::ipv6AcceptRA();
     auto newra = EthernetInterfaceIntf::ipv6AcceptRA(
-        value == DHCPConf::v6stateless || value == DHCPConf::v4v6stateless ||
-        value == DHCPConf::v6 || value == DHCPConf::both);
+        value == DHCPConf::v6stateless || value == DHCPConf::v4v6stateless);
 
     if (old4 != new4 || old6 != new6 || oldra != newra)
     {
@@ -697,6 +696,11 @@ void EthernetInterface::writeConfigurationFile()
         lla.emplace_back("no");
 #endif
         network["IPv6AcceptRA"].emplace_back(ipv6AcceptRA() ? "true" : "false");
+        if (dhcp6())
+        {
+            config.map["DHCPv6"].emplace_back()["WithoutRA"].emplace_back(
+                "solicit");
+        }
         network["DHCP"].emplace_back(dhcp4() ? (dhcp6() ? "true" : "ipv4")
                                              : (dhcp6() ? "ipv6" : "false"));
         {

--- a/test/test_ethernet_interface.cpp
+++ b/test/test_ethernet_interface.cpp
@@ -193,7 +193,7 @@ TEST_F(TestEthernetInterface, DHCPEnabled)
         EXPECT_EQ(dhcp6, interface.dhcp6());
         EXPECT_EQ(ra, interface.ipv6AcceptRA());
     };
-    test(DHCPConf::both, /*dhcp4=*/true, /*dhcp6=*/true, /*ra=*/true);
+    test(DHCPConf::both, /*dhcp4=*/true, /*dhcp6=*/true, /*ra=*/false);
 
     auto set_test = [&](DHCPConf conf, bool dhcp4, bool dhcp6, bool ra) {
         EXPECT_EQ(conf, interface.dhcpEnabled(conf));
@@ -203,10 +203,10 @@ TEST_F(TestEthernetInterface, DHCPEnabled)
     set_test(DHCPConf::v4, /*dhcp4=*/true, /*dhcp6=*/false, /*ra=*/false);
     set_test(DHCPConf::v6stateless, /*dhcp4=*/false, /*dhcp6=*/false,
              /*ra=*/true);
-    set_test(DHCPConf::v6, /*dhcp4=*/false, /*dhcp6=*/true, /*ra=*/true);
+    set_test(DHCPConf::v6, /*dhcp4=*/false, /*dhcp6=*/true, /*ra=*/false);
     set_test(DHCPConf::v4v6stateless, /*dhcp4=*/true, /*dhcp6=*/false,
              /*ra=*/true);
-    set_test(DHCPConf::both, /*dhcp4=*/true, /*dhcp6=*/true, /*ra=*/true);
+    set_test(DHCPConf::both, /*dhcp4=*/true, /*dhcp6=*/true, /*ra=*/false);
 
     auto ind_test = [&](DHCPConf conf, bool dhcp4, bool dhcp6, bool ra) {
         EXPECT_EQ(dhcp4, interface.dhcp4(dhcp4));
@@ -219,11 +219,11 @@ TEST_F(TestEthernetInterface, DHCPEnabled)
     ind_test(DHCPConf::v6stateless, /*dhcp4=*/false, /*dhcp6=*/false,
              /*ra=*/true);
     ind_test(DHCPConf::v6, /*dhcp4=*/false, /*dhcp6=*/true, /*ra=*/false);
-    set_test(DHCPConf::v6, /*dhcp4=*/false, /*dhcp6=*/true, /*ra=*/true);
+    set_test(DHCPConf::v6, /*dhcp4=*/false, /*dhcp6=*/true, /*ra=*/false);
     ind_test(DHCPConf::v4v6stateless, /*dhcp4=*/true, /*dhcp6=*/false,
              /*ra=*/true);
     ind_test(DHCPConf::both, /*dhcp4=*/true, /*dhcp6=*/true, /*ra=*/false);
-    set_test(DHCPConf::both, /*dhcp4=*/true, /*dhcp6=*/true, /*ra=*/true);
+    set_test(DHCPConf::both, /*dhcp4=*/true, /*dhcp6=*/true, /*ra=*/false);
 }
 
 } // namespace network


### PR DESCRIPTION
Currently dhcpv6 IP gets assigned only when there is a RA router attached in the network.

This commit Configures "WithoutRA=solicit" option when dhcpv6 enabled, so dhcpv6 client sends dhcpv6 solicit packets even when there is no RA router in the network.

Tested By: Enable DHCPv6, Disable DHCPv6 & configure v6stateless

Change-Id: I3b1ce4cef1e450c154909d440ea986d8715e14bc