### PR TITLE
Add Network Static Route/Gateway support

### DIFF
--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -5,7 +5,7 @@
 #include "types.hpp"
 #include "xyz/openbmc_project/Network/IP/Create/server.hpp"
 #include "xyz/openbmc_project/Network/Neighbor/CreateStatic/server.hpp"
-#include "xyz/openbmc_project/Network/StaticRoute/CreateStaticRoute/server.hpp"
+#include "xyz/openbmc_project/Network/StaticRoute/Create/server.hpp"
 
 #include <optional>
 #include <sdbusplus/bus.hpp>
@@ -31,8 +31,7 @@ using Ifaces = sdbusplus::server::object_t<
     sdbusplus::xyz::openbmc_project::Network::server::MACAddress,
     sdbusplus::xyz::openbmc_project::Network::IP::server::Create,
     sdbusplus::xyz::openbmc_project::Network::Neighbor::server::CreateStatic,
-    sdbusplus::xyz::openbmc_project::Network::StaticRoute::server::
-        CreateStaticRoute,
+    sdbusplus::xyz::openbmc_project::Network::StaticRoute::server::Create,
     sdbusplus::xyz::openbmc_project::Collection::server::DeleteAll>;
 
 using VlanIfaces = sdbusplus::server::object_t<
@@ -140,7 +139,8 @@ class EthernetInterface : public Ifaces
      *  @parma[in] prefixLength - Number of network bits.
      */
     ObjectPath staticRoute(std::string destination, std::string gateway,
-                           uint32_t prefixLength) override;
+                           size_t prefixLength,
+                           IP::Protocol protocolType) override;
 
     /** Set value of DHCPEnabled */
     DHCPConf dhcpEnabled() const override;

--- a/src/static_route.cpp
+++ b/src/static_route.cpp
@@ -23,9 +23,9 @@ static auto makeObjPath(std::string_view root, std::string addr)
 StaticRoute::StaticRoute(sdbusplus::bus_t& bus, std::string_view objRoot,
                          stdplus::PinnedRef<EthernetInterface> parent,
                          std::string destination, std::string gateway,
-                         uint32_t prefixLength) :
-    StaticRoute(bus, makeObjPath(objRoot, destination), parent, destination,
-                gateway, prefixLength)
+                         size_t prefixLength, IP::Protocol protocolType) :
+    StaticRoute(bus, makeObjPath(objRoot, gateway), parent, destination,
+                gateway, prefixLength, protocolType)
 {
 }
 
@@ -33,7 +33,7 @@ StaticRoute::StaticRoute(sdbusplus::bus_t& bus,
                          sdbusplus::message::object_path objPath,
                          stdplus::PinnedRef<EthernetInterface> parent,
                          std::string destination, std::string gateway,
-                         uint32_t prefixLength) :
+                         size_t prefixLength, IP::Protocol protocolType) :
     StaticRouteObj(bus, objPath.str.c_str(),
                    StaticRouteObj::action::defer_emit),
     parent(parent), objPath(std::move(objPath))
@@ -41,6 +41,7 @@ StaticRoute::StaticRoute(sdbusplus::bus_t& bus,
     StaticRouteObj::destination(destination, true);
     StaticRouteObj::gateway(gateway, true);
     StaticRouteObj::prefixLength(prefixLength, true);
+    StaticRouteObj::protocolType(protocolType, true);
     emit_object_added();
 }
 
@@ -77,10 +78,14 @@ std::string StaticRoute::gateway(std::string /*gateway*/)
     elog<NotAllowed>(REASON("Property update is not allowed"));
 }
 
-uint32_t StaticRoute::prefixLength(uint32_t /*prefixLength*/)
+size_t StaticRoute::prefixLength(size_t /*prefixLength*/)
 {
     elog<NotAllowed>(REASON("Property update is not allowed"));
 }
 
+IP::Protocol StaticRoute::protocolType(IP::Protocol /*protocolType*/)
+{
+    elog<NotAllowed>(REASON("Property update is not allowed"));
+}
 } // namespace network
 } // namespace phosphor

--- a/src/static_route.hpp
+++ b/src/static_route.hpp
@@ -20,6 +20,8 @@ using StaticRouteIntf =
 using StaticRouteObj = sdbusplus::server::object_t<
     StaticRouteIntf, sdbusplus::xyz::openbmc_project::Object::server::Delete>;
 
+using IP = sdbusplus::xyz::openbmc_project::Network::server::IP;
+
 class EthernetInterface;
 
 /** @class StaticRoute
@@ -41,7 +43,7 @@ class StaticRoute : public StaticRouteObj
     StaticRoute(sdbusplus::bus_t& bus, std::string_view objRoot,
                 stdplus::PinnedRef<EthernetInterface> parent,
                 std::string destination, std::string gateway,
-                uint32_t prefixLength);
+                size_t prefixLength, IP::Protocol protocolType);
 
     /** @brief Delete this d-bus object.
      */
@@ -52,8 +54,9 @@ class StaticRoute : public StaticRouteObj
     using StaticRouteObj::gateway;
     std::string gateway(std::string) override;
     using StaticRouteObj::prefixLength;
-    uint32_t prefixLength(uint32_t) override;
-
+    size_t prefixLength(size_t) override;
+    using StaticRouteObj::protocolType;
+    IP::Protocol protocolType(IP::Protocol) override;
     inline const auto& getObjPath() const
     {
         return objPath;
@@ -69,7 +72,7 @@ class StaticRoute : public StaticRouteObj
     StaticRoute(sdbusplus::bus_t& bus, sdbusplus::message::object_path objPath,
                 stdplus::PinnedRef<EthernetInterface> parent,
                 std::string destination, std::string gateway,
-                uint32_t prefixLength);
+                size_t prefixLength, IP::Protocol protocolType);
 };
 
 } // namespace network

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -141,9 +141,10 @@ struct NeighborInfo
 struct StaticRouteInfo
 {
     unsigned ifidx;
-    uint32_t prefixLength;
+    size_t prefixLength;
     std::optional<std::string> destination;
     std::optional<std::string> gateway;
+    std::optional<std::string> protocol;
 
     constexpr bool operator==(const StaticRouteInfo& rhs) const noexcept
     {

--- a/test/test_ethernet_interface.cpp
+++ b/test/test_ethernet_interface.cpp
@@ -51,10 +51,12 @@ class TestEthernetInterface : public stdplus::gtest::TestWithTmp
         return interface.ip(addressType, ipaddress, subnetMask, "");
     }
 
-    auto createStaticRouteObject(std::string destination, std::string gateway,
-                                 uint32_t prefixLength)
+    auto createStaticRouteObject(const std::string& destination,
+                                 const std::string& gateway,
+                                 size_t prefixLength, IP::Protocol protocol)
     {
-        return interface.staticRoute(destination, gateway, prefixLength);
+        return interface.staticRoute(destination, gateway, prefixLength,
+                                     protocol);
     }
 
     void setNtpServers()
@@ -253,6 +255,56 @@ TEST_F(TestEthernetInterface, DeleteStaticRoute)
     interface.staticRoutes.at(std::string("10.10.10.10"))->delete_();
     interface.staticRoutes.at(std::string("10.20.30.10"))->delete_();
     EXPECT_EQ(interface.staticRoutes.empty(), true);
+}
+
+TEST_F(TestEthernetInterface, AddStaticRoute)
+{
+    createStaticRouteObject("10.10.10.10", "10.10.10.1", 24,
+                            IP::Protocol::IPv4);
+    EXPECT_THAT(interface.staticRoutes,
+                UnorderedElementsAre(Key(std::string("10.10.10.1"))));
+}
+
+TEST_F(TestEthernetInterface, AddMultipleStaticRoutes)
+{
+    createStaticRouteObject("10.10.10.10", "10.10.10.1", 24,
+                            IP::Protocol::IPv4);
+    createStaticRouteObject("10.20.30.10", "10.20.30.1", 24,
+                            IP::Protocol::IPv4);
+    EXPECT_THAT(interface.staticRoutes,
+                UnorderedElementsAre(Key(std::string("10.10.10.1")),
+                                     Key(std::string("10.20.30.1"))));
+}
+
+TEST_F(TestEthernetInterface, DeleteStaticRoute)
+{
+    createStaticRouteObject("10.10.10.10", "10.10.10.1", 24,
+                            IP::Protocol::IPv4);
+    createStaticRouteObject("10.20.30.10", "10.20.30.1", 24,
+                            IP::Protocol::IPv4);
+
+    interface.staticRoutes.at(std::string("10.10.10.1"))->delete_();
+    interface.staticRoutes.at(std::string("10.20.30.1"))->delete_();
+    EXPECT_EQ(interface.staticRoutes.empty(), true);
+}
+
+TEST_F(TestEthernetInterface, AddIPv6StaticGateway)
+{
+    createStaticRouteObject("0:0:0:0:0:0:0:0", "2002:903:15f:325::1", 64,
+                            IP::Protocol::IPv6);
+    EXPECT_THAT(interface.staticRoutes,
+                UnorderedElementsAre(Key(std::string("2002:903:15f:325::1"))));
+}
+
+TEST_F(TestEthernetInterface, AddMultipleIPv6StaticGateways)
+{
+    createStaticRouteObject("0:0:0:0:0:0:0:0", "2003:903:15f:325::1", 64,
+                            IP::Protocol::IPv6);
+    createStaticRouteObject("0:0:0:0:0:0:0:0", "2004:903:15f:325::1", 64,
+                            IP::Protocol::IPv6);
+    EXPECT_THAT(interface.staticRoutes,
+                UnorderedElementsAre(Key(std::string("2003:903:15f:325::1")),
+                                     Key(std::string("2004:903:15f:325::1"))));
 }
 
 } // namespace network


### PR DESCRIPTION
This commit enables static route configuration on EthernetInterface Implements CreateStaticRoute method which creates a new d-bus object with StaticRoute interface.

Tested By:
Run StaticRoute D-bus method and verified D-bus object and configuration Delete StaticRoute object

Change-Id: I3fbc6f85ede00b6c1949a0ac85f501037a69c831