### PR TITLE
1030: Catch all the exceptions from validation (#130)

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1303,6 +1303,12 @@ std::string EthernetInterface::macAddress(std::string value)
         elog<InvalidArgument>(Argument::ARGUMENT_NAME("MACAddress"),
                               Argument::ARGUMENT_VALUE(value.c_str()));
     }
+    catch (const std::exception&)
+    {
+        log<level::ERR>("Internal failure in patching MACAddress.",
+                        entry("MAC=%s", value.c_str()));
+        elog<InternalFailure>();
+    }
     if (!mac_address::isUnicast(newMAC))
     {
         log<level::ERR>("MACAddress is not valid.",


### PR DESCRIPTION
#### Catch all the exceptions from validation (#130)
```
Current design:
Only invalid argument exception is caught when validating a
given MAC address, while the validation method throws multiple
other exceptions as well. This causes networkd to crash and restart,
when exceptions other than invalid argument are not caught.

Fix:
The above behaviour is fixed by catching standard exceptions instead.

Tested By:
* Updated an invalid mac address and ensured networkd did not crash.

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>```