### PR TITLE
Hypervisor: Add support for default IPv6 gateway

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
@@ -138,6 +138,11 @@ class HypEthInterface : public CreateIface
      */
     bool isDHCPEnabled(HypIP::Protocol protocol);
 
+    /** @brief set the default v6 gateway of the interface.
+     * @param[in] gateway - default v6 gateway of the interface.
+     */
+    std::string defaultGateway6(std::string gateway) override;
+
     /** Set value of DHCPEnabled */
     HypEthernetIntf::DHCPConf dhcpEnabled() const override;
     HypEthernetIntf::DHCPConf dhcpEnabled(DHCPConf value) override;
@@ -152,6 +157,7 @@ class HypEthInterface : public CreateIface
     bool ipv6AcceptRA(bool value) override;
     using HypEthernetIntf::ipv6AcceptRA;
 
+    using HypEthernetIntf::defaultGateway6;
     using HypEthernetIntf::interfaceName;
 
   protected:

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.hpp
@@ -72,6 +72,11 @@ class HypIPAddress : public HypIPIfaces
      */
     void delete_() override;
 
+    std::string getObjectPath()
+    {
+        return objectPath;
+    }
+
     /** @brief Get bios table property's prefix based
      *         on the protocol.
      *  @result prefix of bios table properties


### PR DESCRIPTION
This commit adds support for default IPv6 gateway configuration in static mode. When a user sets this value, it would be updated in the ethernet dbus object and the same will be sync'ed with the ip address dbus object - this is because, there is only one ipv4 and ipv6 objects permitted for each ethernet interfaces.

This change keeps the "DefaultGateway6" property of ethernet interface, "Gateway" property of ip address object and the "bios table" in sync to avoid misconfigurations.

In case of dynamic configuration, patching of this property will not be permitted and error would be returned.

TestedBy:

[1] Setting "DefaultGateway6" of ethernet object:
busctl set-property xyz.openbmc_project.Network.Hypervisor \ /xyz/openbmc_project/network/hypervisor/eth1 \
xyz.openbmc_project.Network.EthernetInterface DefaultGateway6 \ s "<ipv6Gateway>"

[2] Setting from Bios table: (This should reflect in the dbus object) busctl call xyz.openbmc_project.BIOSConfigManager \ /xyz/openbmc_project/bios_config/manager \
xyz.openbmc_project.BIOSConfig.Manager SetAttribute sv vmi_if1_ipv6_gateway \ s "<ipv6Gateway>"

Change-Id: I7c00acaf8e93c710202ffb3c24a9e13fd76da5b0