### PR TITLE
IPv4 Gateway: Configure GatewayOnLink

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1090,16 +1090,18 @@ void EthernetInterface::writeConfigurationFile()
             }
         }
         {
-            auto& gateways = network["Gateway"];
             if (!dhcp4())
             {
-                auto gateway = EthernetInterfaceIntf::defaultGateway();
-                if (!gateway.empty())
+                auto gateway4 = EthernetInterfaceIntf::defaultGateway();
+                if (!gateway4.empty())
                 {
-                    gateways.emplace_back(gateway);
+                    auto& gateway4route = config.map["Route"].emplace_back();
+                    gateway4route["Gateway"].emplace_back(gateway4);
+                    gateway4route["GatewayOnLink"].emplace_back("true");
                 }
             }
 
+            auto& gateways = network["Gateway"];
             if (!dhcp6())
             {
                 auto gateway6 = EthernetInterfaceIntf::defaultGateway6();


### PR DESCRIPTION
Currently when both interfaces configured static ip addresses and one of that static ip address is in private network then while reload network configuration further, route order keep changes and other interface network is not reachable if private gateway route is on the top of routing table.

This commit configures IPv4 static gateway using systemd-networkd's Route option and sets GatewayOnLink option and make sure interfaces network reachable irrespective of route order while reloading networkd.

Tested By:
configure one interface in static and other interface DHCP. configure both interfaces with static IP and one interface on private network.

Sample IPv4 network route added in systemd-networkd configuration file [Route]
GatewayOnLink=true
Gateway=9.10.x.1

Change-Id: Id7c9ba74cf7e71e6105536c5affc905754cae908