### PR TITLE
Return success on adding existing IP using redfish.

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -319,6 +319,20 @@ ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
 
     std::string objectPath =
         generateObjectPath(protType, ipaddress, prefixLength, gateway);
+
+    auto it = this->addrs.find(ipaddress);
+    if (it != this->addrs.end())
+    {
+        if (it->second->getObjPath() == objectPath)
+        {
+            return it->second->getObjPath();
+        }
+        else
+        {
+            this->addrs.erase(it);
+        }
+    }
+
     this->addrs.insert_or_assign(ipaddress,
                                  std::make_shared<phosphor::network::IPAddress>(
                                      bus, objectPath.c_str(), *this, protType,

--- a/src/ipaddress.cpp
+++ b/src/ipaddress.cpp
@@ -32,6 +32,7 @@ IPAddress::IPAddress(sdbusplus::bus::bus& bus, const char* objPath,
     IP::type(type);
     IP::origin(origin);
 
+    this->objectPath = objPath;
     // Emit deferred signal.
     emit_object_added();
 }
@@ -55,6 +56,12 @@ IP::AddressOrigin IPAddress::origin(IP::AddressOrigin /*origin*/)
 {
     elog<NotAllowed>(Reason("Property update is not allowed"));
 }
+
+std::string IPAddress::getObjPath()
+{
+    return objectPath;
+}
+
 void IPAddress::delete_()
 {
     if (origin() != IP::AddressOrigin::Static)

--- a/src/ipaddress.hpp
+++ b/src/ipaddress.hpp
@@ -56,6 +56,11 @@ class IPAddress : public IPIfaces
     IP::Protocol type(IP::Protocol type) override;
     IP::AddressOrigin origin(IP::AddressOrigin origin) override;
 
+    /** @brief Method to get d-bus object path.
+     *  @result object path.
+     */
+    std::string getObjPath();
+
     /** @brief Delete this d-bus object.
      */
     void delete_() override;
@@ -67,6 +72,8 @@ class IPAddress : public IPIfaces
     using IP::type;
 
   private:
+    std::string objectPath;
+
     /** @brief Parent Object. */
     EthernetInterface& parent;
 };


### PR DESCRIPTION
Currently while adding an existing static IP using redfish will get a internal error in response. 

This commit will allow to by-pass the static ip entry/object creation, if we try to add existing static IP with the same  subnet value and gateway value.

Tested By:
   curl -k -H "X-Auth-Token: $bmc_token" -X PATCH -D patch.txt -d '{"IPv4StaticAddresses":[{},{}, {"Address": "9.3.29.25",   "SubnetMask": "255.255.255.0","Gateway":"9.3.29.1"}]}' https://$bmc/redfish/v1/Managers/bmc/EthernetInterfaces/eth1

And It will delete and then create the static ip entry/object , if we try to add existing static IP with the different subnet and gateway value When try to add existing static IP with modified subnet and gateway

Tested By:
modified subnet
   curl -k -H "X-Auth-Token: $bmc_token" -X PATCH -D patch.txt -d '{"IPv4StaticAddresses":[{},{}, {"Address": "9.3.29.25",   "SubnetMask": "255.255.0.0","Gateway":"9.3.29.1"}]}' https://$bmc/redfish/v1/Managers/bmc/EthernetInterfaces/eth1

modified gateway
curl -k -H "X-Auth-Token: $bmc_token" -X PATCH -D patch.txt -d '{"IPv4StaticAddresses":[{},{},{"Address": "10.10.10.111","SubnetMask": "255.255.255.0","Gateway":"10.10.0.1"}]}' https://$bmc/redfish/v1/Managers/bmc/EthernetInterfaces/eth1
