### PR TITLE
Duplicate entries getting created for static DNS.

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -805,9 +805,16 @@ void EthernetInterface::writeConfigurationFile()
         }
         {
             auto& dnss = network["DNS"];
+            std::vector<std::string> dnsUniqueValues;
+
             for (const auto& dns : EthernetInterfaceIntf::staticNameServers())
             {
-                dnss.emplace_back(dns);
+                if (std::find(dnsUniqueValues.begin(), dnsUniqueValues.end(),
+                              dns) == dnsUniqueValues.end())
+                {
+                    dnsUniqueValues.push_back(dns);
+                    dnss.emplace_back(dns);
+                }
             }
         }
         {


### PR DESCRIPTION
Currently, we store the dbus DNS values in a vector that causes duplicate entries and due to those duplicate entries created.

With this commitment, we are going to store static DNS values in a SET rather than a vector to create a unique list of DNS values

Tested By: PATCH -d '{"StaticNameServers":["10.4.5.60", "10.4.5.60"]}'
    https://${bmc_ip}/redfish/v1/Managers/bmc/EthernetInterfaces/eth0

Change-Id: I0c18eb5fec36c4305f1ded4c5e57bbd046ca4576