### PR TITLE
Populate address origin based on ifa_flags

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -197,6 +197,22 @@ void EthernetInterface::addAddr(const AddressInfo& info)
     }
 #endif
 
+    if ((info.scope == RT_SCOPE_UNIVERSE) && (info.flags & IFA_F_PERMANENT))
+    {
+        origin = IP::AddressOrigin::Static;
+    }
+    if ((info.scope == RT_SCOPE_UNIVERSE) &&
+        ((info.flags & IFA_F_NOPREFIXROUTE) &&
+         (info.flags & IFA_F_MANAGETEMPADDR)))
+    {
+        origin = IP::AddressOrigin::SLAAC;
+    }
+    else if ((info.scope == RT_SCOPE_UNIVERSE) &&
+             ((info.flags & IFA_F_NOPREFIXROUTE)))
+    {
+        origin = IP::AddressOrigin::DHCP;
+    }
+
     auto it = addrs.find(info.ifaddr);
     if (it == addrs.end())
     {


### PR DESCRIPTION
This commit populates address origin based on ifa_flags from rtnetlink message.

Tested by:
Check origin of D-bus object for different type of v4/v6 addresses Verified DHCPv4/v6 enable, disable with static addresses configured

Change-Id: I554e9353107ba62b638654d91b5dfe2c6ee90a03