### PR TITLE
Configure DHCP4 and DHCP6 parameters independently

### DIFF
--- a/src/dhcp_configuration.cpp
+++ b/src/dhcp_configuration.cpp
@@ -24,15 +24,16 @@ using namespace sdbusplus::xyz::openbmc_project::Common::Error;
 
 Configuration::Configuration(sdbusplus::bus_t& bus,
                              stdplus::const_zstring objPath,
-                             stdplus::PinnedRef<Manager> parent) :
+                             stdplus::PinnedRef<EthernetInterface> parent,
+                             stdplus::const_zstring type) :
     Iface(bus, objPath.c_str(), Iface::action::defer_emit),
-    manager(parent)
+    parent(parent)
 {
     config::Parser conf;
     std::filesystem::directory_entry newest_file;
     time_t newest_time = 0;
-    for (const auto& dirent :
-         std::filesystem::directory_iterator(manager.get().getConfDir()))
+    for (const auto& dirent : std::filesystem::directory_iterator(
+             parent.get().manager.get().getConfDir()))
     {
         struct stat st = {};
         stat(dirent.path().native().c_str(), &st);
@@ -50,10 +51,12 @@ Configuration::Configuration(sdbusplus::bus_t& bus,
         conf.setFile(newest_file.path());
     }
 
-    ConfigIntf::dnsEnabled(getDHCPProp(conf, "UseDNS"), true);
-    ConfigIntf::ntpEnabled(getDHCPProp(conf, "UseNTP"), true);
-    ConfigIntf::hostNameEnabled(getDHCPProp(conf, "UseHostname"), true);
-    ConfigIntf::sendHostNameEnabled(getDHCPProp(conf, "SendHostname"), true);
+    ConfigIntf::dnsEnabled(getDHCPProp(conf, "UseDNS", type.c_str()), true);
+    ConfigIntf::ntpEnabled(getDHCPProp(conf, "UseNTP", type.c_str()), true);
+    ConfigIntf::hostNameEnabled(getDHCPProp(conf, "UseHostname", type.c_str()),
+                                true);
+    ConfigIntf::sendHostNameEnabled(
+        getDHCPProp(conf, "SendHostname", type.c_str()), true);
     emit_object_added();
 }
 
@@ -65,10 +68,8 @@ bool Configuration::sendHostNameEnabled(bool value)
     }
 
     auto name = ConfigIntf::sendHostNameEnabled(value);
-
-    manager.get().writeToConfigurationFile();
-    manager.get().reloadConfigs();
-
+    parent.get().writeConfigurationFile();
+    parent.get().manager.get().reloadConfigs();
     return name;
 }
 
@@ -80,8 +81,8 @@ bool Configuration::hostNameEnabled(bool value)
     }
 
     auto name = ConfigIntf::hostNameEnabled(value);
-    manager.get().writeToConfigurationFile();
-    manager.get().reloadConfigs();
+    parent.get().writeConfigurationFile();
+    parent.get().manager.get().reloadConfigs();
 
     return name;
 }
@@ -94,8 +95,8 @@ bool Configuration::ntpEnabled(bool value)
     }
 
     auto ntp = ConfigIntf::ntpEnabled(value);
-    manager.get().writeToConfigurationFile();
-    manager.get().reloadConfigs();
+    parent.get().writeConfigurationFile();
+    parent.get().manager.get().reloadConfigs();
 
     return ntp;
 }
@@ -108,8 +109,8 @@ bool Configuration::dnsEnabled(bool value)
     }
 
     auto dns = ConfigIntf::dnsEnabled(value);
-    manager.get().writeToConfigurationFile();
-    manager.get().reloadConfigs();
+    parent.get().writeConfigurationFile();
+    parent.get().manager.get().reloadConfigs();
 
     return dns;
 }

--- a/src/dhcp_configuration.hpp
+++ b/src/dhcp_configuration.hpp
@@ -10,7 +10,7 @@ namespace phosphor
 namespace network
 {
 
-class Manager; // forward declaration of network manager.
+class EthernetInterface;
 
 namespace dhcp
 {
@@ -34,7 +34,8 @@ class Configuration : public Iface
      *  @param[in] parent - Parent object.
      */
     Configuration(sdbusplus::bus_t& bus, stdplus::const_zstring objPath,
-                  stdplus::PinnedRef<Manager> parent);
+                  stdplus::PinnedRef<EthernetInterface> parent,
+                  stdplus::const_zstring type);
 
     /** @brief If true then DNS servers received from the DHCP server
      *         will be used and take precedence over any statically
@@ -66,7 +67,7 @@ class Configuration : public Iface
      */
     bool sendHostNameEnabled(bool value) override;
 
-    /* @brief Network Manager needed the below function to know the
+    /* @brief Ethernet Interface needed the below function to know the
      *        value of the properties (ntpEnabled,dnsEnabled,hostnameEnabled
               sendHostNameEnabled).
      *
@@ -77,8 +78,8 @@ class Configuration : public Iface
     using ConfigIntf::sendHostNameEnabled;
 
   private:
-    /** @brief Network Manager object. */
-    stdplus::PinnedRef<Manager> manager;
+    /** @brief Ethernet Interface object. */
+    stdplus::PinnedRef<EthernetInterface> parent;
 };
 
 } // namespace dhcp

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -110,6 +110,7 @@ EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
         EthernetInterface::defaultGateway6(std::to_string(*info.defgw6), true);
     }
     emit_object_added();
+    addDHCPConfigurations();
 
     if (info.intf.vlan_id)
     {
@@ -941,17 +942,27 @@ void EthernetInterface::writeConfigurationFile()
         }
     }
     {
-        auto& dhcp = config.map["DHCP"].emplace_back();
-        dhcp["ClientIdentifier"].emplace_back("mac");
-        const auto& conf = manager.get().getDHCPConf();
+        auto& dhcp4 = config.map["DHCPv4"].emplace_back();
+        dhcp4["ClientIdentifier"].emplace_back("mac");
+        const auto& conf = *dhcpConfigs["dhcp4"];
         auto dns_enabled = conf.dnsEnabled() ? "true" : "false";
-        dhcp["UseDNS"].emplace_back(dns_enabled);
-        dhcp["UseDomains"].emplace_back(dns_enabled);
-        dhcp["UseNTP"].emplace_back(conf.ntpEnabled() ? "true" : "false");
-        dhcp["UseHostname"].emplace_back(conf.hostNameEnabled() ? "true"
-                                                                : "false");
-        dhcp["SendHostname"].emplace_back(conf.sendHostNameEnabled() ? "true"
-                                                                     : "false");
+        dhcp4["UseDNS"].emplace_back(dns_enabled);
+        dhcp4["UseDomains"].emplace_back(dns_enabled);
+        dhcp4["UseNTP"].emplace_back(conf.ntpEnabled() ? "true" : "false");
+        dhcp4["UseHostname"].emplace_back(conf.hostNameEnabled() ? "true"
+                                                                 : "false");
+        dhcp4["SendHostname"].emplace_back(
+            conf.sendHostNameEnabled() ? "true" : "false");
+    }
+    {
+        auto& dhcp6 = config.map["DHCPv6"].emplace_back();
+        const auto& conf = *dhcpConfigs["dhcp6"];
+        auto dns_enabled = conf.dnsEnabled() ? "true" : "false";
+        dhcp6["UseDNS"].emplace_back(dns_enabled);
+        dhcp6["UseDomains"].emplace_back(dns_enabled);
+        dhcp6["UseNTP"].emplace_back(conf.ntpEnabled() ? "true" : "false");
+        dhcp6["UseHostname"].emplace_back(conf.hostNameEnabled() ? "true"
+                                                                 : "false");
     }
 
     {
@@ -1161,6 +1172,16 @@ void EthernetInterface::VlanProperties::delete_()
     }
 
     eth.get().manager.get().reloadConfigs();
+}
+
+void EthernetInterface::addDHCPConfigurations()
+{
+    this->dhcpConfigs.emplace(
+        "dhcp4", std::make_unique<dhcp::Configuration>(bus, objPath + "/dhcp4",
+                                                       *this, "dhcp4"));
+    this->dhcpConfigs.emplace(
+        "dhcp6", std::make_unique<dhcp::Configuration>(bus, objPath + "/dhcp6",
+                                                       *this, "dhcp6"));
 }
 
 } // namespace network

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "dhcp_configuration.hpp"
 #include "ipaddress.hpp"
 #include "neighbor.hpp"
 #include "static_route.hpp"
@@ -276,6 +277,14 @@ class EthernetInterface : public Ifaces
      *  @returns true/false value if the address is static
      */
     bool originIsManuallyAssigned(IP::AddressOrigin origin);
+
+    /** @brief Function to add DHCP configurations.
+     */
+    void addDHCPConfigurations();
+
+    /** @brief Map of DHCP conf objects.
+     */
+    string_umap<std::unique_ptr<dhcp::Configuration>> dhcpConfigs;
 };
 
 } // namespace network

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -154,8 +154,6 @@ Manager::Manager(stdplus::PinnedRef<sdbusplus::bus_t> bus,
     std::filesystem::create_directories(confDir);
     systemConf = std::make_unique<phosphor::network::SystemConfiguration>(
         bus, (this->objPath / "config").str);
-    dhcpConf = std::make_unique<phosphor::network::dhcp::Configuration>(
-        bus, (this->objPath / "dhcp").str, *this);
 }
 
 void Manager::createInterface(const AllIntfInfo& info, bool enabled)

--- a/src/network_manager.hpp
+++ b/src/network_manager.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include "dhcp_configuration.hpp"
 #include "ethernet_interface.hpp"
 #include "system_configuration.hpp"
 #include "types.hpp"
@@ -92,14 +91,6 @@ class Manager : public ManagerIface
         return *systemConf;
     }
 
-    /** @brief gets the dhcp conf object.
-     *
-     */
-    inline auto& getDHCPConf()
-    {
-        return *dhcpConf;
-    }
-
     /** @brief Arms a timer to tell systemd-network to reload all of the network
      * configurations
      */
@@ -142,9 +133,6 @@ class Manager : public ManagerIface
 
     /** @brief pointer to system conf object. */
     std::unique_ptr<SystemConfiguration> systemConf = nullptr;
-
-    /** @brief pointer to dhcp conf object. */
-    std::unique_ptr<dhcp::Configuration> dhcpConf = nullptr;
 
     /** @brief Network Configuration directory. */
     std::filesystem::path confDir;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -211,9 +211,14 @@ DHCPVal getDHCPValue(const config::Parser& config)
         .value_or(DHCPVal{.v4 = true, .v6 = true});
 }
 
-bool getDHCPProp(const config::Parser& config, std::string_view key)
+bool getDHCPProp(const config::Parser& config, std::string_view key,
+                 std::string_view type)
 {
-    return systemdParseLast(config, "DHCP", key, config::parseBool)
+    if (nullptr == config.map.getLastValueString(type, key))
+    {
+        type = "DHCP";
+    }
+    return systemdParseLast(config, type, key, config::parseBool)
         .value_or(true);
 }
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -83,7 +83,8 @@ DHCPVal getDHCPValue(const config::Parser& config);
  *  @param[in] config - The parsed configuration.
  *  @param[in] key - The property name.
  */
-bool getDHCPProp(const config::Parser& config, std::string_view key);
+bool getDHCPProp(const config::Parser& config, std::string_view key,
+                 std::string_view type);
 
 namespace internal
 {


### PR DESCRIPTION
At present, DHCP parameters like DNSEnabled, NTPEnabled etc. are shared between DHCPv4 and DHCPv6 in the network configuration.

Hence any update on the ipv4 parameters impacts the ipv6 and get applied to both the interfaces.

This change is to enable the possibility to configure DHCP attributes independently, by having different dbus objects for dhcp4 and dhcp6 and moving the dhcp configuration from network level to ethernet interface.

tested by:

Used the busctl command to set and get the parameter values individually for both DHCPv4 and DHCPv6.
Verified the network configuration file is updated accordingly
Code update from 1030 to 1050 and confirmed the DHCP4 configuration is persisted.

Tree Structure:
busctl tree xyz.openbmc_project.Network
`-/xyz
  `-/xyz/openbmc_project
    `-/xyz/openbmc_project/network
      |-/xyz/openbmc_project/network/config
      |-/xyz/openbmc_project/network/eth0
      | |-/xyz/openbmc_project/network/eth0/dhcp4
      | `-/xyz/openbmc_project/network/eth0/dhcp6
      `-/xyz/openbmc_project/network/eth1
        |-/xyz/openbmc_project/network/eth1/dhcp4
        `-/xyz/openbmc_project/network/eth1/dhcp6

Upstream commit : https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/63124
Change-Id: If7dbbf596bdaf866ea459d631e716153f54302ec