### PR TITLE
Added WithoutRA flag in net inter default config.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,7 @@ conf_data.set(
 conf_data.set('SYNC_MAC_FROM_INVENTORY', get_option('sync-mac'))
 conf_data.set('PERSIST_MAC', get_option('persist-mac'))
 conf_data.set10('FORCE_SYNC_MAC_FROM_INVENTORY', get_option('force-sync-mac'))
-conf_data.set_quoted('ENABLE_DHCP6_WITHOUT_RA', get_option('enable-dhcp6-without-ra'))
+conf_data.set('ENABLE_DHCP6_WITHOUT_RA', get_option('enable-dhcp6-without-ra'))
 
 sdbusplus_dep = dependency('sdbusplus')
 sdbusplusplus_prog = find_program('sdbus++', native: true)

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -920,7 +920,9 @@ void EthernetInterface::writeConfigurationFile()
         lla.emplace_back("no");
 #endif
         network["IPv6AcceptRA"].emplace_back(ipv6AcceptRA() ? "true" : "false");
-        if (dhcp6() && ("solicit" == std::string(ENABLE_DHCP6_WITHOUT_RA)))
+
+        std::string withOutRa = TOSTRING(ENABLE_DHCP6_WITHOUT_RA);
+        if (dhcp6() && ("solicit" == withOutRa))
         {
             config.map["DHCPv6"].emplace_back()["WithoutRA"].emplace_back(
                 "solicit");

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -22,6 +22,8 @@
 #include <xyz/openbmc_project/Network/VLAN/server.hpp>
 #include <xyz/openbmc_project/Object/Delete/server.hpp>
 
+#define TOSTRING(x) #x
+
 namespace phosphor
 {
 namespace network


### PR DESCRIPTION
Added WithoutRA flag in 60-phosphor-networkd-default.network.in
By default it is disabled with a value "no".

"WithoutRA=no" is set, RA message is required for DHCPv6 configuration.
Tested By: After Reset BMC and server settings,
60-phosphor-networkd-default.network file's output.

[Match]
Type=ether
[DHCPv6]
WithoutRA=solicit         -->new entry
[Network]
DHCP=true
LinkLocalAddressing=True
IPv6AcceptRA=False
[DHCP]
ClientIdentifier=mac
UseDNS=true
UseDomains=true
UseNTP=true
UseHostname=true
SendHostname=true
[IPv6AcceptRA]
DHCPv6Client=true

Change-Id: I3f1414fff838182f55366bea26b1127e3aeeafe9