### PR TITLE
Handle NCSI timeout

### DIFF
--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -8,6 +8,8 @@
 #include <filesystem>
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
+#include <sdeventplus/source/io.hpp>
+#include <stdplus/fd/managed.hpp>
 #include <string>
 #include <xyz/openbmc_project/Collection/DeleteAll/server.hpp>
 #include <xyz/openbmc_project/Network/EthernetInterface/server.hpp>
@@ -360,6 +362,17 @@ class EthernetInterface : public Ifaces
     friend class TestEthernetInterface;
 
   private:
+    struct NCSITimeoutWatch
+    {
+        NCSITimeoutWatch(const std::string& ifname, int file);
+
+        void callback(sdeventplus::source::IO&, int, uint32_t);
+
+        const std::string ifname;
+        stdplus::ManagedFd fd;
+        sdeventplus::source::IO io;
+    };
+    std::unique_ptr<NCSITimeoutWatch> ncsiTimeoutWatch;
     /** @brief Determines if DHCP is active for the IP::Protocol supplied.
      *  @param[in] protocol - Either IPv4 or IPv6
      *  @param[in] ignoreProtocol - Allows IPv4 and IPv6 to be checked using a

--- a/test/meson.build
+++ b/test/meson.build
@@ -27,6 +27,7 @@ test_deps = [
   networkd_dep,
   gtest,
   gmock,
+  dependency('sdeventplus'),
 ]
 
 test_lib = static_library(


### PR DESCRIPTION
Add a sd event loop to watch for changes to the new NCSI timeout file. If the file changes, take down the link and bring it up again to fix the interface.

https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=601659