### PR TITLE
Handle NCSI timeout

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -14,12 +14,14 @@
 #include <net/if.h>
 
 #include <algorithm>
+#include <chrono>
 #include <filesystem>
 #include <phosphor-logging/elog-errors.hpp>
 #include <phosphor-logging/log.hpp>
 #include <stdplus/raw.hpp>
 #include <stdplus/zstring.hpp>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <variant>
 #include <xyz/openbmc_project/Common/error.hpp>
@@ -68,6 +70,60 @@ static std::string makeObjPath(std::string_view root, std::string_view intf)
     auto ret = fmt::format(FMT_COMPILE("{}/{}"), root, intf);
     std::replace(ret.begin() + ret.size() - intf.size(), ret.end(), '.', '_');
     return ret;
+}
+
+EthernetInterface::NCSITimeoutWatch::NCSITimeoutWatch(const std::string& ifname,
+                                                      int file) :
+    ifname(ifname),
+    fd(std::forward<int>(file)),
+    io(sdeventplus::Event::get_default(), fd.get(), EPOLLPRI | EPOLLERR,
+       std::bind(&NCSITimeoutWatch::callback, this, std::placeholders::_1,
+                 std::placeholders::_2, std::placeholders::_3))
+{}
+
+void EthernetInterface::NCSITimeoutWatch::callback(sdeventplus::source::IO&,
+                                                   int, uint32_t)
+{
+    char data[2];
+    auto r = read(fd.get(), data, sizeof(data));
+
+    if (r < 2)
+    {
+        auto msg = fmt::format("Failed to read {} ncsi_timeout {}\n", ifname,
+                               r);
+        log<level::ERR>(msg.c_str());
+        return;
+    }
+
+    if (data[0] != '0')
+    {
+        auto msg = fmt::format("{} NCSI timeout, setting link down/up\n",
+                               ifname);
+        log<level::WARNING>(msg.c_str());
+
+        r = write(fd.get(), data, sizeof(data));
+        if (r < 0)
+        {
+            auto msg = fmt::format("Failed to write {} ncsi_timeout {}\n",
+                                   ifname, r);
+            log<level::ERR>(msg.c_str());
+        }
+
+        system::setNICUp(ifname, false);
+
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(1ms);
+
+        system::setNICUp(ifname, true);
+    }
+
+    r = lseek(fd.get(), 0, SEEK_SET);
+    if (r < 0)
+    {
+        auto msg = fmt::format("Failed to seek {} ncsi_timeout {}\n", ifname,
+                               r);
+        log<level::ERR>(msg.c_str());
+    }
 }
 
 EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
@@ -132,6 +188,43 @@ EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
     for (const auto& [_, staticRoute] : info.staticRoutes)
     {
         addStaticRoute(staticRoute);
+    }
+
+    const std::filesystem::path dir = "/sys/class/net";
+    for (auto&& d : std::filesystem::directory_iterator(dir))
+    {
+        std::filesystem::path ifindex = d.path() / "ifindex";
+        int fd = open(ifindex.c_str(), O_RDONLY);
+
+        if (fd >= 0)
+        {
+            std::string data(4, '\0');
+            auto r = read(fd, data.data(), data.size());
+
+            close(fd);
+            if (r < 0)
+            {
+                continue;
+            }
+
+            int i = std::stoi(data, nullptr, 0);
+            if (i == info.intf.idx)
+            {
+                std::filesystem::path ncsi_timeout = d.path() / "ncsi_timeout";
+
+                fd = open(ncsi_timeout.c_str(), O_RDWR | O_NONBLOCK);
+                if (fd >= 0)
+                {
+                    auto msg = fmt::format(
+                        "Starting to watch for NCSI timeout on {}\n",
+                        *info.intf.name);
+                    log<level::NOTICE>(msg.c_str());
+                    ncsiTimeoutWatch =
+                        std::make_unique<NCSITimeoutWatch>(*info.intf.name, fd);
+                }
+                break;
+            }
+        }
     }
 }
 

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -79,7 +79,8 @@ EthernetInterface::NCSITimeoutWatch::NCSITimeoutWatch(const std::string& ifname,
     io(sdeventplus::Event::get_default(), fd.get(), EPOLLPRI | EPOLLERR,
        std::bind(&NCSITimeoutWatch::callback, this, std::placeholders::_1,
                  std::placeholders::_2, std::placeholders::_3))
-{}
+{
+}
 
 void EthernetInterface::NCSITimeoutWatch::callback(sdeventplus::source::IO&,
                                                    int, uint32_t)
@@ -89,23 +90,23 @@ void EthernetInterface::NCSITimeoutWatch::callback(sdeventplus::source::IO&,
 
     if (r < 2)
     {
-        auto msg = fmt::format("Failed to read {} ncsi_timeout {}\n", ifname,
-                               r);
+        auto msg =
+            fmt::format("Failed to read {} ncsi_timeout {}\n", ifname, r);
         log<level::ERR>(msg.c_str());
         return;
     }
 
     if (data[0] != '0')
     {
-        auto msg = fmt::format("{} NCSI timeout, setting link down/up\n",
-                               ifname);
+        auto msg =
+            fmt::format("{} NCSI timeout, setting link down/up\n", ifname);
         log<level::WARNING>(msg.c_str());
 
         r = write(fd.get(), data, sizeof(data));
         if (r < 0)
         {
-            auto msg = fmt::format("Failed to write {} ncsi_timeout {}\n",
-                                   ifname, r);
+            auto msg =
+                fmt::format("Failed to write {} ncsi_timeout {}\n", ifname, r);
             log<level::ERR>(msg.c_str());
         }
 
@@ -120,8 +121,8 @@ void EthernetInterface::NCSITimeoutWatch::callback(sdeventplus::source::IO&,
     r = lseek(fd.get(), 0, SEEK_SET);
     if (r < 0)
     {
-        auto msg = fmt::format("Failed to seek {} ncsi_timeout {}\n", ifname,
-                               r);
+        auto msg =
+            fmt::format("Failed to seek {} ncsi_timeout {}\n", ifname, r);
         log<level::ERR>(msg.c_str());
     }
 }

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -11,6 +11,8 @@
 #include <optional>
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
+#include <sdeventplus/source/io.hpp>
+#include <stdplus/fd/managed.hpp>
 #include <stdplus/pinned.hpp>
 #include <stdplus/zstring_view.hpp>
 #include <string>
@@ -275,6 +277,18 @@ class EthernetInterface : public Ifaces
     friend class TestNetworkManager;
 
   private:
+    struct NCSITimeoutWatch
+    {
+        NCSITimeoutWatch(const std::string& ifname, int file);
+
+        void callback(sdeventplus::source::IO&, int, uint32_t);
+
+        const std::string ifname;
+        stdplus::ManagedFd fd;
+        sdeventplus::source::IO io;
+    };
+    std::unique_ptr<NCSITimeoutWatch> ncsiTimeoutWatch;
+
     EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
                       stdplus::PinnedRef<Manager> manager,
                       const AllIntfInfo& info, std::string&& objPath,

--- a/test/meson.build
+++ b/test/meson.build
@@ -28,6 +28,7 @@ test_deps = [
   gtest,
   gmock,
   dependency('stdplus-gtest'),
+  dependency('sdeventplus'),
 ]
 
 test_lib = static_library(


### PR DESCRIPTION
Add a sd event loop to watch for changes to the new NCSI timeout file. If the file changes, take down the link and bring it up again to fix the interface.

https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=601659