### PR TITLE
Added WithoutRA=solicit, to enable stateful DHCPv6

### DIFF
--- a/60-phosphor-networkd-default.network.in
+++ b/60-phosphor-networkd-default.network.in
@@ -1,6 +1,8 @@
 [Match]
 Name=*
 Name=!lo
+[DHCPv6]
+WithoutRA=@ENABLE_DHCP6_WITHOUT_RA@
 [Network]
 DHCP=true
 LinkLocalAddressing=@LINK_LOCAL_AUTOCONFIGURATION@

--- a/60-phosphor-networkd-default.network.in
+++ b/60-phosphor-networkd-default.network.in
@@ -4,9 +4,12 @@ Name=!lo
 [DHCPv6]
 WithoutRA=@SOLICIT_ENABLE_DHCP6_WITHOUT_RA@
 [Network]
+DHCPPrefixDelegation=@DHCP_PREFIX_DELIGATION@
 DHCP=true
 LinkLocalAddressing=@LINK_LOCAL_AUTOCONFIGURATION@
 IPv6AcceptRA=@ENABLE_IPV6_ACCEPT_RA@
+[DHCPPrefixDelegation]
+UplinkInterface=@UPLINK_INTERFACE@
 [DHCP]
 ClientIdentifier=mac
 UseDNS=true

--- a/60-phosphor-networkd-default.network.in
+++ b/60-phosphor-networkd-default.network.in
@@ -2,7 +2,7 @@
 Name=*
 Name=!lo
 [DHCPv6]
-WithoutRA=@ENABLE_DHCP6_WITHOUT_RA@
+WithoutRA=@SOLICIT_ENABLE_DHCP6_WITHOUT_RA@
 [Network]
 DHCP=true
 LinkLocalAddressing=@LINK_LOCAL_AUTOCONFIGURATION@

--- a/60-phosphor-networkd-default.network.in
+++ b/60-phosphor-networkd-default.network.in
@@ -2,7 +2,7 @@
 Name=*
 Name=!lo
 [DHCPv6]
-WithoutRA=@SOLICIT_ENABLE_DHCP6_WITHOUT_RA@
+WithoutRA=@ENABLE_DHCP6_WITHOUT_RA@
 [Network]
 DHCPPrefixDelegation=@DHCP_PREFIX_DELIGATION@
 DHCP=true

--- a/meson.build
+++ b/meson.build
@@ -19,12 +19,19 @@ conf_data.set(
 conf_data.set(
   'ENABLE_IPV6_ACCEPT_RA',
   get_option('default-ipv6-accept-ra'))
-conf_data.set(
-  'SOLICIT_ENABLE_DHCP6_WITHOUT_RA',
-   get_option('default-dhcp6-without-ra'))
 conf_data.set('SYNC_MAC_FROM_INVENTORY', get_option('sync-mac'))
 conf_data.set('PERSIST_MAC', get_option('persist-mac'))
 conf_data.set10('FORCE_SYNC_MAC_FROM_INVENTORY', get_option('force-sync-mac'))
+conf_data.set('DHCP_PREFIX_DELIGATION', get_option('dhcp-prefix-delegation'))
+
+if get_option('uplink-interface-self')
+    conf_data.set('UPLINK_INTERFACE', 'self')
+    if get_option('dhcp-prefix-delegation')
+        conf_data.set('SOLICIT_ENABLE_DHCP6_WITHOUT_RA', 'solicit')
+    else
+        conf_data.set('SOLICIT_ENABLE_DHCP6_WITHOUT_RA', 'no')
+    endif
+endif
 
 sdbusplus_dep = dependency('sdbusplus')
 sdbusplusplus_prog = find_program('sdbus++', native: true)

--- a/meson.build
+++ b/meson.build
@@ -20,8 +20,8 @@ conf_data.set(
   'ENABLE_IPV6_ACCEPT_RA',
   get_option('default-ipv6-accept-ra'))
 conf_data.set(
-  'ENABLE_DHCP6_WITHOUT_RA',
-  get_option('default-dhcp6-without-ra'))
+  'SOLICIT_ENABLE_DHCP6_WITHOUT_RA',
+   get_option('default-dhcp6-without-ra'))
 conf_data.set('SYNC_MAC_FROM_INVENTORY', get_option('sync-mac'))
 conf_data.set('PERSIST_MAC', get_option('persist-mac'))
 conf_data.set10('FORCE_SYNC_MAC_FROM_INVENTORY', get_option('force-sync-mac'))

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'phosphor-networkd',
   'cpp',
   version: '0.1',
-  meson_version: '>=0.57.0',
+  meson_version: '>=0.58.0',
   default_options: [
     'warning_level=3',
     'cpp_std=c++20',
@@ -92,7 +92,7 @@ configure_file(
   configuration: conf_data,
   install: true,
   install_dir: dependency('systemd').get_variable(
-    pkgconfig: 'systemdutildir') / 'network')
+    'systemdutildir') / 'network')
 
 configure_file(
   input: 'xyz.openbmc_project.Network.service.in',
@@ -103,7 +103,7 @@ configure_file(
   },
   install: true,
   install_dir: dependency('systemd').get_variable(
-    pkgconfig: 'systemdsystemunitdir'))
+    'systemdsystemunitdir'))
 
 configure_file(
   input: 'xyz.openbmc_project.Network.conf.in',

--- a/meson.build
+++ b/meson.build
@@ -22,16 +22,7 @@ conf_data.set(
 conf_data.set('SYNC_MAC_FROM_INVENTORY', get_option('sync-mac'))
 conf_data.set('PERSIST_MAC', get_option('persist-mac'))
 conf_data.set10('FORCE_SYNC_MAC_FROM_INVENTORY', get_option('force-sync-mac'))
-conf_data.set('DHCP_PREFIX_DELIGATION', get_option('dhcp-prefix-delegation'))
-
-if get_option('uplink-interface-self')
-    conf_data.set('UPLINK_INTERFACE', 'self')
-    if get_option('dhcp-prefix-delegation')
-        conf_data.set('SOLICIT_ENABLE_DHCP6_WITHOUT_RA', 'solicit')
-    else
-        conf_data.set('SOLICIT_ENABLE_DHCP6_WITHOUT_RA', 'no')
-    endif
-endif
+conf_data.set_quoted('ENABLE_DHCP6_WITHOUT_RA', get_option('enable-dhcp6-without-ra'))
 
 sdbusplus_dep = dependency('sdbusplus')
 sdbusplusplus_prog = find_program('sdbus++', native: true)

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,9 @@ conf_data.set(
 conf_data.set(
   'ENABLE_IPV6_ACCEPT_RA',
   get_option('default-ipv6-accept-ra'))
+conf_data.set(
+  'ENABLE_DHCP6_WITHOUT_RA',
+  get_option('default-dhcp6-without-ra'))
 conf_data.set('SYNC_MAC_FROM_INVENTORY', get_option('sync-mac'))
 conf_data.set('PERSIST_MAC', get_option('persist-mac'))
 conf_data.set10('FORCE_SYNC_MAC_FROM_INVENTORY', get_option('force-sync-mac'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,8 +14,8 @@ option('persist-mac', type: 'boolean',
        description: 'Permit the MAC address to be written to the systemd.network config')
 option('force-sync-mac', type: 'boolean',
        description: 'Force sync mac address no matter is first boot or not')
-option('default-dhcp6-without-ra', type: 'combo',
-       choices: ['solicit', 'no', 'nformation-request'],
-       value: 'solicit',
-       description: 'Enables stateful DHCPv6 by default.')
+option('dhcp-prefix-delegation', type: 'boolean',
+       description: 'Enable dhcp prefix delegation by default')
+option('uplink-interface-self', type: 'boolean',
+       description: 'Enable link uplink interface and set it to "self"')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,6 +14,8 @@ option('persist-mac', type: 'boolean',
        description: 'Permit the MAC address to be written to the systemd.network config')
 option('force-sync-mac', type: 'boolean',
        description: 'Force sync mac address no matter is first boot or not')
-option('default-dhcp6-without-ra', type: 'boolean',
-       description: 'Enables stateful DHCPv6 by default')
+option('default-dhcp6-without-ra', type: 'combo',
+       choices: ['solicit', 'no', 'nformation-request'],
+       value: 'solicit',
+       description: 'Enables stateful DHCPv6 by default.')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,8 +14,7 @@ option('persist-mac', type: 'boolean',
        description: 'Permit the MAC address to be written to the systemd.network config')
 option('force-sync-mac', type: 'boolean',
        description: 'Force sync mac address no matter is first boot or not')
-option('dhcp-prefix-delegation', type: 'boolean',
-       description: 'Enable dhcp prefix delegation by default')
-option('uplink-interface-self', type: 'boolean',
-       description: 'Enable link uplink interface and set it to "self"')
+option('default-dhcp6-without-ra', type: 'string',
+       value: 'no',
+       description: 'Enables stateful DHCPv6 by default.')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,4 +14,6 @@ option('persist-mac', type: 'boolean',
        description: 'Permit the MAC address to be written to the systemd.network config')
 option('force-sync-mac', type: 'boolean',
        description: 'Force sync mac address no matter is first boot or not')
+option('default-dhcp6-without-ra', type: 'boolean',
+       description: 'Force sync mac address no matter is first boot or not')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,5 +15,5 @@ option('persist-mac', type: 'boolean',
 option('force-sync-mac', type: 'boolean',
        description: 'Force sync mac address no matter is first boot or not')
 option('default-dhcp6-without-ra', type: 'boolean',
-       description: 'Force sync mac address no matter is first boot or not')
+       description: 'Enables stateful DHCPv6 by default')
 

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -858,8 +858,7 @@ void EthernetInterface::writeConfigurationFile()
         lla.emplace_back("no");
 #endif
         network["IPv6AcceptRA"].emplace_back(ipv6AcceptRA() ? "true" : "false");
-#ifdef SOLICIT_ENABLE_DHCP6_WITHOUT_RA
-        if (dhcp6())
+        if ((ENABLE_DHCP6_WITHOUT_RA == "solicit") && dhcp6())
         {
             config.map["DHCPv6"].emplace_back()["WithoutRA"].emplace_back(
                 "solicit");

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -858,13 +858,13 @@ void EthernetInterface::writeConfigurationFile()
         lla.emplace_back("no");
 #endif
         network["IPv6AcceptRA"].emplace_back(ipv6AcceptRA() ? "true" : "false");
+#ifdef SOLICIT_ENABLE_DHCP6_WITHOUT_RA
         if (dhcp6())
         {
-#ifdef SOLICIT_ENABLE_DHCP6_WITHOUT_RA
             config.map["DHCPv6"].emplace_back()["WithoutRA"].emplace_back(
                 "solicit");
-#endif
         }
+#endif
         network["DHCP"].emplace_back(dhcp4() ? (dhcp6() ? "true" : "ipv4")
                                              : (dhcp6() ? "ipv6" : "false"));
         {

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -860,7 +860,7 @@ void EthernetInterface::writeConfigurationFile()
         network["IPv6AcceptRA"].emplace_back(ipv6AcceptRA() ? "true" : "false");
         if (dhcp6())
         {
-#ifdef ENABLE_DHCP6_WITHOUT_RA
+#ifdef SOLICIT_ENABLE_DHCP6_WITHOUT_RA
             config.map["DHCPv6"].emplace_back()["WithoutRA"].emplace_back(
                 "solicit");
 #endif

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -860,8 +860,10 @@ void EthernetInterface::writeConfigurationFile()
         network["IPv6AcceptRA"].emplace_back(ipv6AcceptRA() ? "true" : "false");
         if (dhcp6())
         {
+#ifdef ENABLE_DHCP6_WITHOUT_RA
             config.map["DHCPv6"].emplace_back()["WithoutRA"].emplace_back(
                 "solicit");
+#endif
         }
         network["DHCP"].emplace_back(dhcp4() ? (dhcp6() ? "true" : "ipv4")
                                              : (dhcp6() ? "ipv6" : "false"));

--- a/src/ibm/hypervisor-network-mgr-src/meson.build
+++ b/src/ibm/hypervisor-network-mgr-src/meson.build
@@ -9,7 +9,7 @@ configure_file(
   },
   install: true,
   install_dir: dependency('systemd').get_variable(
-    pkgconfig: 'systemdsystemunitdir'))
+    'systemdsystemunitdir'))
 
 hyp_src_includes = include_directories('.')
 

--- a/test/test_ethernet_interface.cpp
+++ b/test/test_ethernet_interface.cpp
@@ -233,32 +233,6 @@ TEST_F(TestEthernetInterface, IPv6AcceptRA)
 
 TEST_F(TestEthernetInterface, AddStaticRoute)
 {
-    createStaticRouteObject("10.10.10.10", "10.10.10.1", 24);
-    EXPECT_THAT(interface.staticRoutes,
-                UnorderedElementsAre(Key(std::string("10.10.10.10"))));
-}
-
-TEST_F(TestEthernetInterface, AddMultipleStaticRoutes)
-{
-    createStaticRouteObject("10.10.10.10", "10.10.10.1", 24);
-    createStaticRouteObject("10.20.30.10", "10.20.30.1", 24);
-    EXPECT_THAT(interface.staticRoutes,
-                UnorderedElementsAre(Key(std::string("10.10.10.10")),
-                                     Key(std::string("10.20.30.10"))));
-}
-
-TEST_F(TestEthernetInterface, DeleteStaticRoute)
-{
-    createStaticRouteObject("10.10.10.10", "10.10.10.1", 24);
-    createStaticRouteObject("10.20.30.10", "10.20.30.1", 24);
-
-    interface.staticRoutes.at(std::string("10.10.10.10"))->delete_();
-    interface.staticRoutes.at(std::string("10.20.30.10"))->delete_();
-    EXPECT_EQ(interface.staticRoutes.empty(), true);
-}
-
-TEST_F(TestEthernetInterface, AddStaticRoute)
-{
     createStaticRouteObject("10.10.10.10", "10.10.10.1", 24,
                             IP::Protocol::IPv4);
     EXPECT_THAT(interface.staticRoutes,

--- a/test/test_network_manager.hpp
+++ b/test/test_network_manager.hpp
@@ -11,7 +11,7 @@ namespace network
 struct MockExecutor : DelayedExecutor
 {
     MOCK_METHOD((void), schedule, (), (override));
-    MOCK_METHOD((void), setCallback, (fu2::unique_function<void()> &&),
+    MOCK_METHOD((void), setCallback, (fu2::unique_function<void()>&&),
                 (override));
 };
 


### PR DESCRIPTION
Enable Stateful DHCPv6 at factory reset configuration.
Added WithoutRA flag in 60-phosphor-networkd-default.network.in to enable this by default.

Upstream Commit:  https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/63444

This PR is required for openBmc PR: https://github.ibm.com/openbmc/openbmc/pull/3691