### PR TITLE
Fix for Network Manager Crash

### DIFF
--- a/src/rtnetlink_server.cpp
+++ b/src/rtnetlink_server.cpp
@@ -59,10 +59,11 @@ static bool shouldRefresh(const struct nlmsghdr& hdr, std::string_view data)
 static int eventHandler(sd_event_source* /*es*/, int fd, uint32_t /*revents*/,
                         void* /*userdata*/)
 {
-    char buffer[phosphor::network::rtnetlink::BUFSIZE]{};
+    std::array<char, phosphor::network::rtnetlink::BUFSIZE> buffer = {};
     int len{};
 
-    auto netLinkHeader = reinterpret_cast<struct nlmsghdr*>(buffer);
+    auto netLinkHeader = reinterpret_cast<struct nlmsghdr*>(buffer.data());
+
     while ((len = recv(fd, netLinkHeader, phosphor::network::rtnetlink::BUFSIZE,
                        0)) > 0)
     {
@@ -87,6 +88,9 @@ static int eventHandler(sd_event_source* /*es*/, int fd, uint32_t /*revents*/,
 
         } // end for
 
+        buffer.fill('\0');
+
+        netLinkHeader = reinterpret_cast<struct nlmsghdr*>(buffer.data());
     } // end while
 
     return 0;


### PR DESCRIPTION
RTNet Link Packet is received with a buffer size of 4096 bytes, the pointer to the buffer is not moved back to the start address of buffer when the pointer to the buffer is used to receive the next packet in queue causing the pointer access of array out of bound. The fix for this in this patch re-initializes the pointer to start address of buffer before the next packet is received. No other checking is required to validate the case of array out of bound as the NLMSG preprocessor macros is taking care of checking the received and remaining length of data in the packet and send for processing.

Tested:
Flashed the BMC image on available platforms in which the crash was reported and regression of sending the Net Link Packet continuously. No core file/crash was observed during the time of regression and reboot cycle tests.


Change-Id: Ibcfbb03dcce694d4116163be3db25f0597cda1eb