### PR TITLE
Network: Disable IPv4 LinkLocal on Eth1

### DIFF
--- a/60-phosphor-networkd-eth1-default.network.in
+++ b/60-phosphor-networkd-eth1-default.network.in
@@ -1,11 +1,11 @@
 [Match]
-Name=eth0
+Name=eth1
 Name=!lo
 [DHCPv6]
 WithoutRA=@ENABLE_DHCP6_WITHOUT_RA@
 [Network]
 DHCP=true
-LinkLocalAddressing=@LINK_LOCAL_AUTOCONFIGURATION@
+LinkLocalAddressing=ipv6
 IPv6AcceptRA=@ENABLE_IPV6_ACCEPT_RA@
 [DHCP]
 ClientIdentifier=mac

--- a/meson.build
+++ b/meson.build
@@ -86,6 +86,14 @@ configure_file(
     'systemdutildir') / 'network')
 
 configure_file(
+  input: '60-phosphor-networkd-eth1-default.network.in',
+  output: '60-phosphor-networkd-eth1-default.network',
+  configuration: conf_data,
+  install: true,
+  install_dir: dependency('systemd').get_variable(
+    'systemdutildir') / 'network')
+
+configure_file(
   input: 'xyz.openbmc_project.Network.service.in',
   output: 'xyz.openbmc_project.Network.service',
   configuration: {

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -929,7 +929,14 @@ void EthernetInterface::writeConfigurationFile()
         auto& network = config.map["Network"].emplace_back();
         auto& lla = network["LinkLocalAddressing"];
 #ifdef LINK_LOCAL_AUTOCONFIGURATION
-        lla.emplace_back("yes");
+        if (interfaceName() == "eth0")
+        {
+            lla.emplace_back("yes");
+        }
+        else if (interfaceName() == "eth1")
+        {
+            lla.emplace_back("ipv6");
+        }
 #else
         lla.emplace_back("no");
 #endif


### PR DESCRIPTION
Currently both interfaces have LinkLocalAddressing enabled,
but only one ethernet interface linklocal IP reachable since both
interfaces have got link local address of same subnet.
This commit disables IPv4 linklocalAddressing on eth1 interface
Adds a new default config file for eth1 interface to handle factory reset cases

Tested By: Verify linklocal addresses on interfaces
verified factory reset