### PR TITLE
Add Network Static Route/Gateway support

### DIFF
--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -117,6 +117,9 @@ class EthernetInterface : public Ifaces
     /** @brief Function used to delete IPv4 static addresses
      */
     void deleteStaticIPv4Addresses();
+    /** @brief Function used to load the static routes.
+     */
+    void loadStaticRoutes(const config::Parser& config);
 
     /** @brief Function to create ipAddress dbus object.
      *  @param[in] addressType - Type of ip address.

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -199,6 +199,7 @@ void Manager::createInterface(const AllIntfInfo& info, bool enabled)
         bus, *this, info, objPath.str, config, enabled);
     intf->loadNameServers(config);
     intf->loadNTPServers(config);
+    intf->loadStaticRoutes(config);
     auto ptr = intf.get();
     interfaces.insert_or_assign(*info.intf.name, std::move(intf));
     interfacesByIdx.insert_or_assign(info.intf.idx, ptr);

--- a/src/static_route.cpp
+++ b/src/static_route.cpp
@@ -82,7 +82,6 @@ size_t StaticRoute::prefixLength(size_t /*prefixLength*/)
 {
     elog<NotAllowed>(REASON("Property update is not allowed"));
 }
-
 IP::Protocol StaticRoute::protocolType(IP::Protocol /*protocolType*/)
 {
     elog<NotAllowed>(REASON("Property update is not allowed"));


### PR DESCRIPTION
This commit enables static route configuration on EthernetInterface Implements CreateStaticRoute method which creates a new d-bus object with StaticRoute interface.

Tested By:
Run StaticRoute D-bus method and verified D-bus object and configuration Delete StaticRoute object

Change-Id: I3fbc6f85ede00b6c1949a0ac85f501037a69c831