### PR TITLE
Handle NCSI timeout

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -20,8 +20,10 @@
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <filesystem>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <variant>
 
@@ -69,6 +71,60 @@ static std::string makeObjPath(std::string_view root, std::string_view intf)
     auto ret = fmt::format(FMT_COMPILE("{}/{}"), root, intf);
     std::replace(ret.begin() + ret.size() - intf.size(), ret.end(), '.', '_');
     return ret;
+}
+
+EthernetInterface::NCSITimeoutWatch::NCSITimeoutWatch(const std::string& ifname,
+                                                      int file) :
+    ifname(ifname),
+    fd(std::forward<int>(file)),
+    io(sdeventplus::Event::get_default(), fd.get(), EPOLLPRI | EPOLLERR,
+       std::bind(&NCSITimeoutWatch::callback, this, std::placeholders::_1,
+                 std::placeholders::_2, std::placeholders::_3))
+{}
+
+void EthernetInterface::NCSITimeoutWatch::callback(sdeventplus::source::IO&,
+                                                   int, uint32_t)
+{
+    char data[2];
+    auto r = read(fd.get(), data, sizeof(data));
+
+    if (r < 2)
+    {
+        auto msg = fmt::format("Failed to read {} ncsi_timeout {}\n", ifname,
+                               r);
+        log<level::ERR>(msg.c_str());
+        return;
+    }
+
+    if (data[0] != '0')
+    {
+        auto msg = fmt::format("{} NCSI timeout, setting link down/up\n",
+                               ifname);
+        log<level::WARNING>(msg.c_str());
+
+        r = write(fd.get(), data, sizeof(data));
+        if (r < 0)
+        {
+            auto msg = fmt::format("Failed to write {} ncsi_timeout {}\n",
+                                   ifname, r);
+            log<level::ERR>(msg.c_str());
+        }
+
+        system::setNICUp(ifname, false);
+
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(1ms);
+
+        system::setNICUp(ifname, true);
+    }
+
+    r = lseek(fd.get(), 0, SEEK_SET);
+    if (r < 0)
+    {
+        auto msg = fmt::format("Failed to seek {} ncsi_timeout {}\n", ifname,
+                               r);
+        log<level::ERR>(msg.c_str());
+    }
 }
 
 EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
@@ -132,6 +188,43 @@ EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
     for (const auto& [_, staticRoute] : info.staticRoutes)
     {
         addStaticRoute(staticRoute);
+    }
+
+    const std::filesystem::path dir = "/sys/class/net";
+    for (auto&& d : std::filesystem::directory_iterator(dir))
+    {
+        std::filesystem::path ifindex = d.path() / "ifindex";
+        int fd = open(ifindex.c_str(), O_RDONLY);
+
+        if (fd >= 0)
+        {
+            std::string data(4, '\0');
+            auto r = read(fd, data.data(), data.size());
+
+            close(fd);
+            if (r < 0)
+            {
+                continue;
+            }
+
+            int i = std::stoi(data, nullptr, 0);
+            if (i == info.intf.idx)
+            {
+                std::filesystem::path ncsi_timeout = d.path() / "ncsi_timeout";
+
+                fd = open(ncsi_timeout.c_str(), O_RDWR | O_NONBLOCK);
+                if (fd >= 0)
+                {
+                    auto msg = fmt::format(
+                        "Starting to watch for NCSI timeout on {}\n",
+                        *info.intf.name);
+                    log<level::NOTICE>(msg.c_str());
+                    ncsiTimeoutWatch =
+                        std::make_unique<NCSITimeoutWatch>(*info.intf.name, fd);
+                }
+                break;
+            }
+        }
     }
 }
 

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <chrono>
 #include <filesystem>
+#include <fstream>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -102,6 +103,7 @@ void EthernetInterface::NCSITimeoutWatch::callback(sdeventplus::source::IO&,
                                ifname);
         log<level::WARNING>(msg.c_str());
 
+        // Clears the ncsi_timeout - link down should proceed despite error
         r = write(fd.get(), data, sizeof(data));
         if (r < 0)
         {
@@ -118,6 +120,7 @@ void EthernetInterface::NCSITimeoutWatch::callback(sdeventplus::source::IO&,
         system::setNICUp(ifname, true);
     }
 
+    // Must seek to zero otherwise the poll returns immediately
     r = lseek(fd.get(), 0, SEEK_SET);
     if (r < 0)
     {
@@ -194,36 +197,30 @@ EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
     for (auto&& d : std::filesystem::directory_iterator(dir))
     {
         std::filesystem::path ifindex = d.path() / "ifindex";
-        int fd = open(ifindex.c_str(), O_RDONLY);
+        std::ifstream file(ifindex);
+        unsigned int i;
 
-        if (fd >= 0)
+        file >> i;
+        if (!file)
         {
-            std::string data(4, '\0');
-            auto r = read(fd, data.data(), data.size());
+            continue;
+        }
 
-            close(fd);
-            if (r < 0)
+        if (i == info.intf.idx)
+        {
+            std::filesystem::path ncsi_timeout = d.path() / "ncsi_timeout";
+            int fd = open(ncsi_timeout.c_str(), O_RDWR | O_NONBLOCK);
+
+            if (fd >= 0)
             {
-                continue;
+                auto msg =
+                    fmt::format("Starting to watch for NCSI timeout on {}\n",
+                                *info.intf.name);
+                log<level::NOTICE>(msg.c_str());
+                ncsiTimeoutWatch =
+                    std::make_unique<NCSITimeoutWatch>(*info.intf.name, fd);
             }
-
-            int i = std::stoi(data, nullptr, 0);
-            if (i == info.intf.idx)
-            {
-                std::filesystem::path ncsi_timeout = d.path() / "ncsi_timeout";
-
-                fd = open(ncsi_timeout.c_str(), O_RDWR | O_NONBLOCK);
-                if (fd >= 0)
-                {
-                    auto msg = fmt::format(
-                        "Starting to watch for NCSI timeout on {}\n",
-                        *info.intf.name);
-                    log<level::NOTICE>(msg.c_str());
-                    ncsiTimeoutWatch =
-                        std::make_unique<NCSITimeoutWatch>(*info.intf.name, fd);
-                }
-                break;
-            }
+            break;
         }
     }
 }

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -10,6 +10,8 @@
 
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
+#include <sdeventplus/source/io.hpp>
+#include <stdplus/fd/managed.hpp>
 #include <stdplus/pinned.hpp>
 #include <stdplus/zstring_view.hpp>
 #include <xyz/openbmc_project/Collection/DeleteAll/server.hpp>
@@ -276,6 +278,18 @@ class EthernetInterface : public Ifaces
     friend class TestNetworkManager;
 
   private:
+    struct NCSITimeoutWatch
+    {
+        NCSITimeoutWatch(const std::string& ifname, int file);
+
+        void callback(sdeventplus::source::IO&, int, uint32_t);
+
+        const std::string ifname;
+        stdplus::ManagedFd fd;
+        sdeventplus::source::IO io;
+    };
+    std::unique_ptr<NCSITimeoutWatch> ncsiTimeoutWatch;
+
     EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
                       stdplus::PinnedRef<Manager> manager,
                       const AllIntfInfo& info, std::string&& objPath,

--- a/test/meson.build
+++ b/test/meson.build
@@ -28,6 +28,7 @@ test_deps = [
   gtest,
   gmock,
   dependency('stdplus-gtest'),
+  dependency('sdeventplus'),
 ]
 
 test_lib = static_library(


### PR DESCRIPTION
Add a sd event loop to watch for changes to the new NCSI timeout file. If the file changes, take down the link and bring it up again to fix the interface.

https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=601659