### PR TITLE
Fix Systemd-network reload while DHCP Enable/Disable

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -549,16 +549,16 @@ void EthernetInterface::deleteStaticIPv4Addresses()
             ptr = std::move(it->second);
             it = addrs.erase(it);
             writeConfigurationFile();
-            manager.get().reloadConfigs();
-            auto msg = fmt::format(
-                "deleteStaticIPv4Addresses(): reloaded systemd-networkd");
-            log<level::INFO>(msg.c_str());
         }
         else
         {
             it++;
         }
     }
+    manager.get().reloadConfigs();
+    auto msg =
+        fmt::format("deleteStaticIPv4Addresses(): reloaded systemd-networkd");
+    log<level::INFO>(msg.c_str());
 }
 
 EthernetInterface::DHCPConf EthernetInterface::dhcpEnabled(DHCPConf value)


### PR DESCRIPTION
This commit fixes reloads Systemd-networkd while deleting IPv4 static addresses

Tested By:
Enable & Disable DHCPv4 in loop 
Add IPv4 static address while DHCPv4 enabled
Enable DHCPv4 with multiple IPv4 static addresses configured

