### PR TITLE
Network: Disable IPv4 LinkLocalAddressing on eth1 interface

### DIFF
--- a/60-phosphor-networkd-eth1-default.network.in
+++ b/60-phosphor-networkd-eth1-default.network.in
@@ -1,0 +1,15 @@
+[Match]
+Type=ether
+[Network]
+DHCP=true
+LinkLocalAddressing=ipv6
+IPv6AcceptRA=@ENABLE_IPV6_ACCEPT_RA@
+[DHCP]
+ClientIdentifier=mac
+UseDNS=true
+UseDomains=true
+UseNTP=true
+UseHostname=true
+SendHostname=true
+[IPv6AcceptRA]
+DHCPv6Client=true

--- a/meson.build
+++ b/meson.build
@@ -79,6 +79,14 @@ configure_file(
     'systemdutildir') / 'network')
 
 configure_file(
+  input: '60-phosphor-networkd-eth1-default.network.in',
+  output: '60-phosphor-networkd-eth1-default.network',
+  configuration: conf_data,
+  install: true,
+  install_dir: dependency('systemd').get_variable(
+    'systemdutildir') / 'network')
+
+configure_file(
   input: 'xyz.openbmc_project.Network.service.in',
   output: 'xyz.openbmc_project.Network.service',
   configuration: {

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -680,7 +680,14 @@ void EthernetInterface::writeConfigurationFile()
         auto& network = config.map["Network"].emplace_back();
         auto& lla = network["LinkLocalAddressing"];
 #ifdef LINK_LOCAL_AUTOCONFIGURATION
-        lla.emplace_back("yes");
+        if (interfaceName() == "eth0")
+        {
+            lla.emplace_back("yes");
+        }
+        else if (interfaceName() == "eth1")
+        {
+            lla.emplace_back("ipv6");
+        }
 #else
         lla.emplace_back("no");
 #endif


### PR DESCRIPTION
Even though LinkLocalAddressing enabled on both interfaces, only IPv4 Link local address on one interface will work.

This commit introduces a default configuration file with IPv4 LinkLocalAddressing disabled on eth1 interface

Change-Id: I985b7c475e09d0d068c1096434cbeeacd86f9a49