### PR TITLE
Add Network Static Route support

### DIFF
--- a/gen/xyz/openbmc_project/Network/StaticRoute/CreateStaticRoute/meson.build
+++ b/gen/xyz/openbmc_project/Network/StaticRoute/CreateStaticRoute/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/Network/StaticRoute/CreateStaticRoute__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/xyz/openbmc_project/Network/StaticRoute/CreateStaticRoute.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'xyz/openbmc_project/Network/StaticRoute/CreateStaticRoute',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Network/StaticRoute/meson.build
+++ b/gen/xyz/openbmc_project/Network/StaticRoute/meson.build
@@ -1,0 +1,16 @@
+# Generated file; do not modify.
+subdir('CreateStaticRoute')
+generated_others += custom_target(
+    'xyz/openbmc_project/Network/StaticRoute/CreateStaticRoute__markdown'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/Network/StaticRoute/CreateStaticRoute.interface.yaml',  ],
+    output: [ 'CreateStaticRoute.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Network/StaticRoute/CreateStaticRoute',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Network/meson.build
+++ b/gen/xyz/openbmc_project/Network/meson.build
@@ -1,4 +1,5 @@
 # Generated file; do not modify.
 subdir('IP')
 subdir('Neighbor')
+subdir('StaticRoute')
 subdir('VLAN')

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -127,6 +127,10 @@ EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
     {
         addStaticNeigh(neigh);
     }
+    for (const auto& [_, staticRoute] : info.staticRoutes)
+    {
+        addStaticRoute(staticRoute);
+    }
 }
 
 void EthernetInterface::updateInfo(const InterfaceInfo& info, bool skipSignal)
@@ -248,6 +252,31 @@ void EthernetInterface::addStaticNeigh(const NeighborInfo& info)
     }
 }
 
+void EthernetInterface::addStaticRoute(const StaticRouteInfo& info)
+{
+    if (!info.gateway || !info.destination)
+    {
+        auto msg = fmt::format("Missing static route details on {}\n",
+                               interfaceName());
+        log<level::ERR>(msg.c_str());
+        return;
+    }
+
+    if (auto it = staticRoutes.find(*info.destination);
+        it != staticRoutes.end())
+    {
+        it->second->StaticRouteObj::gateway(*info.gateway);
+    }
+    else
+    {
+        staticRoutes.emplace(
+            *info.destination,
+            std::make_unique<StaticRoute>(bus, std::string_view(objPath), *this,
+                                          *info.destination, *info.gateway,
+                                          info.prefixLength));
+    }
+}
+
 ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
                                  uint8_t prefixLength, std::string)
 {
@@ -360,6 +389,47 @@ ObjectPath EthernetInterface::neighbor(std::string ipAddress,
             return it->second->getObjPath();
         }
         it->second->NeighborObj::macAddress(str);
+    }
+
+    writeConfigurationFile();
+    manager.get().reloadConfigs();
+
+    return it->second->getObjPath();
+}
+
+ObjectPath EthernetInterface::staticRoute(std::string destination,
+                                          std::string gateway,
+                                          uint32_t prefixLength)
+{
+    InAddrAny addr;
+    try
+    {
+        addr = ToAddr<InAddrAny>{}(destination);
+    }
+    catch (const std::exception& e)
+    {
+        auto msg = fmt::format("Not a valid IP address `{}`: {}", destination,
+                               e.what());
+        log<level::ERR>(msg.c_str(), entry("ADDRESS=%s", destination.c_str()));
+        elog<InvalidArgument>(Argument::ARGUMENT_NAME("destination"),
+                              Argument::ARGUMENT_VALUE(destination.c_str()));
+    }
+
+    auto it = staticRoutes.find(destination);
+    if (it == staticRoutes.end())
+    {
+        it = std::get<0>(staticRoutes.emplace(
+            destination,
+            std::make_unique<StaticRoute>(bus, std::string_view(objPath), *this,
+                                          destination, gateway, prefixLength)));
+    }
+    else
+    {
+        if (it->second->StaticRouteObj::destination() == destination)
+        {
+            return it->second->getObjPath();
+        }
+        it->second->StaticRouteObj::destination(destination);
     }
 
     writeConfigurationFile();
@@ -801,6 +871,20 @@ void EthernetInterface::writeConfigurationFile()
         dhcp["SendHostname"].emplace_back(conf.sendHostNameEnabled() ? "true"
                                                                      : "false");
     }
+
+    {
+        auto& sroutes = config.map["Route"];
+        for (const auto& temp : staticRoutes)
+        {
+            auto& staticRoute = sroutes.emplace_back();
+            staticRoute["Destination"].emplace_back(
+                fmt::format("{}/{}", temp.second->destination(),
+                            temp.second->prefixLength()));
+            staticRoute["Gateway"].emplace_back(temp.second->gateway());
+            staticRoute["GatewayOnLink"].emplace_back("true");
+        }
+    }
+
     auto path =
         config::pathForIntfConf(manager.get().getConfDir(), interfaceName());
     config.writeFile(path);

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -1,9 +1,11 @@
 #pragma once
 #include "ipaddress.hpp"
 #include "neighbor.hpp"
+#include "static_route.hpp"
 #include "types.hpp"
 #include "xyz/openbmc_project/Network/IP/Create/server.hpp"
 #include "xyz/openbmc_project/Network/Neighbor/CreateStatic/server.hpp"
+#include "xyz/openbmc_project/Network/StaticRoute/CreateStaticRoute/server.hpp"
 
 #include <optional>
 #include <sdbusplus/bus.hpp>
@@ -15,6 +17,7 @@
 #include <xyz/openbmc_project/Collection/DeleteAll/server.hpp>
 #include <xyz/openbmc_project/Network/EthernetInterface/server.hpp>
 #include <xyz/openbmc_project/Network/MACAddress/server.hpp>
+#include <xyz/openbmc_project/Network/StaticRoute/server.hpp>
 #include <xyz/openbmc_project/Network/VLAN/server.hpp>
 #include <xyz/openbmc_project/Object/Delete/server.hpp>
 
@@ -28,6 +31,8 @@ using Ifaces = sdbusplus::server::object_t<
     sdbusplus::xyz::openbmc_project::Network::server::MACAddress,
     sdbusplus::xyz::openbmc_project::Network::IP::server::Create,
     sdbusplus::xyz::openbmc_project::Network::Neighbor::server::CreateStatic,
+    sdbusplus::xyz::openbmc_project::Network::StaticRoute::server::
+        CreateStaticRoute,
     sdbusplus::xyz::openbmc_project::Collection::server::DeleteAll>;
 
 using VlanIfaces = sdbusplus::server::object_t<
@@ -42,6 +47,8 @@ using EthernetInterfaceIntf =
     sdbusplus::xyz::openbmc_project::Network::server::EthernetInterface;
 using MacAddressIntf =
     sdbusplus::xyz::openbmc_project::Network::server::MACAddress;
+using StaticRouteIntf =
+    sdbusplus::xyz::openbmc_project::Network::server::StaticRoute;
 
 using ServerList = std::vector<std::string>;
 using ObjectPath = sdbusplus::message::object_path;
@@ -90,8 +97,12 @@ class EthernetInterface : public Ifaces
     /** @brief Persistent map of Neighbor dbus objects and their names */
     std::unordered_map<InAddrAny, std::unique_ptr<Neighbor>> staticNeighbors;
 
+    /** @brief Persistent map of static route dbus objects and their names */
+    std::unordered_map<std::string, std::unique_ptr<StaticRoute>> staticRoutes;
+
     void addAddr(const AddressInfo& info);
     void addStaticNeigh(const NeighborInfo& info);
+    void addStaticRoute(const StaticRouteInfo& info);
 
     /** @brief Updates the interface information based on new InterfaceInfo */
     void updateInfo(const InterfaceInfo& info, bool skipSignal = false);
@@ -118,6 +129,14 @@ class EthernetInterface : public Ifaces
      *  @param[in] macAddress - Low level MAC address.
      */
     ObjectPath neighbor(std::string ipAddress, std::string macAddress) override;
+
+    /** @brief Function to create static route dbus object.
+     *  @param[in] destination - Destination IP address.
+     *  @param[in] gateway - Gateway
+     *  @parma[in] prefixLength - Number of network bits.
+     */
+    ObjectPath staticRoute(std::string destination, std::string gateway,
+                           uint32_t prefixLength) override;
 
     /** Set value of DHCPEnabled */
     DHCPConf dhcpEnabled() const override;

--- a/src/meson.build
+++ b/src/meson.build
@@ -48,6 +48,7 @@ networkd_lib = static_library(
   'ethernet_interface.cpp',
   'neighbor.cpp',
   'ipaddress.cpp',
+  'static_route.cpp',
   'netlink.cpp',
   'network_manager.cpp',
   'rtnetlink.cpp',

--- a/src/static_route.cpp
+++ b/src/static_route.cpp
@@ -1,0 +1,86 @@
+#include "static_route.hpp"
+
+#include "ethernet_interface.hpp"
+#include "network_manager.hpp"
+
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/elog.hpp>
+#include <string>
+#include <xyz/openbmc_project/Common/error.hpp>
+
+namespace phosphor
+{
+namespace network
+{
+
+static auto makeObjPath(std::string_view root, std::string addr)
+{
+    auto ret = sdbusplus::message::object_path(std::string(root));
+    ret /= addr;
+    return ret;
+}
+
+StaticRoute::StaticRoute(sdbusplus::bus_t& bus, std::string_view objRoot,
+                         stdplus::PinnedRef<EthernetInterface> parent,
+                         std::string destination, std::string gateway,
+                         uint32_t prefixLength) :
+    StaticRoute(bus, makeObjPath(objRoot, destination), parent, destination,
+                gateway, prefixLength)
+{
+}
+
+StaticRoute::StaticRoute(sdbusplus::bus_t& bus,
+                         sdbusplus::message::object_path objPath,
+                         stdplus::PinnedRef<EthernetInterface> parent,
+                         std::string destination, std::string gateway,
+                         uint32_t prefixLength) :
+    StaticRouteObj(bus, objPath.str.c_str(),
+                   StaticRouteObj::action::defer_emit),
+    parent(parent), objPath(std::move(objPath))
+{
+    StaticRouteObj::destination(destination, true);
+    StaticRouteObj::gateway(gateway, true);
+    StaticRouteObj::prefixLength(prefixLength, true);
+    emit_object_added();
+}
+
+void StaticRoute::delete_()
+{
+    auto& staticRoutes = parent.get().staticRoutes;
+    std::unique_ptr<StaticRoute> ptr;
+    for (auto it = staticRoutes.begin(); it != staticRoutes.end(); ++it)
+    {
+        if (it->second.get() == this)
+        {
+            ptr = std::move(it->second);
+            staticRoutes.erase(it);
+            break;
+        }
+    }
+
+    parent.get().writeConfigurationFile();
+    parent.get().manager.get().reloadConfigs();
+}
+
+using sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
+using REASON =
+    phosphor::logging::xyz::openbmc_project::Common::NotAllowed::REASON;
+using phosphor::logging::elog;
+
+std::string StaticRoute::destination(std::string /*Destination Address*/)
+{
+    elog<NotAllowed>(REASON("Property update is not allowed"));
+}
+
+std::string StaticRoute::gateway(std::string /*gateway*/)
+{
+    elog<NotAllowed>(REASON("Property update is not allowed"));
+}
+
+uint32_t StaticRoute::prefixLength(uint32_t /*prefixLength*/)
+{
+    elog<NotAllowed>(REASON("Property update is not allowed"));
+}
+
+} // namespace network
+} // namespace phosphor

--- a/src/static_route.hpp
+++ b/src/static_route.hpp
@@ -1,0 +1,76 @@
+#pragma once
+#include "types.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/message/native_types.hpp>
+#include <sdbusplus/server/object.hpp>
+#include <stdplus/pinned.hpp>
+#include <string_view>
+#include <xyz/openbmc_project/Network/StaticRoute/server.hpp>
+#include <xyz/openbmc_project/Object/Delete/server.hpp>
+
+namespace phosphor
+{
+namespace network
+{
+
+using StaticRouteIntf =
+    sdbusplus::xyz::openbmc_project::Network::server::StaticRoute;
+
+using StaticRouteObj = sdbusplus::server::object_t<
+    StaticRouteIntf, sdbusplus::xyz::openbmc_project::Object::server::Delete>;
+
+class EthernetInterface;
+
+/** @class StaticRoute
+ *  @brief OpenBMC network static route implementation.
+ *  @details A concrete implementation for the
+ *  xyz.openbmc_project.Network.StaticRoute dbus interface.
+ */
+class StaticRoute : public StaticRouteObj
+{
+  public:
+    /** @brief Constructor to put object onto bus at a dbus path.
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] objRoot - Path to attach at.
+     *  @param[in] parent - Parent object.
+     *  @param[in] destination - Destination address.
+     *  @param[in] gateway - Gateway address.
+     *  @param[in] prefixLength - Prefix length.
+     */
+    StaticRoute(sdbusplus::bus_t& bus, std::string_view objRoot,
+                stdplus::PinnedRef<EthernetInterface> parent,
+                std::string destination, std::string gateway,
+                uint32_t prefixLength);
+
+    /** @brief Delete this d-bus object.
+     */
+    void delete_() override;
+
+    using StaticRouteObj::destination;
+    std::string destination(std::string) override;
+    using StaticRouteObj::gateway;
+    std::string gateway(std::string) override;
+    using StaticRouteObj::prefixLength;
+    uint32_t prefixLength(uint32_t) override;
+
+    inline const auto& getObjPath() const
+    {
+        return objPath;
+    }
+
+  private:
+    /** @brief Parent Object. */
+    stdplus::PinnedRef<EthernetInterface> parent;
+
+    /** @brief Dbus object path */
+    sdbusplus::message::object_path objPath;
+
+    StaticRoute(sdbusplus::bus_t& bus, sdbusplus::message::object_path objPath,
+                stdplus::PinnedRef<EthernetInterface> parent,
+                std::string destination, std::string gateway,
+                uint32_t prefixLength);
+};
+
+} // namespace network
+} // namespace phosphor

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -135,6 +135,23 @@ struct NeighborInfo
     }
 };
 
+/** @class StaticRouteInfo
+ *  @brief Information about a static route from the kernel
+ */
+struct StaticRouteInfo
+{
+    unsigned ifidx;
+    uint32_t prefixLength;
+    std::optional<std::string> destination;
+    std::optional<std::string> gateway;
+
+    constexpr bool operator==(const StaticRouteInfo& rhs) const noexcept
+    {
+        return ifidx == rhs.ifidx && prefixLength == rhs.prefixLength &&
+               destination == rhs.destination && gateway == rhs.gateway;
+    }
+};
+
 struct string_hash : public std::hash<std::string_view>
 {
     using is_transparent = void;
@@ -854,6 +871,7 @@ struct AllIntfInfo
     std::optional<in6_addr> defgw6 = std::nullopt;
     std::unordered_map<IfAddr, AddressInfo> addrs = {};
     std::unordered_map<InAddrAny, NeighborInfo> staticNeighs = {};
+    std::unordered_map<std::string, StaticRouteInfo> staticRoutes = {};
 };
 
 } // namespace phosphor::network

--- a/test/test_ethernet_interface.cpp
+++ b/test/test_ethernet_interface.cpp
@@ -51,6 +51,12 @@ class TestEthernetInterface : public stdplus::gtest::TestWithTmp
         return interface.ip(addressType, ipaddress, subnetMask, "");
     }
 
+    auto creatStaicRouteObject(std::string destination, std::string& gateway,
+                               uint8_t prefixLength)
+    {
+        return interface.staticRoute(destination, gateway, prefixLength);
+    }
+
     void setNtpServers()
     {
         ServerList ntpServers = {"10.1.1.1", "10.2.2.2", "10.3.3.3"};
@@ -223,6 +229,33 @@ TEST_F(TestEthernetInterface, DHCPEnabled)
              /*ra=*/true);
     ind_test(DHCPConf::both, /*dhcp4=*/true, /*dhcp6=*/true, /*ra=*/false);
     set_test(DHCPConf::both, /*dhcp4=*/true, /*dhcp6=*/true, /*ra=*/false);
+}
+
+TEST_F(TestEthernetInterface, AddStaticRoute)
+{
+    createStaticRouteObject("10.10.10.10", 10.10.10.1, 24);
+    EXPECT_THAT(interface.staticRoutes,
+                UnorderedElementsAre(Key(std::string("10.10.10.10"))));
+}
+
+TEST_F(TestEthernetInterface, AddMultipleStaticRoutes)
+{
+    createStaticRouteObject("10.10.10.10", 10.10.10.1, 24);
+    createStaticRouteObject("10.20.30.10", 10.20.30.1, 24);
+    EXPECT_THAT(
+        interface.staticRoutes,
+        UnorderedElementsAre(Key(std::string("10.10.10.10")),
+                             Key(std::string("10.20.30.10")));
+}
+
+TEST_F(TestEthernetInterface, DeleteIPAddress)
+{
+    createStaticRouteObject("10.10.10.10", 10.10.10.1, 24);
+    createStaticRouteObject("10.20.30.10", 10.20.30.1, 24);
+
+    interfaces.staticRoutes.at(std::string("10.10.10.10"))->delete_();
+    interfaces.staticRoutes.at(std::string("10.20.30.10"))->delete_();
+    EXPECT_EQ(interface.staticRoutes.empty(), true);
 }
 
 } // namespace network

--- a/yaml/xyz/openbmc_project/Network/StaticRoute/CreateStaticRoute.interface.yaml
+++ b/yaml/xyz/openbmc_project/Network/StaticRoute/CreateStaticRoute.interface.yaml
@@ -1,0 +1,26 @@
+description: >
+methods:
+    - name: StaticRoute
+      description: >
+          Create a static route entry.
+      parameters:
+          - name: Destination
+            type: string
+            description: >
+                Destination Address.
+          - name: Gateway
+            type: string
+            description: >
+                Next hop address to reach destination address
+          - name: PrefixLength
+            type: uint32
+            description: >
+                Number of network bits in the address
+
+      returns:
+          - name: Path
+            type: object_path
+            description: >
+                The path for the created static route object.
+      errors:
+          - xyz.openbmc_project.Common.Error.InvalidArgument


### PR DESCRIPTION
This commit enables static route configuration on EthernetInterface Implements CreateStaticRoute method which creates a new d-bus object with StaticRoute interface.

Tested By:
Run CreateStaticRoute D-bus method and verified D-bus object and configuration Delete StaticRoute object

Change-Id: I670045563c4e46d22344000ba9eaf1620f80a205