### PR TITLE
regenerate-meson: re-run with latest from sdbusplus

### DIFF
--- a/gen/meson.build
+++ b/gen/meson.build
@@ -5,10 +5,10 @@ sdbuspp_gen_meson_ver = run_command(
     check: true,
 ).stdout().strip().split('\n')[0]
 
-if sdbuspp_gen_meson_ver != 'sdbus++-gen-meson version 5'
+if sdbuspp_gen_meson_ver != 'sdbus++-gen-meson version 6'
     warning('Generated meson files from wrong version of sdbus++-gen-meson.')
     warning(
-        'Expected "sdbus++-gen-meson version 5", got:',
+        'Expected "sdbus++-gen-meson version 6", got:',
         sdbuspp_gen_meson_ver
     )
 endif

--- a/gen/xyz/openbmc_project/Network/IP/Create/meson.build
+++ b/gen/xyz/openbmc_project/Network/IP/Create/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/IP/Create__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Network/IP/Create.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/Neighbor/CreateStatic/meson.build
+++ b/gen/xyz/openbmc_project/Network/Neighbor/CreateStatic/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/Neighbor/CreateStatic__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Network/Neighbor/CreateStatic.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/VLAN/Create/meson.build
+++ b/gen/xyz/openbmc_project/Network/VLAN/Create/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/VLAN/Create__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Network/VLAN/Create.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',


### PR DESCRIPTION
The sdbus++-gen-meson has a new version, which requires regenerating all the meson in this repository.  Re-run the `regenerate-meson` script.


Change-Id: I45c691970d685403a15c1790eabc66663f338d4b