### PR TITLE
Change SLAAC to IPv6SLAAC as per bios enum

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -485,9 +485,9 @@ ServerList EthernetInterface::staticNameServers(ServerList value)
 void EthernetInterface::loadNTPServers(const config::Parser& config)
 {
     std::string timeSyncMethod{};
-    auto method = bus.get().new_method_call("xyz.openbmc_project.Settings",
-                                      "/xyz/openbmc_project/time/sync_method",
-                                      PROPERTY_INTERFACE, METHOD_GET);
+    auto method = bus.get().new_method_call(
+        "xyz.openbmc_project.Settings", "/xyz/openbmc_project/time/sync_method",
+        PROPERTY_INTERFACE, METHOD_GET);
 
     method.append("xyz.openbmc_project.Time.Synchronization", "TimeSyncMethod");
 
@@ -510,7 +510,8 @@ void EthernetInterface::loadNTPServers(const config::Parser& config)
     {
         EthernetInterfaceIntf::ntpServers(getNTPServerFromTimeSyncd());
     }
-    EthernetInterfaceIntf::staticNTPServers(config.map.getValueStrings("Network", "NTP"));
+    EthernetInterfaceIntf::staticNTPServers(
+        config.map.getValueStrings("Network", "NTP"));
 }
 
 void EthernetInterface::loadNameServers(const config::Parser& config)

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -139,7 +139,8 @@ void HypEthInterface::watchBaseBiosTable()
                 DHCPConf dhcpState = ethObj->dhcpEnabled();
                 if ((dhcpState == HypEthInterface::DHCPConf::none) &&
                     ((dhcpEnabled == "IPv4DHCP") ||
-                     (dhcpEnabled == "IPv6DHCP") || (dhcpEnabled == "SLAAC")))
+                     (dhcpEnabled == "IPv6DHCP") ||
+                     (dhcpEnabled == "IPv6SLAAC")))
                 {
                     // There is a change in bios table method attribute (changed
                     // to dhcp) but dbus property contains static Change the
@@ -161,7 +162,7 @@ void HypEthInterface::watchBaseBiosTable()
                             ethObj->dhcp6(true);
                         }
                     }
-                    else if (dhcpEnabled == "SLAAC")
+                    else if (dhcpEnabled == "IPv6SLAAC")
                     {
                         if (ethObj->ipv6AcceptRA())
                         {
@@ -528,9 +529,10 @@ void HypEthInterface::createIPAddressObjects()
                     dhcp6(true);
                 }
             }
-            else if ((ipType.find("SLAAC") != std::string::npos) &&
+            else if ((ipType.find("IPv6SLAAC") != std::string::npos) &&
                      (protocol == "ipv6"))
             {
+                ipOrigin = HypIP::AddressOrigin::SLAAC;
                 ipv6AcceptRA(true);
             }
             else
@@ -1014,7 +1016,8 @@ HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled(DHCPConf value)
             {
                 if (slaacEnabled)
                 {
-                    method = "SLAAC";
+                    method = "IPv6SLAAC";
+                    (itr->second)->origin(HypIP::AddressOrigin::SLAAC);
                 }
                 else if (v6Enabled)
                 {
@@ -1060,12 +1063,15 @@ HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled(DHCPConf value)
                 ((itr->second)->origin() == HypIP::AddressOrigin::DHCP))
             {
                 method = "IPv4Static";
+                (itr->second)->origin(HypIP::AddressOrigin::Static);
                 (itr->second)->resetBaseBiosTableAttrs("IPv4");
             }
             else if (((itr->second)->type() == HypIP::Protocol::IPv6) &&
-                     ((itr->second)->origin() == HypIP::AddressOrigin::DHCP))
+                     (((itr->second)->origin() == HypIP::AddressOrigin::DHCP) ||
+                      ((itr->second)->origin() == HypIP::AddressOrigin::SLAAC)))
             {
                 method = "IPv6Static";
+                (itr->second)->origin(HypIP::AddressOrigin::Static);
                 (itr->second)->resetBaseBiosTableAttrs("IPv6");
             }
 

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
@@ -8,8 +8,8 @@
 #include <phosphor-logging/elog.hpp>
 #include <phosphor-logging/log.hpp>
 #include <sdbusplus/bus.hpp>
-#include <xyz/openbmc_project/Common/error.hpp>
 #include <xyz/openbmc_project/BIOSConfig/Manager/server.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
 #include <xyz/openbmc_project/Network/EthernetInterface/server.hpp>
 #include <xyz/openbmc_project/Network/IP/Create/server.hpp>
 

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -393,8 +393,10 @@ HypIP::AddressOrigin HypIPAddress::origin(HypIP::AddressOrigin origin)
         convertAddressOriginToString(HypIP::AddressOrigin::DHCP);
     std::string staticStr =
         convertAddressOriginToString(HypIP::AddressOrigin::Static);
+    std::string slaacStr =
+        convertAddressOriginToString(HypIP::AddressOrigin::SLAAC);
 
-    if (originStr != dhcpStr && originStr != staticStr)
+    if (originStr != dhcpStr && originStr != staticStr && originStr != slaacStr)
     {
         log<level::ERR>("Not a valid origin");
         elog<NotAllowed>(NotAllowedArgument::REASON("Invalid Origin"));
@@ -423,6 +425,19 @@ HypIP::AddressOrigin HypIPAddress::origin(HypIP::AddressOrigin origin)
             originBiosAttr = "IPv6DHCP";
         }
     }
+    else if (originStr.substr(originStr.rfind(".") + 1) == "SLAAC")
+    {
+        if (HypIP::type() == HypIP::Protocol::IPv4)
+        {
+            log<level::ERR>("Not a valid origin for IPv4");
+            elog<NotAllowed>(
+                NotAllowedArgument::REASON("Invalid Origin for IPv4"));
+        }
+        else if (HypIP::type() == HypIP::Protocol::IPv6)
+        {
+            originBiosAttr = "IPv6SLAAC";
+        }
+    }
 
     std::string currOriginValue;
     if (addrOrigin == HypIP::AddressOrigin::Static)
@@ -445,6 +460,19 @@ HypIP::AddressOrigin HypIPAddress::origin(HypIP::AddressOrigin origin)
         else if (HypIP::type() == HypIP::Protocol::IPv6)
         {
             currOriginValue = "IPv6DHCP";
+        }
+    }
+    else if (addrOrigin == HypIP::AddressOrigin::SLAAC)
+    {
+        if (HypIP::type() == HypIP::Protocol::IPv4)
+        {
+            log<level::ERR>("Not a valid origin for IPv4");
+            elog<NotAllowed>(
+                NotAllowedArgument::REASON("Invalid Origin for IPv4"));
+        }
+        else if (HypIP::type() == HypIP::Protocol::IPv6)
+        {
+            currOriginValue = "IPv6SLAAC";
         }
     }
 

--- a/src/ibm/hypervisor-network-mgr-src/xyz.openbmc_project.Network.Hypervisor.service.in
+++ b/src/ibm/hypervisor-network-mgr-src/xyz.openbmc_project.Network.Hypervisor.service.in
@@ -1,6 +1,9 @@
 [Unit]
 Description=Hypervisor Network Manager
+Wants=xyz.openbmc_project.biosconfig_manager.service
 After=xyz.openbmc_project.biosconfig_manager.service
+Wants=pldmd.service
+After=pldmd.service
 
 [Service]
 ExecStart=/usr/bin/hyp-network-manager

--- a/test/test_ethernet_interface.cpp
+++ b/test/test_ethernet_interface.cpp
@@ -193,7 +193,6 @@ TEST_F(TestEthernetInterface, DHCPEnabled)
         EXPECT_EQ(dhcp6, interface.dhcp6());
         EXPECT_EQ(ra, interface.ipv6AcceptRA());
     };
-    test(DHCPConf::both, /*dhcp4=*/true, /*dhcp6=*/true, /*ra=*/false);
 
     auto set_test = [&](DHCPConf conf, bool dhcp4, bool dhcp6, bool ra) {
         EXPECT_EQ(conf, interface.dhcpEnabled(conf));


### PR DESCRIPTION
The "method" attribute of the bios table had the below values:
"IPv6Static", "IPv6DHCP", "SLAAC"

There is a recent change in pldm that changes "SLAAC" to "IPv6SLAAC".
This commit has changes with respect to the above change.

Fixes: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=449841

Change-Id: I028aff8c8e54210b3b06b1282e79691310009a45