### PR TITLE
Avoid ipv4 static and DHCP IPaddress coexistence

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -277,6 +277,44 @@ void EthernetInterface::addStaticRoute(const StaticRouteInfo& info)
     }
 }
 
+bool EthernetInterface::dhcpIsEnabled(IP::Protocol family, bool ignoreProtocol)
+{
+    return ((EthernetInterfaceIntf::dhcpEnabled() ==
+             EthernetInterface::DHCPConf::both) ||
+            ((EthernetInterfaceIntf::dhcpEnabled() ==
+              EthernetInterface::DHCPConf::v6) &&
+             ((family == IP::Protocol::IPv6) || ignoreProtocol)) ||
+            ((EthernetInterfaceIntf::dhcpEnabled() ==
+              EthernetInterface::DHCPConf::v4) &&
+             ((family == IP::Protocol::IPv4) || ignoreProtocol)));
+}
+
+void EthernetInterface::disableDHCP(IP::Protocol protocol)
+{
+    DHCPConf dhcpState = EthernetInterfaceIntf::dhcpEnabled();
+    if (dhcpState == EthernetInterface::DHCPConf::both)
+    {
+        if (protocol == IP::Protocol::IPv4)
+        {
+            dhcpEnabled(EthernetInterface::DHCPConf::v6);
+        }
+        else if (protocol == IP::Protocol::IPv6)
+        {
+            dhcpEnabled(EthernetInterface::DHCPConf::v4);
+        }
+    }
+    else if ((dhcpState == EthernetInterface::DHCPConf::v4) &&
+             (protocol == IP::Protocol::IPv4))
+    {
+        dhcpEnabled(EthernetInterface::DHCPConf::none);
+    }
+    else if ((dhcpState == EthernetInterface::DHCPConf::v6) &&
+             (protocol == IP::Protocol::IPv6))
+    {
+        dhcpEnabled(EthernetInterface::DHCPConf::none);
+    }
+}
+
 ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
                                  uint8_t prefixLength, std::string)
 {
@@ -338,6 +376,14 @@ ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
     writeConfigurationFile();
     manager.get().reloadConfigs();
 
+    // TODO This is a workaround to avoid IPv4 static and DHCP IP address
+    // coexistence Disable IPv4 DHCP while configuring IPv4 static address
+    if ((protType == IP::Protocol::IPv4) && dhcpIsEnabled(protType, false))
+    {
+        log<level::INFO>("DHCP enabled on the interface"),
+            entry("INTERFACE=%s", interfaceName().c_str());
+        disableDHCP(protType);
+    }
     return it->second->getObjPath();
 }
 
@@ -468,20 +514,43 @@ bool EthernetInterface::dhcp6(bool value)
     return value;
 }
 
+void EthernetInterface::deleteStaticIPv4Addresses()
+{
+    std::unique_ptr<IPAddress> ptr;
+    for (auto it = addrs.begin(); it != addrs.end();)
+    {
+        if ((it->second->origin() == IP::AddressOrigin::Static) &&
+            (it->second->type() == IP::Protocol::IPv4))
+        {
+            ptr = std::move(it->second);
+            it = addrs.erase(it);
+            writeConfigurationFile();
+            manager.get().reloadConfigs();
+        }
+        else
+        {
+            it++;
+        }
+    }
+}
+
 EthernetInterface::DHCPConf EthernetInterface::dhcpEnabled(DHCPConf value)
 {
-    auto old4 = EthernetInterfaceIntf::dhcp4();
-    auto new4 = EthernetInterfaceIntf::dhcp4(value == DHCPConf::v4 ||
-                                             value == DHCPConf::both);
-    auto old6 = EthernetInterfaceIntf::dhcp6();
-    auto new6 = EthernetInterfaceIntf::dhcp6(value == DHCPConf::v6 ||
-                                             value == DHCPConf::both);
 
-    if (old4 != new4 || old6 != new6)
+    // TODO This is a workaround to avoid IPv4 static and DHCP IP address
+    // coexistence
+    if ((value == DHCPConf::v4) || (value == DHCPConf::both))
     {
-        writeConfigurationFile();
-        manager.get().reloadConfigs();
+        // Delete all IPv4 static addresses while enabling DHCP
+        deleteStaticIPv4Addresses();
     }
+
+    EthernetInterfaceIntf::dhcp4(value == DHCPConf::v4 ||
+                                 value == DHCPConf::both);
+    EthernetInterfaceIntf::dhcp6(value == DHCPConf::v6 ||
+                                 value == DHCPConf::both);
+    writeConfigurationFile();
+    manager.get().reloadConfigs();
     return value;
 }
 

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -115,6 +115,10 @@ class EthernetInterface : public Ifaces
      */
     void loadNameServers(const config::Parser& config);
 
+    /** @brief Function used to delete IPv4 static addresses
+     */
+    void deleteStaticIPv4Addresses();
+
     /** @brief Function to create ipAddress dbus object.
      *  @param[in] addressType - Type of ip address.
      *  @param[in] ipAddress- IP address.
@@ -216,6 +220,8 @@ class EthernetInterface : public Ifaces
      */
     std::string defaultGateway6(std::string gateway) override;
 
+    bool dhcpIsEnabled(IP::Protocol family, bool ignoreProtocol);
+    void disableDHCP(IP::Protocol protocol);
     using EthernetInterfaceIntf::interfaceName;
     using EthernetInterfaceIntf::linkUp;
     using EthernetInterfaceIntf::mtu;


### PR DESCRIPTION
Currently IPv4 Static and DHCP IP addresses coexists, but Static IP configuration
can't work while DHCP enabled on the interface.

This commits avoids coexistence, disables DHCPv4 while configuring static IPv4 address
and deletes static address while enabling DHCPv4.

This is downstream only change for now, needs discussions in the upstream community

Tested by:
Enable DHCPv4 with multiple static IPv4 addresses configured on interface.
Configure Static addresses when DHCPv4 enabled on interface.
Verified DHCPv6 Enable/Disable test cases.
Verified Static IPv6 address configuration while enabling DHCP