### PR TITLE
DHCP: Populate nameservers D-bus property from resolv.conf

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -783,7 +783,12 @@ ServerList EthernetInterface::getNTPServerFromTimeSyncd()
     return servers;
 }
 
-ServerList EthernetInterface::getNameServerFromResolvd()
+ServerList EthernetInterface::nameservers() const
+{
+    return getNameServerFromResolvd();
+}
+
+ServerList EthernetInterface::getNameServerFromResolvd() const
 {
     ServerList servers;
     auto OBJ_PATH = fmt::format("{}{}", RESOLVED_SERVICE_PATH, ifIdx);

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -197,6 +197,9 @@ class EthernetInterface : public Ifaces
      */
     ServerList staticNTPServers(ServerList value) override;
 
+    /** @brief Get value of nameservers */
+    ServerList nameservers() const override;
+
     /** @brief sets the Static DNS/nameservers.
      *  @param[in] value - vector of DNS servers.
      */
@@ -246,7 +249,7 @@ class EthernetInterface : public Ifaces
     /** @brief get the name server details from the network conf
      *
      */
-    virtual ServerList getNameServerFromResolvd();
+    virtual ServerList getNameServerFromResolvd() const;
 
     /** @brief Persistent sdbusplus DBus bus connection. */
     stdplus::PinnedRef<sdbusplus::bus_t> bus;

--- a/test/mock_ethernet_interface.hpp
+++ b/test/mock_ethernet_interface.hpp
@@ -17,7 +17,7 @@ class MockEthernetInterface : public EthernetInterface
     }
 
     MOCK_METHOD((ServerList), getNTPServerFromTimeSyncd, (), (override));
-    MOCK_METHOD((ServerList), getNameServerFromResolvd, (), (override));
+    MOCK_METHOD((ServerList), getNameServerFromResolvd, (), (const override));
 };
 } // namespace network
 } // namespace phosphor


### PR DESCRIPTION
Currently when DHCP enabled, nameservers D-bus property does not have updated DHCP provided nameservers.

This commit populates nameservers D-bus property from resolv.conf

Tested By: verify nameservers D-bus property value with DHCP enable/disable

Change-Id: If1a2508927d5f4f0c9c5d8b3f533fdf384d68821