### PR TITLE
Set LinkLocalAddressing to IPv6 on eth1

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1056,14 +1056,19 @@ void EthernetInterface::writeConfigurationFile()
     // with eth0 route.
     // https://github.com/systemd/systemd/issues/23595
     // TODO: Remove this check once 23595 is resolved
-    if (interfaceName() != "eth1")
-    {
 #ifdef LINK_LOCAL_AUTOCONFIGURATION
+    if (interfaceName() == "eth0")
+    {
         stream << "LinkLocalAddressing=yes\n";
-#else
-        stream << "LinkLocalAddressing=no\n";
-#endif
     }
+    else if (interfaceName() == "eth1")
+    {
+        stream << "LinkLocalAddressing=ipv6\n";
+    }
+#else
+    stream << "LinkLocalAddressing=no\n";
+#endif
+
     stream << std::boolalpha
            << "IPv6AcceptRA=" << EthernetInterfaceIntf::ipv6AcceptRA() << "\n";
 

--- a/src/network_config.cpp
+++ b/src/network_config.cpp
@@ -29,7 +29,11 @@ void writeDHCPDefault(const std::string& filename, const std::string& interface)
     {
         filestream << "[Match]\nName=" << interface <<
                 "\n[Network]\nDHCP=true\n"
+#ifdef LINK_LOCAL_AUTOCONFIGURATION
+                "LinkLocalAddressing=ipv6\n"
+#else
                 "LinkLocalAddressing=no\n"
+#endif
 #ifdef ENABLE_IPV6_ACCEPT_RA
                 "IPv6AcceptRA=true\n"
 #else


### PR DESCRIPTION
Currently LinkLocalAddressing disabled on eth1
This commit enables IPv6 LinkLocalAddressing eth1

Tested by:
code update tests from 1030 to 1050 & 1050 to 1030
configure static IP & DHCP 