### PR TITLE
Update the error on deleting a link local address

### DIFF
--- a/src/ipaddress.cpp
+++ b/src/ipaddress.cpp
@@ -95,7 +95,16 @@ void IPAddress::delete_()
             entry("ADDRESS=%s", address().c_str()),
             entry("PREFIX=%" PRIu8, prefixLength()),
             entry("INTERFACE=%s", parent.get().interfaceName().c_str());
-        elog<InternalFailure>();
+
+        if (origin() == IP::AddressOrigin::LinkLocal)
+        {
+            elog<NotAllowed>(
+                Reason("Not allowed to delete a LinkLocal address"));
+        }
+        else
+        {
+            elog<InternalFailure>();
+        }
     }
 
     std::unique_ptr<IPAddress> ptr;


### PR DESCRIPTION
Upstream commit https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/62003

It is in reference to https://github.com/openbmc/openbmc/issues/2342

Currently, when a user tries to delete a non-static ip address, it throws an error as "the operation failed internally"

With the update, when an attempt is made to delete the link-local address of the bmc it throws "The operation is not allowed" error

Tested by:

Current behaviour:

busctl call xyz.openbmc_project.Network /xyz/openbmc_project/network/eth1/_66e80_3a_3aa94_3aefff_3afe81_3ad629_2f64 xyz.openbmc_project.Object.Delete Delete

response: Call failed: The operation failed internally.

Modified behaviour:

busctl call xyz.openbmc_project.Network /xyz/openbmc_project/network/eth1/_66e80_3a_3aa94_3aefff_3afe81_3ad62d_2f64 xyz.openbmc_project.Object.Delete Delete

response: Call failed: The operation is not allowed