### PR TITLE
Revert DHCPv6 standalone support 

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -911,11 +911,6 @@ void EthernetInterface::writeConfigurationFile()
         lla.emplace_back("no");
 #endif
         network["IPv6AcceptRA"].emplace_back(ipv6AcceptRA() ? "true" : "false");
-        if (dhcp6())
-        {
-            config.map["DHCPv6"].emplace_back()["WithoutRA"].emplace_back(
-                "solicit");
-        }
         network["DHCP"].emplace_back(dhcp4() ? (dhcp6() ? "true" : "ipv4")
                                              : (dhcp6() ? "ipv6" : "false"));
         {


### PR DESCRIPTION
As per discussions with PEs, eBMC would expected not do anything with ipv6 unless the ebmc gets a ipv6 "router Advertisement" per RFC.

This commit reverts DHCPv6 standalone support.