### PR TITLE
1050: Delete DHCP IP when disabled

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -1084,6 +1084,14 @@ HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled(DHCPConf value)
                 else
                 {
                     method = "IPv4Static";
+                    // Reset IPv4 to the defaults only when dhcpv4 is disabled;
+                    // if the old4 is false (which means static), then
+                    // reset shouldn't happen in order to restore the static
+                    // v4 configuration
+                    if (old4 == true)
+                    {
+                        (itr->second)->resetBaseBiosTableAttrs("IPv4");
+                    }
                 }
             }
             else if ((itr->second)->type() == HypIP::Protocol::IPv6)
@@ -1101,6 +1109,14 @@ HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled(DHCPConf value)
                 else
                 {
                     method = "IPv6Static";
+                    // Reset IPv6 to the defaults only when dhcpv6 is disabled;
+                    // if old6/oldra is false (which means static), then
+                    // reset shouldn't happen in order to restore the static
+                    // v6 configuration
+                    if (old6 == true || oldra == true)
+                    {
+                        (itr->second)->resetBaseBiosTableAttrs("IPv6");
+                    }
                 }
             }
             if (!method.empty())

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -29,7 +29,7 @@ constexpr bool validUnicast(in_addr addr) noexcept
 
 constexpr bool validUnicast(in6_addr addr) noexcept
 {
-    return addr != in6_addr{} && // ::/128
+    return addr != in6_addr{} &&                       // ::/128
            addr != in6_addr{0, 0, 0, 0, 0, 0, 0, 0,
                             0, 0, 0, 0, 0, 0, 0, 1} && // ::1/128
            addr.s6_addr[0] != 0xff;                    // ff00::/8


### PR DESCRIPTION
#### test commit
```
```
#### Fix CI failure
```
Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
```
#### Delete DHCP IP when disabled
```
This commit helps deletes the dhcp v4/v6 IP whenever it
is disabled. Currently, when either v4/v6 is disabled, the
method just changes to static with the dhcp IP being present
in the dbus object, which is incorrect.

Tested By:
* With DHCPv6 enabled, disable DHCPv6 - IPv6 defaulted to ::
[1] PATCH -d '{"DHCPv6": {"OperatingMode":"Disabled"}}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0

* With DHCPv4 enabled, disable DHCPv4 - IPv4 defaulted to 0s
[1] PATCH -d '{"DHCPv4": {"DHCPEnabled":false}}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
```