### PR TITLE
Avoid resetting ip when dhcp is enabled

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -1008,7 +1008,6 @@ HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled(DHCPConf value)
                 else
                 {
                     method = "IPv4Static";
-                    (itr->second)->resetBaseBiosTableAttrs("IPv4");
                 }
             }
             else if ((itr->second)->type() == HypIP::Protocol::IPv6)
@@ -1026,7 +1025,6 @@ HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled(DHCPConf value)
                 else
                 {
                     method = "IPv6Static";
-                    (itr->second)->resetBaseBiosTableAttrs("IPv6");
                 }
             }
             if (!method.empty())


### PR DESCRIPTION
Whenever dhcpv4 is enabled, the static v6 ip on that interface is reset to default and vice versa. This change avoids the issue by not resetting the ip address object.

Fixes:
[486882](https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=486882)

Tested By:

On eth1 interface:
* Configure static ipv4 address
* Enable DHCP v6
* Static ipv4 address will be retained
* Tested other scenarios as well
  * Enable SLAAC and verified that ipv4 static address is retained
  * Configure static ipv6
  * Tested for Static v6 address, when dhcpv4 is enabled