### PR TITLE
meta-ibm: Enable Stateful DHCPv6 at factory reset

### DIFF
--- a/60-phosphor-networkd-default.network.in
+++ b/60-phosphor-networkd-default.network.in
@@ -1,6 +1,8 @@
 [Match]
 Name=*
 Name=!lo
+[DHCPv6]
+WithoutRA=@ENABLE_DHCP6_WITHOUT_RA@
 [Network]
 DHCP=true
 LinkLocalAddressing=@LINK_LOCAL_AUTOCONFIGURATION@

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ conf_data.set(
 conf_data.set('SYNC_MAC_FROM_INVENTORY', get_option('sync-mac'))
 conf_data.set('PERSIST_MAC', get_option('persist-mac'))
 conf_data.set10('FORCE_SYNC_MAC_FROM_INVENTORY', get_option('force-sync-mac'))
+conf_data.set_quoted('ENABLE_DHCP6_WITHOUT_RA', get_option('enable-dhcp6-without-ra'))
 
 sdbusplus_dep = dependency('sdbusplus')
 sdbusplusplus_prog = find_program('sdbus++', native: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,4 +14,7 @@ option('persist-mac', type: 'boolean',
        description: 'Permit the MAC address to be written to the systemd.network config')
 option('force-sync-mac', type: 'boolean',
        description: 'Force sync mac address no matter is first boot or not')
+option('enable-dhcp6-without-ra', type: 'string',
+        value: 'no',
+        description: 'Enables stateful DHCPv6 by default.')
 

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -911,7 +911,7 @@ void EthernetInterface::writeConfigurationFile()
         lla.emplace_back("no");
 #endif
         network["IPv6AcceptRA"].emplace_back(ipv6AcceptRA() ? "true" : "false");
-        if (dhcp6())
+        if (dhcp6() && ("solicit" == std::string(ENABLE_DHCP6_WITHOUT_RA)))
         {
             config.map["DHCPv6"].emplace_back()["WithoutRA"].emplace_back(
                 "solicit");


### PR DESCRIPTION
Enable Stateful DHCPv6 at factory reset configuration. Added WithoutRA flag in 60-phosphor-networkd-default.network.in to enable this by default.

A RA message(which has managed flag) is required to start the DHCPv6 
client.
Now, after this change, the DHCPv6 client starts without RA message. 
There will not be any dependence on RA message to start the DHCPv6 
client.

Tested By: After Reset BMC and server settings,
60-phosphor-networkd-default.network file's output.

[Match]
Name=*
Name=!lo
[DHCPv6]
WithoutRA=solicit         -->new entry
[Network]
DHCP=true
LinkLocalAddressing=True
IPv6AcceptRA=False
[DHCP]
ClientIdentifier=mac
UseDNS=true
UseDomains=true
UseNTP=true
UseHostname=true
SendHostname=true
[IPv6AcceptRA]
DHCPv6Client=true

Change-Id: I3f1414fff838182f55366bea26b1127e3aeeafe9

Old closed PR:  https://github.com/ibm-openbmc/phosphor-networkd/pull/84
Upstream Commit: https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/63444