### PR TITLE
VMI: Validate ipv6 static loopback & multicast add

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -848,6 +848,10 @@ ObjectPath HypEthInterface::ip(HypIP::Protocol protType, std::string ipaddress,
             default:
                 throw std::logic_error("Exhausted protocols");
         }
+        if (!validUnicast(addr))
+        {
+            throw std::invalid_argument("not unicast");
+        }
     }
     catch (const std::exception& e)
     {

--- a/test/ibm/hypervisor-network-mgr-test/mock_hyp_ethernet_interface.hpp
+++ b/test/ibm/hypervisor-network-mgr-test/mock_hyp_ethernet_interface.hpp
@@ -67,10 +67,15 @@ class MockHypEthernetInterface : public HypEthInterface
                 default:
                     return false;
             }
+            if (!validUnicast(addr))
+            {
+                throw std::invalid_argument("not unicast");
+            }
         }
         catch (const std::exception& e)
         {
             // Invalid ip address
+            return false;
         }
 
         IfAddr ifaddr;

--- a/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
+++ b/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
@@ -82,6 +82,14 @@ TEST_F(TestHypEthernetInterface, AddIPAddress)
     {
         EXPECT_EQ(true, isIPObjExist("eth0", "10.10.10.10"));
     }
+
+    addressType = HypIP::Protocol::IPv6;
+    EXPECT_EQ(false, interface.createIP(interface, "eth0", addressType,
+                                        "::", 128, ""));
+    EXPECT_EQ(false, interface.createIP(interface, "eth0", addressType, "::1",
+                                        128, ""));
+    EXPECT_EQ(false, interface.createIP(interface, "eth0", addressType,
+                                        "ff00::1", 8, ""));
 }
 
 TEST_F(TestHypEthernetInterface, AddMultipleAddress)


### PR DESCRIPTION
Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=546486

Tested By:

Loopback Address
curl -k -H "X-Auth-Token:$bmc_token" -X PATCH -D patch.txt 
-d '{"IPv6StaticAddresses": [{"Address":"::1","PrefixLength":128}]}'
https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1

  "Address@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value '::1' for the property Address is of a
                  different format than the property can accept.",
      "MessageArgs": [
        "::1",
        "Address"
      ],
      "MessageId": "Base.1.13.0.PropertyValueFormatError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the
      request body and resubmit the request if the operation failed."
    }
  ]
}

Multicast Address
curl -k -H "X-Auth-Token:$bmc_token" -X PATCH -D patch.txt 
-d '{"IPv6StaticAddresses": [{"Address":"FF00::","PrefixLength":8}]}'
https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth1

{
  "Address@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value 'FF00::' for the property Address is of a
                  different format than the property can accept.",
      "MessageArgs": [
        "::1",
        "Address"
      ],
      "MessageId": "Base.1.13.0.PropertyValueFormatError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the
      request body and resubmit the request if the operation failed."
    }
  ]
}