### PR TITLE
Fixed unwanted dhcp6 enabling on adding static ipv4

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -302,7 +302,7 @@ bool EthernetInterface::dhcpIsEnabled(IP::Protocol family, bool ignoreProtocol)
 
 void EthernetInterface::disableDHCP(IP::Protocol protocol)
 {
-    DHCPConf dhcpState = EthernetInterfaceIntf::dhcpEnabled();
+    DHCPConf dhcpState = dhcpEnabled();
     if (dhcpState == EthernetInterface::DHCPConf::both)
     {
         if (protocol == IP::Protocol::IPv4)


### PR DESCRIPTION
This scenario is related to one of the cases where we avoid coexistence of DHCPv4 and static IPv4 address.

Currently, when DHCPv4 is enabled & DHCPv6 is disabled, on adding a static v4 address DHCPv6 attribute is getting enabled

This commit will fix enabling of DHCPv6 for the above scenario.

Tested by:
DHCPv4 is enabled & DHCPv6 is disabled, by adding static IPv4 address DHCPv6 attribute is not getting enabled.