### PR TITLE
1050: DHCP Config: Add DomainEnabled D-bus property & Configure DHCP4 and DHCP6 parameters independently

### DIFF
--- a/src/dhcp_configuration.cpp
+++ b/src/dhcp_configuration.cpp
@@ -50,6 +50,7 @@ Configuration::Configuration(sdbusplus::bus_t& bus,
         conf.setFile(newest_file.path());
     }
 
+    ConfigIntf::domainEnabled(getDHCPProp(conf, type, "UseDomains"), true);
     ConfigIntf::dnsEnabled(getDHCPProp(conf, type, "UseDNS"), true);
     ConfigIntf::ntpEnabled(getDHCPProp(conf, type, "UseNTP"), true);
     ConfigIntf::hostNameEnabled(getDHCPProp(conf, type, "UseHostname"), true);
@@ -115,6 +116,20 @@ bool Configuration::dnsEnabled(bool value)
     parent.get().reloadConfigs();
 
     return dns;
+}
+
+bool Configuration::domainEnabled(bool value)
+{
+    if (value == domainEnabled())
+    {
+        return value;
+    }
+
+    auto domain = ConfigIntf::domainEnabled(value);
+    parent.get().writeConfigurationFile();
+    parent.get().reloadConfigs();
+
+    return domain;
 }
 
 } // namespace dhcp

--- a/src/dhcp_configuration.cpp
+++ b/src/dhcp_configuration.cpp
@@ -2,7 +2,6 @@
 
 #include "config_parser.hpp"
 #include "network_manager.hpp"
-#include "util.hpp"
 
 #include <sys/stat.h>
 
@@ -25,9 +24,9 @@ using namespace sdbusplus::xyz::openbmc_project::Common::Error;
 Configuration::Configuration(sdbusplus::bus_t& bus,
                              stdplus::const_zstring objPath,
                              stdplus::PinnedRef<EthernetInterface> parent,
-                             stdplus::const_zstring type) :
+                             DHCPType type) :
     Iface(bus, objPath.c_str(), Iface::action::defer_emit),
-    parent(parent)
+    parent(parent), type(type)
 {
     config::Parser conf;
     std::filesystem::directory_entry newest_file;
@@ -51,14 +50,13 @@ Configuration::Configuration(sdbusplus::bus_t& bus,
         conf.setFile(newest_file.path());
     }
 
-    ConfigIntf::dnsEnabled(getDHCPProp(conf, "UseDNS", type.c_str()), true);
-    ConfigIntf::ntpEnabled(getDHCPProp(conf, "UseNTP", type.c_str()), true);
-    ConfigIntf::hostNameEnabled(getDHCPProp(conf, "UseHostname", type.c_str()),
-                                true);
-    if (std::string(type.c_str()) == "dhcp4")
+    ConfigIntf::dnsEnabled(getDHCPProp(conf, type, "UseDNS"), true);
+    ConfigIntf::ntpEnabled(getDHCPProp(conf, type, "UseNTP"), true);
+    ConfigIntf::hostNameEnabled(getDHCPProp(conf, type, "UseHostname"), true);
+    if (type == DHCPType::v4)
     {
-        ConfigIntf::sendHostNameEnabled(
-            getDHCPProp(conf, "SendHostname", type.c_str()), true);
+        ConfigIntf::sendHostNameEnabled(getDHCPProp(conf, type, "SendHostname"),
+                                        true);
     }
 
     emit_object_added();
@@ -73,7 +71,7 @@ bool Configuration::sendHostNameEnabled(bool value)
 
     auto name = ConfigIntf::sendHostNameEnabled(value);
     parent.get().writeConfigurationFile();
-    parent.get().manager.get().reloadConfigs();
+    parent.get().reloadConfigs();
     return name;
 }
 
@@ -86,7 +84,7 @@ bool Configuration::hostNameEnabled(bool value)
 
     auto name = ConfigIntf::hostNameEnabled(value);
     parent.get().writeConfigurationFile();
-    parent.get().manager.get().reloadConfigs();
+    parent.get().reloadConfigs();
 
     return name;
 }
@@ -100,7 +98,7 @@ bool Configuration::ntpEnabled(bool value)
 
     auto ntp = ConfigIntf::ntpEnabled(value);
     parent.get().writeConfigurationFile();
-    parent.get().manager.get().reloadConfigs();
+    parent.get().reloadConfigs();
 
     return ntp;
 }
@@ -114,7 +112,7 @@ bool Configuration::dnsEnabled(bool value)
 
     auto dns = ConfigIntf::dnsEnabled(value);
     parent.get().writeConfigurationFile();
-    parent.get().manager.get().reloadConfigs();
+    parent.get().reloadConfigs();
 
     return dns;
 }

--- a/src/dhcp_configuration.hpp
+++ b/src/dhcp_configuration.hpp
@@ -47,6 +47,12 @@ class Configuration : public Iface
      */
     bool dnsEnabled(bool value) override;
 
+    /** @brief If true then domain names received from the DHCP server
+     *  @param[in] value - true if domain names needed from DHCP server
+     *                     else false.
+     */
+    bool domainEnabled(bool value) override;
+
     /** @brief If true then NTP servers received from the DHCP server
                will be used by systemd-timesyncd.
      *  @param[in] value - true if NTP server needed from DHCP server
@@ -75,6 +81,7 @@ class Configuration : public Iface
      *
      */
     using ConfigIntf::dnsEnabled;
+    using ConfigIntf::domainEnabled;
     using ConfigIntf::hostNameEnabled;
     using ConfigIntf::ntpEnabled;
     using ConfigIntf::sendHostNameEnabled;

--- a/src/dhcp_configuration.hpp
+++ b/src/dhcp_configuration.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include "util.hpp"
+
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
 #include <stdplus/pinned.hpp>
@@ -32,10 +34,10 @@ class Configuration : public Iface
      *  @param[in] bus - Bus to attach to.
      *  @param[in] objPath - Path to attach at.
      *  @param[in] parent - Parent object.
+     *  @param[in] type - Network type.
      */
     Configuration(sdbusplus::bus_t& bus, stdplus::const_zstring objPath,
-                  stdplus::PinnedRef<EthernetInterface> parent,
-                  stdplus::const_zstring type);
+                  stdplus::PinnedRef<EthernetInterface> parent, DHCPType type);
 
     /** @brief If true then DNS servers received from the DHCP server
      *         will be used and take precedence over any statically
@@ -80,6 +82,7 @@ class Configuration : public Iface
   private:
     /** @brief Ethernet Interface object. */
     stdplus::PinnedRef<EthernetInterface> parent;
+    DHCPType type;
 };
 
 } // namespace dhcp

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1124,7 +1124,7 @@ void EthernetInterface::writeConfigurationFile()
     {
         auto& dhcp4 = config.map["DHCPv4"].emplace_back();
         dhcp4["ClientIdentifier"].emplace_back("mac");
-        const auto& conf = *dhcpConfigs["dhcp4"];
+        const auto& conf = *dhcpConfigs[static_cast<int>(DHCPType::v4)];
         auto dns_enabled = conf.dnsEnabled() ? "true" : "false";
         dhcp4["UseDNS"].emplace_back(dns_enabled);
         dhcp4["UseDomains"].emplace_back(dns_enabled);
@@ -1136,7 +1136,7 @@ void EthernetInterface::writeConfigurationFile()
     }
     {
         auto& dhcp6 = config.map["DHCPv6"].emplace_back();
-        const auto& conf = *dhcpConfigs["dhcp6"];
+        const auto& conf = *dhcpConfigs[static_cast<int>(DHCPType::v6)];
         auto dns_enabled = conf.dnsEnabled() ? "true" : "false";
         dhcp6["UseDNS"].emplace_back(dns_enabled);
         dhcp6["UseDomains"].emplace_back(dns_enabled);
@@ -1358,12 +1358,15 @@ void EthernetInterface::VlanProperties::delete_()
 
 void EthernetInterface::addDHCPConfigurations()
 {
-    this->dhcpConfigs.emplace(
-        "dhcp4", std::make_unique<dhcp::Configuration>(bus, objPath + "/dhcp4",
-                                                       *this, "dhcp4"));
-    this->dhcpConfigs.emplace(
-        "dhcp6", std::make_unique<dhcp::Configuration>(bus, objPath + "/dhcp6",
-                                                       *this, "dhcp6"));
+    this->dhcpConfigs.emplace_back(std::make_unique<dhcp::Configuration>(
+        bus, objPath + "/dhcp4", *this, DHCPType::v4));
+    this->dhcpConfigs.emplace_back(std::make_unique<dhcp::Configuration>(
+        bus, objPath + "/dhcp6", *this, DHCPType::v6));
+}
+
+void EthernetInterface::reloadConfigs()
+{
+    manager.get().reloadConfigs();
 }
 
 } // namespace network

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1126,8 +1126,9 @@ void EthernetInterface::writeConfigurationFile()
         dhcp4["ClientIdentifier"].emplace_back("mac");
         const auto& conf = *dhcpConfigs[static_cast<int>(DHCPType::v4)];
         auto dns_enabled = conf.dnsEnabled() ? "true" : "false";
+        auto domain_enabled = conf.domainEnabled() ? "true" : "false";
         dhcp4["UseDNS"].emplace_back(dns_enabled);
-        dhcp4["UseDomains"].emplace_back(dns_enabled);
+        dhcp4["UseDomains"].emplace_back(domain_enabled);
         dhcp4["UseNTP"].emplace_back(conf.ntpEnabled() ? "true" : "false");
         dhcp4["UseHostname"].emplace_back(conf.hostNameEnabled() ? "true"
                                                                  : "false");
@@ -1138,8 +1139,9 @@ void EthernetInterface::writeConfigurationFile()
         auto& dhcp6 = config.map["DHCPv6"].emplace_back();
         const auto& conf = *dhcpConfigs[static_cast<int>(DHCPType::v6)];
         auto dns_enabled = conf.dnsEnabled() ? "true" : "false";
+        auto domain_enabled = conf.domainEnabled() ? "true" : "false";
         dhcp6["UseDNS"].emplace_back(dns_enabled);
-        dhcp6["UseDomains"].emplace_back(dns_enabled);
+        dhcp6["UseDomains"].emplace_back(domain_enabled);
         dhcp6["UseNTP"].emplace_back(conf.ntpEnabled() ? "true" : "false");
         dhcp6["UseHostname"].emplace_back(conf.hostNameEnabled() ? "true"
                                                                  : "false");

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -231,6 +231,10 @@ class EthernetInterface : public Ifaces
      */
     std::string defaultGateway6(std::string gateway) override;
 
+    /** @brief Function to reload network configurations.
+     */
+    void reloadConfigs();
+
     bool dhcpIsEnabled(IP::Protocol family, bool ignoreProtocol);
     void disableDHCP(IP::Protocol protocol);
     using EthernetInterfaceIntf::interfaceName;
@@ -304,9 +308,9 @@ class EthernetInterface : public Ifaces
      */
     void addDHCPConfigurations();
 
-    /** @brief Map of DHCP conf objects.
+    /** @brief Vector of DHCP conf objects.
      */
-    string_umap<std::unique_ptr<dhcp::Configuration>> dhcpConfigs;
+    std::vector<std::unique_ptr<dhcp::Configuration>> dhcpConfigs;
 };
 
 } // namespace network

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -211,12 +211,12 @@ DHCPVal getDHCPValue(const config::Parser& config)
         .value_or(DHCPVal{.v4 = true, .v6 = true});
 }
 
-bool getDHCPProp(const config::Parser& config, std::string_view key,
-                 std::string_view type)
+bool getDHCPProp(const config::Parser& config, DHCPType dhcpType,
+                 std::string_view key)
 {
-    type = (type == "dhcp4") ? "DHCPv4" : "DHCPv6";
+    std::string_view type = (dhcpType == DHCPType::v4) ? "DHCPv4" : "DHCPv6";
 
-    if (config.map.find(type) == config.map.end())
+    if (!config.map.contains(type))
     {
         type = "DHCP";
     }

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -100,14 +100,22 @@ struct DHCPVal
 {
     bool v4, v6;
 };
+
+enum class DHCPType
+{
+    v4,
+    v6
+};
+
 DHCPVal getDHCPValue(const config::Parser& config);
 
 /** @brief Read a boolean DHCP property from a conf file
  *  @param[in] config - The parsed configuration.
+ *  @param[in] nwType - The network type.
  *  @param[in] key - The property name.
  */
-bool getDHCPProp(const config::Parser& config, std::string_view key,
-                 std::string_view type);
+bool getDHCPProp(const config::Parser& config, DHCPType dhcpType,
+                 std::string_view key);
 
 namespace internal
 {


### PR DESCRIPTION
#### DHCP Config: Add DomainEnabled D-bus property
```
This commit implements DomainEnabled D-bus property for DHCP
configuration.
When DomainEnabled is set to true then the domain names received from
the DHCP server

Tested by:
Set DomainEnabled D-bus property to true or false
Check domain name configured on BMC

Change-Id: Ia3db5f5054d4c758be336851175b05ddc05d2eda
Signed-off-by: Ravi Teja <raviteja28031990@gmail.com>
```
#### Configure DHCP4 and DHCP6 parameters independently
```
At present, DHCP parameters like DNSEnabled, NTPEnabled etc. are
shared between DHCPv4 and DHCPv6 in the network configuration.

Hence any update on the ipv4 parameters impacts the ipv6 and get
applied to both the interfaces.

This change is to enable the possibility to configure DHCP attributes
independently, by having different dbus objects for dhcp4 and dhcp6
and moving the dhcp configuration from network level to ethernet
interface.

tested by:

Used the busctl command to set and get the parameter values
individually for both DHCPv4 and DHCPv6.
Verified the network configuration file is updated accordingly

Tree Structure:
busctl tree xyz.openbmc_project.Network
`-/xyz
  `-/xyz/openbmc_project
    `-/xyz/openbmc_project/network
      |-/xyz/openbmc_project/network/config
      |-/xyz/openbmc_project/network/eth0
      | |-/xyz/openbmc_project/network/eth0/dhcp4
      | `-/xyz/openbmc_project/network/eth0/dhcp6
      `-/xyz/openbmc_project/network/eth1
        |-/xyz/openbmc_project/network/eth1/dhcp4
        `-/xyz/openbmc_project/network/eth1/dhcp6

Change-Id: If7dbbf596bdaf866ea459d631e716153f54302ec
Signed-off-by: Jishnu CM <jishnunambiarcm@duck.com>
```