### PR TITLE
inventory_mac: Fix Update MAC for eth1

### DIFF
--- a/src/inventory_mac.cpp
+++ b/src/inventory_mac.cpp
@@ -269,7 +269,6 @@ void watchEthernetInterface(sdbusplus::bus_t& bus)
         else
         {
             registerSignals(bus);
-            EthInterfaceMatch = nullptr;
 
             if (setInventoryMACOnSystem(bus, infname))
             {
@@ -311,12 +310,10 @@ void watchEthernetInterface(sdbusplus::bus_t& bus)
     // collected by the time network service has come up, better to check the
     // VPD directly and set the MAC Address on the respective Interface.
 
-    bool registeredSignals = false;
     for (const auto& interfaceString : configJson.items())
     {
-        if ((FORCE_SYNC_MAC_FROM_INVENTORY ||
-             !std::filesystem::exists(firstBootPath + interfaceString.key())) &&
-            !registeredSignals)
+        if (FORCE_SYNC_MAC_FROM_INVENTORY ||
+            !std::filesystem::exists(firstBootPath + interfaceString.key()))
         {
             auto msg = fmt::format("{}, check VPD for MAC",
                                    (FORCE_SYNC_MAC_FROM_INVENTORY)
@@ -328,7 +325,6 @@ void watchEthernetInterface(sdbusplus::bus_t& bus)
                 "interface='org.freedesktop.DBus.ObjectManager',type='signal',"
                 "member='InterfacesAdded',path='/xyz/openbmc_project/network'",
                 mycallback);
-            registeredSignals = true;
 
             for (const auto& intf : manager->interfaces)
             {


### PR DESCRIPTION
Whenever the network daemon starts, and if the inventory manager has already started, then networkd should read the MAC address from the inventory and update the dbus object and configuration file.

Currently, this is being done for just eth0 interface and is exiting before updating the MAC on eth1.

This commit fixes the above issue.

Upstream : https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/66592

Tested-By:
* Restarted network manager service; checked MAC on both inventory and network dbus & config files for both interfaces.
* Checked for both reboot and factory reset usecases.

Change-Id: I49d94f22d914f74c23999a5fe175bfc4d97759a9