### PR TITLE
Remove dependancy of DHCPEnabled & IPv6AcceptRA

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -472,16 +472,12 @@ EthernetInterface::DHCPConf EthernetInterface::dhcpEnabled(DHCPConf value)
 {
     auto old4 = EthernetInterfaceIntf::dhcp4();
     auto new4 = EthernetInterfaceIntf::dhcp4(value == DHCPConf::v4 ||
-                                             value == DHCPConf::v4v6stateless ||
                                              value == DHCPConf::both);
     auto old6 = EthernetInterfaceIntf::dhcp6();
     auto new6 = EthernetInterfaceIntf::dhcp6(value == DHCPConf::v6 ||
                                              value == DHCPConf::both);
-    auto oldra = EthernetInterfaceIntf::ipv6AcceptRA();
-    auto newra = EthernetInterfaceIntf::ipv6AcceptRA(
-        value == DHCPConf::v6stateless || value == DHCPConf::v4v6stateless);
 
-    if (old4 != new4 || old6 != new6 || oldra != newra)
+    if (old4 != new4 || old6 != new6)
     {
         writeConfigurationFile();
         manager.get().reloadConfigs();
@@ -497,9 +493,9 @@ EthernetInterface::DHCPConf EthernetInterface::dhcpEnabled() const
     }
     else if (dhcp4())
     {
-        return ipv6AcceptRA() ? DHCPConf::v4v6stateless : DHCPConf::v4;
+        return DHCPConf::v4;
     }
-    return ipv6AcceptRA() ? DHCPConf::v6stateless : DHCPConf::none;
+    return DHCPConf::none;
 }
 
 size_t EthernetInterface::mtu(size_t value)


### PR DESCRIPTION
Currently IPv6AcceptRA property value set based on DHCPEnabled property enum value. There are some corner cases where DHCPEnabled value could not control IPv6AutoConfig enable/disable when both v4 and v6 enabled.

Redfish schema has provided two separate properties to control DHCPv6 and IPv6AutoConfig. so bmcweb need to have complex logic to evaluate DHCPEnabled property value every time it does GET/SET of DHCPEnabled property.

To simplify this commit modifies DHCPEnabled to deal with v6,v4 and both enum values and use IPv6AcceptRA property independently to control IPv6AutoConfig.

Tested by: Set DHCPEnabled value to both,v4 and v6 while toggling IPv6AcceptRA enable/disable.
IPv6AutoConfig enable/disable works irrespective of DHCPEnabled states.

Change-Id: Iebbe81946a1b525c6b46bf103d8080dddbed219a