### PR TITLE
IPv4 Network: Configure GatewayOnLink

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1088,16 +1088,18 @@ void EthernetInterface::writeConfigurationFile()
             }
         }
         {
-            auto& gateways = network["Gateway"];
             if (!dhcp4())
             {
-                auto gateway = EthernetInterfaceIntf::defaultGateway();
-                if (!gateway.empty())
+                auto gateway4 = EthernetInterfaceIntf::defaultGateway();
+                if (!gateway4.empty())
                 {
-                    gateways.emplace_back(gateway);
+                    auto& gateway4route = config.map["Route"].emplace_back();
+                    gateway4route["Gateway"].emplace_back(gateway4);
+                    gateway4route["GatewayOnLink"].emplace_back("true");
                 }
             }
 
+            auto& gateways = network["Gateway"];
             if (!dhcp6())
             {
                 auto gateway6 = EthernetInterfaceIntf::defaultGateway6();


### PR DESCRIPTION
This commit configures Gateway using systemd-network Route option
And sets GatewayOnLink option

This commit fixes network configuration for private network and interfaces reachable 
irrespective of route order.

Tested By:
1.  configure one interface in static and other interface DHCP.
2. configure both interfaces static private network