### PR TITLE
Don't accept Linklocal address as IP .

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -976,23 +976,39 @@ void EthernetInterface::deleteAll()
     manager.get().reloadConfigs();
 }
 
-std::string EthernetInterface::defaultGateway(std::string gateway)
+template <typename Addr>
+static void normalizeGateway(std::string& gw)
 {
+    if (gw.empty())
+    {
+        return;
+    }
     try
     {
-        if (!gateway.empty())
+        auto ip = ToAddr<Addr>{}(gw);
+        if (ip == Addr{})
         {
-            gateway = std::to_string(ToAddr<in_addr>{}(gateway));
+            gw.clear();
+            return;
         }
+        if (!validUnicast(ip))
+        {
+            throw std::invalid_argument("Invalid unicast");
+        }
+        gw = std::to_string(ip);
     }
     catch (const std::exception& e)
     {
-        auto msg = fmt::format("Invalid v4 GW `{}`: {}", gateway, e.what());
-        log<level::ERR>(msg.c_str(), entry("GATEWAY=%s", gateway.c_str()));
+        auto msg = fmt::format("Invalid GW `{}`: {}", gw, e.what());
+        log<level::ERR>(msg.c_str(), entry("GATEWAY=%s", gw.c_str()));
         elog<InvalidArgument>(Argument::ARGUMENT_NAME("GATEWAY"),
-                              Argument::ARGUMENT_VALUE(gateway.c_str()));
+                              Argument::ARGUMENT_VALUE(gw.c_str()));
     }
+}
 
+std::string EthernetInterface::defaultGateway(std::string gateway)
+{
+    normalizeGateway<in_addr>(gateway);
     if (EthernetInterfaceIntf::defaultGateway() == gateway)
     {
         return gateway;
@@ -1007,21 +1023,7 @@ std::string EthernetInterface::defaultGateway(std::string gateway)
 
 std::string EthernetInterface::defaultGateway6(std::string gateway)
 {
-    try
-    {
-        if (!gateway.empty())
-        {
-            gateway = std::to_string(ToAddr<in6_addr>{}(gateway));
-        }
-    }
-    catch (const std::exception& e)
-    {
-        auto msg = fmt::format("Invalid v6 GW `{}`: {}", gateway, e.what());
-        log<level::ERR>(msg.c_str(), entry("GATEWAY=%s", gateway.c_str()));
-        elog<InvalidArgument>(Argument::ARGUMENT_NAME("GATEWAY"),
-                              Argument::ARGUMENT_VALUE(gateway.c_str()));
-    }
-
+    normalizeGateway<in6_addr>(gateway);
     if (EthernetInterfaceIntf::defaultGateway6() == gateway)
     {
         return gateway;

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -294,6 +294,10 @@ ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
             default:
                 throw std::logic_error("Exhausted protocols");
         }
+        if (!validUnicast(addr))
+        {
+            throw std::invalid_argument("not unicast");
+        }
     }
     catch (const std::exception& e)
     {
@@ -305,6 +309,10 @@ ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
     IfAddr ifaddr;
     try
     {
+        if (prefixLength == 0)
+        {
+            throw std::invalid_argument("default route");
+        }
         ifaddr = {addr, prefixLength};
     }
     catch (const std::exception& e)

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -17,6 +17,29 @@ namespace config
 class Parser;
 }
 
+constexpr bool validUnicast(in_addr addr) noexcept
+{
+    const auto s8net = addr.s_addr & hton(0xff000000u);
+    const auto s4net = addr.s_addr & hton(0xf0000000u);
+    return s8net != 0u &&                // 0.0.0.0/8
+           s8net != hton(0x7f000000u) && // 127.0.0.0/8
+           s4net != hton(0xe0000000u) && // 224.0.0.0/4
+           addr.s_addr != 0xffffffffu;   // 255.255.255.255/32
+}
+
+constexpr bool validUnicast(in6_addr addr) noexcept
+{
+    return addr != in6_addr{} && // ::/128
+           addr != in6_addr{0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 0, 0, 0, 1} && // ::1/128
+           addr.s6_addr[0] != 0xff;                    // ff00::/8
+}
+
+constexpr bool validUnicast(InAddrAny addr) noexcept
+{
+    return std::visit([](auto a) { return validUnicast(a); }, addr);
+}
+
 namespace mac_address
 {
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -24,7 +24,8 @@ constexpr bool validUnicast(in_addr addr) noexcept
     return s8net != 0u &&                // 0.0.0.0/8
            s8net != hton(0x7f000000u) && // 127.0.0.0/8
            s4net != hton(0xe0000000u) && // 224.0.0.0/4
-           addr.s_addr != 0xffffffffu;   // 255.255.255.255/32
+           addr.s_addr != 0xffffffffu &&  // 255.255.255.255/32
+           s8net != hton(0xa9fe0000u);   // 169.254.0.0/16
 }
 
 constexpr bool validUnicast(in6_addr addr) noexcept
@@ -32,7 +33,8 @@ constexpr bool validUnicast(in6_addr addr) noexcept
     return addr != in6_addr{} && // ::/128
            addr != in6_addr{0, 0, 0, 0, 0, 0, 0, 0,
                             0, 0, 0, 0, 0, 0, 0, 1} && // ::1/128
-           addr.s6_addr[0] != 0xff;                    // ff00::/8
+           addr.s6_addr[0] != 0xff &&                 // ff00::/8
+	   !(addr.s6_addr[0] == 0xfe && (addr.s6_addr[1] & 0xc0) == 0x80);
 }
 
 constexpr bool validUnicast(InAddrAny addr) noexcept

--- a/test/test_ethernet_interface.cpp
+++ b/test/test_ethernet_interface.cpp
@@ -99,6 +99,19 @@ TEST_F(TestEthernetInterface, NoIPaddress)
 
 TEST_F(TestEthernetInterface, AddIPAddress)
 {
+    EXPECT_THROW(createIPObject(IP::Protocol::IPv4, "127.0.0.1", 16),
+                 InvalidArgument);
+    EXPECT_THROW(createIPObject(IP::Protocol::IPv4, "127.0.0.1", 32),
+                 InvalidArgument);
+    EXPECT_THROW(createIPObject(IP::Protocol::IPv4, "192.168.1.1", 0),
+                 InvalidArgument);
+    EXPECT_THROW(createIPObject(IP::Protocol::IPv6, "::1", 64),
+                 InvalidArgument);
+    EXPECT_THROW(createIPObject(IP::Protocol::IPv6, "::", 128),
+                 InvalidArgument);
+    EXPECT_THROW(createIPObject(IP::Protocol::IPv6, "fe80::1", 0),
+                 InvalidArgument);
+
     createIPObject(IP::Protocol::IPv4, "10.10.10.10", 16);
     EXPECT_THAT(interface.addrs, UnorderedElementsAre(Key(
                                      IfAddr(in_addr{htonl(0x0a0a0a0a)}, 16))));

--- a/test/test_ethernet_interface.cpp
+++ b/test/test_ethernet_interface.cpp
@@ -17,6 +17,7 @@ namespace phosphor
 namespace network
 {
 
+using sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
 using std::literals::string_view_literals::operator""sv;
 using testing::Key;
 using testing::UnorderedElementsAre;
@@ -174,14 +175,18 @@ TEST_F(TestEthernetInterface, addGateway)
     std::string gateway = "10.3.3.3";
     interface.defaultGateway(gateway);
     EXPECT_EQ(interface.defaultGateway(), gateway);
+    EXPECT_THROW(interface.defaultGateway6("127.0.0.10"), InvalidArgument);
+    EXPECT_EQ(interface.defaultGateway(), gateway);
     interface.defaultGateway("");
     EXPECT_EQ(interface.defaultGateway(), "");
 }
 
 TEST_F(TestEthernetInterface, addGateway6)
 {
-    std::string gateway6 = "ffff:ffff:ffff:fe80::1";
+    std::string gateway6 = "fe80::1";
     interface.defaultGateway6(gateway6);
+    EXPECT_EQ(interface.defaultGateway6(), gateway6);
+    EXPECT_THROW(interface.defaultGateway6("::1"), InvalidArgument);
     EXPECT_EQ(interface.defaultGateway6(), gateway6);
     interface.defaultGateway6("");
     EXPECT_EQ(interface.defaultGateway6(), "");

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -13,6 +13,47 @@ namespace phosphor
 namespace network
 {
 
+TEST(TestUtil, ValidateUnicast4)
+{
+    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("1.1.1.1")));
+    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("192.168.1.0")));
+    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("10.30.0.1")));
+    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("8.8.4.4")));
+    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("169.253.255.255")));
+    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("169.254.0.1")));
+    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("169.254.255.255")));
+    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("169.255.0.0")));
+    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("240.0.0.0")));
+    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("255.255.255.1")));
+
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("0.0.0.0")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("0.255.255.255")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("127.0.0.0")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("127.0.0.1")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("127.0.0.83")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("127.253.0.0")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("127.255.255.255")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("224.0.0.0")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("227.30.10.50")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("239.255.255.255")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("255.255.255.255")));
+}
+
+TEST(TestUtil, ValidateUnicast6)
+{
+    EXPECT_TRUE(validUnicast(ToAddr<in6_addr>{}("::2")));
+    EXPECT_TRUE(validUnicast(ToAddr<in6_addr>{}("1::")));
+    EXPECT_TRUE(validUnicast(ToAddr<in6_addr>{}("2001:5938::fd98")));
+    EXPECT_TRUE(validUnicast(ToAddr<in6_addr>{}("fe80::1")));
+    EXPECT_TRUE(validUnicast(ToAddr<in6_addr>{}("feff:ffff:ffff:ffff::")));
+
+    EXPECT_FALSE(validUnicast(ToAddr<in6_addr>{}("::")));
+    EXPECT_FALSE(validUnicast(ToAddr<in6_addr>{}("::1")));
+    EXPECT_FALSE(validUnicast(ToAddr<in6_addr>{}("ff00::")));
+    EXPECT_FALSE(
+        validUnicast(ToAddr<in6_addr>{}("ffff:ffff:ffff:ffff:ffff::")));
+}
+
 TEST(TestUtil, AddrFromBuf)
 {
     std::string tooSmall(1, 'a');


### PR DESCRIPTION
Link Local addresses should not be assignable as IPs .

Tested By :

```
1. Configure Linklocal addres using the command
curl -g -k -H "X-Auth-Token: $bmc_token" -X PATCH -D patch.txt -d '{"IPv6StaticAddresses":[{"Address":"fe80::a94:efff:fe82","PrefixLength":64}]}' https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/eth0
2.Seeing that the link local address is getting configured in the GET command
curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/eth0
 
```

Defect link:
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=546470


