### PR TITLE
Fix Default network config to enable DHCPv6

### DIFF
--- a/60-phosphor-networkd-default.network.in
+++ b/60-phosphor-networkd-default.network.in
@@ -1,6 +1,8 @@
 [Match]
 Name=*
 Name=!lo
+[DHCPv6]
+WithoutRA=solicit
 [Network]
 DHCP=true
 LinkLocalAddressing=@LINK_LOCAL_AUTOCONFIGURATION@


### PR DESCRIPTION
This commit enables DHCPv6 in the factory reset default config.

Currently, after a factory reset, IPv6 Stateful DHCPv6 client will not
run, as the networkd is not instructed to be WithoutRA=solicit.

This PR modifies  default at 60-phosphor-networkd-default.network.in to
include "WithoutRA=solicit" option

