### PR TITLE
Follow-up PR for DHCP4 and DHCP6 parameter configuration.

### DIFF
--- a/src/dhcp_configuration.cpp
+++ b/src/dhcp_configuration.cpp
@@ -55,8 +55,12 @@ Configuration::Configuration(sdbusplus::bus_t& bus,
     ConfigIntf::ntpEnabled(getDHCPProp(conf, "UseNTP", type.c_str()), true);
     ConfigIntf::hostNameEnabled(getDHCPProp(conf, "UseHostname", type.c_str()),
                                 true);
-    ConfigIntf::sendHostNameEnabled(
-        getDHCPProp(conf, "SendHostname", type.c_str()), true);
+    if (std::string(type.c_str()) == "dhcp4")
+    {
+        ConfigIntf::sendHostNameEnabled(
+            getDHCPProp(conf, "SendHostname", type.c_str()), true);
+    }
+
     emit_object_added();
 }
 

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -112,7 +112,6 @@ EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
     }
     addDHCPConfigurations();
     emit_object_added();
-    addDHCPConfigurations();
 
     if (info.intf.vlan_id)
     {

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -110,6 +110,7 @@ EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
     {
         EthernetInterface::defaultGateway6(std::to_string(*info.defgw6), true);
     }
+    addDHCPConfigurations();
     emit_object_added();
     addDHCPConfigurations();
 

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -12,6 +12,7 @@
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
 #include <stdplus/pinned.hpp>
+#include <stdplus/str/maps.hpp>
 #include <stdplus/zstring_view.hpp>
 #include <string>
 #include <vector>

--- a/src/inventory_mac.cpp
+++ b/src/inventory_mac.cpp
@@ -269,7 +269,6 @@ void watchEthernetInterface(sdbusplus::bus_t& bus)
         else
         {
             registerSignals(bus);
-            EthInterfaceMatch = nullptr;
 
             if (setInventoryMACOnSystem(bus, infname))
             {
@@ -311,12 +310,10 @@ void watchEthernetInterface(sdbusplus::bus_t& bus)
     // collected by the time network service has come up, better to check the
     // VPD directly and set the MAC Address on the respective Interface.
 
-    bool registeredSignals = false;
     for (const auto& interfaceString : configJson.items())
     {
-        if ((FORCE_SYNC_MAC_FROM_INVENTORY ||
-             !std::filesystem::exists(firstBootPath + interfaceString.key())) &&
-            !registeredSignals)
+        if (FORCE_SYNC_MAC_FROM_INVENTORY ||
+            !std::filesystem::exists(firstBootPath + interfaceString.key()))
         {
             auto msg = fmt::format("{}, check VPD for MAC",
                                    (FORCE_SYNC_MAC_FROM_INVENTORY)
@@ -328,7 +325,6 @@ void watchEthernetInterface(sdbusplus::bus_t& bus)
                 "interface='org.freedesktop.DBus.ObjectManager',type='signal',"
                 "member='InterfacesAdded',path='/xyz/openbmc_project/network'",
                 mycallback);
-            registeredSignals = true;
 
             for (const auto& intf : manager->interfaces)
             {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -214,10 +214,13 @@ DHCPVal getDHCPValue(const config::Parser& config)
 bool getDHCPProp(const config::Parser& config, std::string_view key,
                  std::string_view type)
 {
-    if (nullptr == config.map.getLastValueString(type, key))
+    type = (type == "dhcp4") ? "DHCPv4" : "DHCPv6";
+
+    if (config.map.find(type) == config.map.end())
     {
         type = "DHCP";
     }
+
     return systemdParseLast(config, type, key, config::parseBool)
         .value_or(true);
 }


### PR DESCRIPTION
This is a follow-up PR for https://github.com/ibm-openbmc/phosphor-networkd/pull/96
It includes the review comments incorporations.

Upstream : https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/63124
tested by:
Used the busctl command to set and get the parameter values individually for both DHCPv4 and DHCPv6.
Verified the network configuration file is updated accordingly.
Verified unwanted logs are not printed in the journal logs

Change-Id: If7dbbf596bdaf866ea459d631e716153f54302ec