### PR TITLE
Duplicate entries getting created for static DNS.

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1066,9 +1066,15 @@ void EthernetInterface::writeConfigurationFile()
     }
 
     // Add the DNS entry
+    std::vector<std::string> dnsUniqueValues;
     for (const auto& dns : EthernetInterfaceIntf::staticNameServers())
     {
-        stream << "DNS=" << dns << "\n";
+        if (std::find(dnsUniqueValues.begin(), dnsUniqueValues.end(), dns) ==
+            dnsUniqueValues.end())
+        {
+            dnsUniqueValues.push_back(dns);
+            stream << "DNS=" << dns << "\n";
+        }
     }
 
     // Add the DHCP entry


### PR DESCRIPTION
Currently, we store the dbus DNS values in a vector that causes duplicate entries and due to those duplicate entries created.

With this commit, we are removing the duplicate value from vector before writing dns value to configuration files.

Tested By: PATCH -d '{"StaticNameServers":["10.4.5.60", "10.4.5.60"]}'
	   https://${bmc_ip}/redfish/v1/Managers/bmc/EthernetInterfaces/eth0