### PR TITLE
Network Hypervisor IPv6 address persistency

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -45,8 +45,18 @@ HypIPAddress::HypIPAddress(sdbusplus::bus::bus& bus, const char* objPath,
     this->intf = intf;
     emit_object_added();
 
+    std::string addressType;
+    if (HypIP::type() == HypIP::Protocol::IPv4)
+    {
+        addressType = "ipv4";
+    }
+    else if (HypIP::type() == HypIP::Protocol::IPv6)
+    {
+        addressType = "ipv6";
+    }
+
     // De-serialize the persisted data and set the dbus property
-    persistdata::deserialize(nwIPConfigList, intf);
+    persistdata::deserialize(nwIPConfigList, intf, addressType);
     setEnabledProp();
 }
 
@@ -87,8 +97,18 @@ bool HypIPAddress::enabled(bool value)
         // Insert the key value pair (Enabled, true)
         nwIPConfigList.insert(std::pair<std::string, bool>(propName, value));
     }
+
+    std::string type{};
+    if (HypIP::type() == HypIP::Protocol::IPv4)
+    {
+        type = "ipv4";
+    }
+    else if (HypIP::type() == HypIP::Protocol::IPv6)
+    {
+        type = "ipv6";
+    }
     // serialize the data
-    persistdata::serialize(nwIPConfigList, intf);
+    persistdata::serialize(nwIPConfigList, intf, type);
     return value;
 }
 

--- a/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.cpp
@@ -12,9 +12,10 @@ namespace persistdata
 
 using namespace phosphor::logging;
 
-void serialize(const NwConfigPropMap& list, std::string intf)
+void serialize(const NwConfigPropMap& list, std::string intf, std::string type)
 {
-    std::string filePath = HYP_NW_CONFIG_PERSIST_PATH + intf + "_network";
+    std::string filePath =
+        HYP_NW_CONFIG_PERSIST_PATH + intf + "_" + type + "_network";
 
     // Create directory if it doesnot exist
     if (!std::filesystem::exists(HYP_NW_CONFIG_PERSIST_PATH.c_str()))
@@ -50,10 +51,10 @@ void serialize(const NwConfigPropMap& list, std::string intf)
     }
 }
 
-bool deserialize(NwConfigPropMap& list, std::string intf)
+bool deserialize(NwConfigPropMap& list, std::string intf, std::string type)
 {
-    std::string filePath = HYP_NW_CONFIG_PERSIST_PATH + intf + "_network";
-
+    std::string filePath =
+        HYP_NW_CONFIG_PERSIST_PATH + intf + "_" + type + "_network";
     try
     {
         if (std::filesystem::exists(filePath))

--- a/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.hpp
@@ -22,13 +22,13 @@ const std::string HYP_NW_CONFIG_PERSIST_PATH = "/var/lib/network/hypervisor/";
  *  @param[in] list - list of hypervisor n/w config properties.
  *  @param[in] intf - hyp eth interface label (eth0/eth1).
  */
-void serialize(const NwConfigPropMap& list, std::string intf);
+void serialize(const NwConfigPropMap& list, std::string intf, std::string type);
 
 /** @brief Deserialze a persisted list of n/w config properties.
  *  @param[out] list - list of n/w config properties.
  *  @return intf - hyp eth interface label (eth0/eth1).
  */
-bool deserialize(NwConfigPropMap& list, std::string intf);
+bool deserialize(NwConfigPropMap& list, std::string intf, std::string type);
 
 } // namespace persistdata
 } // namespace network


### PR DESCRIPTION
This commit adds hypervisor IPv6 address persistency after BMC reboot.
so that redfish hypervisor network events will suppressed after BMC reboot 

Tested By:
Connect HMC with configured VMI network  and reboot BMC while phyp is running
check redfish hypervisor events on HMC Side there is no vmi network events seen