### PR TITLE
ethernet_interface: Validate linklocal addresses

### DIFF
--- a/src/util.hpp
+++ b/src/util.hpp
@@ -24,7 +24,8 @@ constexpr bool validUnicast(in_addr addr) noexcept
     return s8net != 0u &&                // 0.0.0.0/8
            s8net != hton(0x7f000000u) && // 127.0.0.0/8
            s4net != hton(0xe0000000u) && // 224.0.0.0/4
-           addr.s_addr != 0xffffffffu;   // 255.255.255.255/32
+           addr.s_addr != 0xffffffffu && // 255.255.255.255/32
+           s8net != hton(0xa9000000u);   // 169.254.0.0/16
 }
 
 constexpr bool validUnicast(in6_addr addr) noexcept
@@ -32,7 +33,8 @@ constexpr bool validUnicast(in6_addr addr) noexcept
     return addr != in6_addr{} && // ::/128
            addr != in6_addr{0, 0, 0, 0, 0, 0, 0, 0,
                             0, 0, 0, 0, 0, 0, 0, 1} && // ::1/128
-           addr.s6_addr[0] != 0xff;                    // ff00::/8
+           addr.s6_addr[0] != 0xff &&                  // ff00::/8
+           !(addr.s6_addr[0] == 0xfe && (addr.s6_addr[1] & 0xc0) == 0x80);
 }
 
 constexpr bool validUnicast(InAddrAny addr) noexcept

--- a/test/test_ethernet_interface.cpp
+++ b/test/test_ethernet_interface.cpp
@@ -198,11 +198,8 @@ TEST_F(TestEthernetInterface, addGateway)
 
 TEST_F(TestEthernetInterface, addGateway6)
 {
-    std::string gateway6 = "fe80::1";
-    interface.defaultGateway6(gateway6);
-    EXPECT_EQ(interface.defaultGateway6(), gateway6);
+    EXPECT_THROW(interface.defaultGateway6("fe80::1"), InvalidArgument);
     EXPECT_THROW(interface.defaultGateway6("::1"), InvalidArgument);
-    EXPECT_EQ(interface.defaultGateway6(), gateway6);
     interface.defaultGateway6("");
     EXPECT_EQ(interface.defaultGateway6(), "");
 }

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -19,10 +19,10 @@ TEST(TestUtil, ValidateUnicast4)
     EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("192.168.1.0")));
     EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("10.30.0.1")));
     EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("8.8.4.4")));
-    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("169.253.255.255")));
-    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("169.254.0.1")));
-    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("169.254.255.255")));
-    EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("169.255.0.0")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("169.253.255.255")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("169.254.0.1")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("169.254.255.255")));
+    EXPECT_FALSE(validUnicast(ToAddr<in_addr>{}("169.255.0.0")));
     EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("240.0.0.0")));
     EXPECT_TRUE(validUnicast(ToAddr<in_addr>{}("255.255.255.1")));
 
@@ -44,7 +44,7 @@ TEST(TestUtil, ValidateUnicast6)
     EXPECT_TRUE(validUnicast(ToAddr<in6_addr>{}("::2")));
     EXPECT_TRUE(validUnicast(ToAddr<in6_addr>{}("1::")));
     EXPECT_TRUE(validUnicast(ToAddr<in6_addr>{}("2001:5938::fd98")));
-    EXPECT_TRUE(validUnicast(ToAddr<in6_addr>{}("fe80::1")));
+    EXPECT_FALSE(validUnicast(ToAddr<in6_addr>{}("fe80::1")));
     EXPECT_TRUE(validUnicast(ToAddr<in6_addr>{}("feff:ffff:ffff:ffff::")));
 
     EXPECT_FALSE(validUnicast(ToAddr<in6_addr>{}("::")));


### PR DESCRIPTION
-linklocal address should not be assignable
 as static IPs or Gateway

Defect URL:https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=546470

```
TESTED BY :
1)  curl -k -H “X-Auth-Token: $bmc_token” -X PATCH -D patch.txt -d ‘{“IPv6StaticAddresses”: [{“Address”: “FF00::“,”PrefixLength”: 8}]}’ https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1

- should give error with Message “The value ‘FF00::’ for the property Address is of a different format than the property can accept.“

2)curl -k -H "X-Auth-Token: $bmc_token" -X PATCH -d '{"IPv4StaticAddresses": [{"Address": "169.254.0.1","SubnetMask": "255.255.255.0","Gateway":"169.254.0.1"}]}' https://${bmc}/redfish/v1/Managers/bmc/EthernetInterfaces/eth0

- should give error with Message “The value 169.254.0.1‘’ for the property Address is of a different format than the property can accept.“

```
upstream URL:https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/64424/3

Change-Id: I79fc7b9cef491cdc30c51a17f2f323faa84af54f