### PR TITLE
Update the error on deleting a link local address

### DIFF
--- a/src/ipaddress.cpp
+++ b/src/ipaddress.cpp
@@ -96,15 +96,7 @@ void IPAddress::delete_()
             entry("PREFIX=%" PRIu8, prefixLength()),
             entry("INTERFACE=%s", parent.get().interfaceName().c_str());
 
-        if (origin() == IP::AddressOrigin::LinkLocal)
-        {
-            elog<NotAllowed>(
-                Reason("Not allowed to delete a LinkLocal address"));
-        }
-        else
-        {
-            elog<InternalFailure>();
-        }
+        elog<NotAllowed>(Reason("Not allowed to delete a non-static address"));
     }
 
     std::unique_ptr<IPAddress> ptr;


### PR DESCRIPTION
It is in reference to https://github.com/openbmc/openbmc/issues/2342

This is a follow up PR for
https://github.com/ibm-openbmc/phosphor-networkd/commit/173ba5ab8c180b3b5a305a716f87bb6f43387bb6
Updated according to upstream comment.

Tested by:

Current behaviour:

busctl call xyz.openbmc_project.Network
/xyz/openbmc_project/network/eth1/_66e80_3a_3aa94... xyz.openbmc_project.Object.Delete Delete

response: Call failed: The operation failed internally.

Modified behaviour:

busctl call xyz.openbmc_project.Network
/xyz/openbmc_project/network/eth1/_66e80_3a_3aa94... xyz.openbmc_project.Object.Delete Delete

response: Call failed: The operation is not allowed

Change-Id: Ib5df33b8ad356a868aecc508ad6531ed15390a1d