### PR TITLE
Creating eth object based on BIOS attributess

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
@@ -187,7 +187,10 @@ void HypNetworkMgr::setBIOSTableAttrs()
             {
                 const std::string& itemType =
                     std::get<biosBaseAttrType>(item.second);
-
+                if (item.first.rfind("vmi_if1", 0) == 0)
+                {
+                    if1Present = 1;
+                }
                 if (itemType.compare(itemType.size() - intType.size(),
                                      intType.size(), intType) == 0)
                 {
@@ -244,17 +247,19 @@ void HypNetworkMgr::createIfObjects()
     // created during init time to support the static
     // network configurations on the both.
     // create eth0 and eth1 objects
-    log<level::INFO>("Creating eth0 and eth1 objects");
+    log<level::INFO>("Creating eth0 object");
     interfaces.emplace("eth0",
                        std::make_unique<HypEthInterface>(
                            bus, (objectPath + "/eth0").c_str(), "eth0", *this));
-    interfaces.emplace("eth1",
-                       std::make_unique<HypEthInterface>(
-                           bus, (objectPath + "/eth1").c_str(), "eth1", *this));
-
-    // Create ip address objects for each ethernet interface
     interfaces["eth0"]->createIPAddressObjects();
-    interfaces["eth1"]->createIPAddressObjects();
+    if (if1Present)
+    {
+        log<level::INFO>("Creating eth1 object");
+        interfaces.emplace(
+            "eth1", std::make_unique<HypEthInterface>(
+                        bus, (objectPath + "/eth1").c_str(), "eth1", *this));
+        interfaces["eth1"]->createIPAddressObjects();
+    }
 
     // Call watch method to register for properties changed signal
     // This method can be called only once

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
@@ -129,6 +129,14 @@ class HypNetworkMgr
         return systemConf;
     }
 
+    /** @brief checks if if1 related bios attributes present
+     *
+     */
+    inline bool if1Exist()
+    {
+        return if1Present;
+    }
+
   protected:
     /**
      * @brief get Dbus Prop
@@ -158,6 +166,8 @@ class HypNetworkMgr
     /** @brief pointer to system conf object. */
     SystemConfPtr systemConf = nullptr;
 
+    /** @brief interface1 present or not  */
+    bool if1Present = 0;
     /** @brief Persistent map of EthernetInterface dbus
      *         objects and their names
      */


### PR DESCRIPTION
ethernet interfaces1 for vmi should only initialised if corresponding BIOS attribute exists for the same 

Fix for Defects : https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=586842
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=591806


Tested By :
1) Network hypervisor tree on Rainer system
```
root@rain111bmc:~# busctl tree xyz.openbmc_project.Network.Hypervisor
`- /xyz
  `- /xyz/openbmc_project
    `- /xyz/openbmc_project/network
      `- /xyz/openbmc_project/network/hypervisor
        |- /xyz/openbmc_project/network/hypervisor/config
        |- /xyz/openbmc_project/network/hypervisor/eth0
        | |- /xyz/openbmc_project/network/hypervisor/eth0/ipv4
        | | `- /xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0
        | `- /xyz/openbmc_project/network/hypervisor/eth0/ipv6
        |   `- /xyz/openbmc_project/network/hypervisor/eth0/ipv6/addr0
        `- /xyz/openbmc_project/network/hypervisor/eth1
          |- /xyz/openbmc_project/network/hypervisor/eth1/ipv4
          | `- /xyz/openbmc_project/network/hypervisor/eth1/ipv4/addr0
          `- /xyz/openbmc_project/network/hypervisor/eth1/ipv6
            `- /xyz/openbmc_project/network/hypervisor/eth1/ipv6/addr0
```
 2)Network hypervisor tree on Bonnel system
 root@bonn027:~# busctl tree xyz.openbmc_project.Network.Hypervisor
```
`- /xyz
  `- /xyz/openbmc_project
    `- /xyz/openbmc_project/network
      `- /xyz/openbmc_project/network/hypervisor
        |- /xyz/openbmc_project/network/hypervisor/config
        `- /xyz/openbmc_project/network/hypervisor/eth0
          |- /xyz/openbmc_project/network/hypervisor/eth0/ipv4
          | `- /xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0
          `- /xyz/openbmc_project/network/hypervisor/eth0/ipv6
            `- /xyz/openbmc_project/network/hypervisor/eth0/ipv6/addr0
```
 3) upadte IPaddr and check if persist after reboot