### PR TITLE
Add network static gateway configuration support

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -7,6 +7,7 @@
 #include "system_queries.hpp"
 #include "util.hpp"
 
+#include <arpa/inet.h>
 #include <fcntl.h>
 #include <linux/rtnetlink.h>
 #include <net/if.h>
@@ -137,6 +138,10 @@ EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
     {
         addStaticNeigh(neigh);
     }
+    for (const auto& [_, staticGateway] : info.staticGateways)
+    {
+        addStaticGateway(staticGateway);
+    }
 }
 
 void EthernetInterface::updateInfo(const InterfaceInfo& info, bool skipSignal)
@@ -237,6 +242,39 @@ void EthernetInterface::addStaticNeigh(const NeighborInfo& info)
                                                 bus, std::string_view(objPath),
                                                 *this, *info.addr, *info.mac,
                                                 Neighbor::State::Permanent));
+    }
+}
+
+void EthernetInterface::addStaticGateway(const StaticGatewayInfo& info)
+{
+    if (!info.gateway)
+    {
+        lg2::error("Missing static gateway on {NET_INTF}", "NET_INTF",
+                   interfaceName());
+        return;
+    }
+
+    IP::Protocol protocolType;
+    if (*info.protocol == "IPv4")
+    {
+        protocolType = IP::Protocol::IPv4;
+    }
+    else if (*info.protocol == "IPv6")
+    {
+        protocolType = IP::Protocol::IPv6;
+    }
+
+    if (auto it = staticGateways.find(*info.gateway);
+        it != staticGateways.end())
+    {
+        it->second->StaticGatewayObj::gateway(*info.gateway);
+    }
+    else
+    {
+        staticGateways.emplace(
+            *info.gateway, std::make_unique<StaticGateway>(
+                               bus, std::string_view(objPath), *this,
+                               *info.gateway, info.prefixLength, protocolType));
     }
 }
 
@@ -355,6 +393,44 @@ ObjectPath EthernetInterface::neighbor(std::string ipAddress,
             return it->second->getObjPath();
         }
         it->second->NeighborObj::macAddress(str);
+    }
+
+    writeConfigurationFile();
+    manager.get().reloadConfigs();
+
+    return it->second->getObjPath();
+}
+
+ObjectPath EthernetInterface::staticGateway(std::string gateway,
+                                            size_t prefixLength,
+                                            IP::Protocol protocolType)
+{
+    std::optional<stdplus::InAnyAddr> addr;
+    std::string route;
+    try
+    {
+        addr.emplace(stdplus::fromStr<stdplus::InAnyAddr>(gateway));
+        route = gateway;
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Not a valid IP address {GATEWAY}: {ERROR}", "GATEWAY",
+                   gateway, "ERROR", e);
+        elog<InvalidArgument>(Argument::ARGUMENT_NAME("gateway"),
+                              Argument::ARGUMENT_VALUE(gateway.c_str()));
+    }
+
+    auto it = staticGateways.find(route);
+    if (it == staticGateways.end())
+    {
+        it = std::get<0>(staticGateways.emplace(
+            route, std::make_unique<StaticGateway>(
+                       bus, std::string_view(objPath), *this, gateway,
+                       prefixLength, protocolType)));
+    }
+    else
+    {
+        it->second->StaticGatewayObj::gateway(gateway);
     }
 
     writeConfigurationFile();
@@ -507,6 +583,60 @@ void EthernetInterface::loadNameServers(const config::Parser& config)
     EthernetInterfaceIntf::nameservers(getNameServerFromResolvd());
     EthernetInterfaceIntf::staticNameServers(
         config.map.getValueStrings("Network", "DNS"));
+}
+
+void EthernetInterface::loadStaticGateways(const config::Parser& config)
+{
+    std::vector<std::string> destinations =
+        config.map.getValueStrings("Route", "Destination");
+    std::vector<std::string> gateways = config.map.getValueStrings("Route",
+                                                                   "Gateway");
+    for (uint8_t i = 0; i < destinations.size() && i < gateways.size(); i++)
+    {
+        size_t pos = destinations[i].find("/");
+        std::string prefixStr =
+            destinations[i].substr(pos + 1, destinations[i].length());
+        uint8_t prefix = stoi(prefixStr);
+        std::optional<stdplus::SubnetAny> ifaddr;
+        std::optional<stdplus::InAnyAddr> addr;
+        IP::Protocol addressType;
+        unsigned char buf[sizeof(struct in6_addr)];
+        int status6 = inet_pton(AF_INET6, gateways[i].c_str(), buf);
+        if (status6 <= 0)
+        {
+            int status4 = inet_pton(AF_INET, gateways[i].c_str(), buf);
+            if (status4 <= 0)
+            {
+                auto msg1 = fmt::format("Invalid static gateway\n");
+                log<level::ERR>(msg1.c_str());
+                return;
+            }
+            addr.emplace(stdplus::fromStr<stdplus::In4Addr>(gateways[i]));
+            addressType = IP::Protocol::IPv4;
+        }
+        else if (status6)
+        {
+            addr.emplace(stdplus::fromStr<stdplus::In6Addr>(gateways[i]));
+            addressType = IP::Protocol::IPv6;
+        }
+        try
+        {
+            ifaddr.emplace(*addr, prefix);
+        }
+
+        catch (const std::exception& e)
+        {
+            lg2::error("Invalid prefix length {NET_PFX}: {ERROR}", "NET_PFX",
+                       prefix, "ERROR", e);
+            elog<InvalidArgument>(
+                Argument::ARGUMENT_NAME("PrefixLength"),
+                Argument::ARGUMENT_VALUE(stdplus::toStr(prefix).c_str()));
+        }
+        staticGateways.emplace(gateways[i],
+                               std::make_unique<StaticGateway>(
+                                   bus, std::string_view(objPath), *this,
+                                   gateways[i], prefix, addressType));
+    }
 }
 
 ServerList EthernetInterface::getNTPServerFromTimeSyncd()
@@ -785,6 +915,27 @@ void EthernetInterface::writeConfigurationFile()
         dhcp6["UseHostname"].emplace_back(conf.hostNameEnabled() ? "true"
                                                                  : "false");
     }
+
+    {
+        auto& sroutes = config.map["Route"];
+        for (const auto& temp : staticGateways)
+        {
+            auto& staticGateway = sroutes.emplace_back();
+            if (temp.second->protocolType() == IP::Protocol::IPv6)
+            {
+                staticGateway["Destination"].emplace_back(fmt::format(
+                    "{}/{}", "0:0:0:0:0:0:0:0", temp.second->prefixLength()));
+            }
+            else
+            {
+                staticGateway["Destination"].emplace_back(fmt::format(
+                    "{}/{}", "0.0.0.0", temp.second->prefixLength()));
+            }
+            staticGateway["Gateway"].emplace_back(temp.second->gateway());
+            staticGateway["GatewayOnLink"].emplace_back("true");
+        }
+    }
+
     auto path = config::pathForIntfConf(manager.get().getConfDir(),
                                         interfaceName());
     config.writeFile(path);

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -2,9 +2,11 @@
 #include "dhcp_configuration.hpp"
 #include "ipaddress.hpp"
 #include "neighbor.hpp"
+#include "static_gateway.hpp"
 #include "types.hpp"
 #include "xyz/openbmc_project/Network/IP/Create/server.hpp"
 #include "xyz/openbmc_project/Network/Neighbor/CreateStatic/server.hpp"
+#include "xyz/openbmc_project/Network/StaticGateway/Create/server.hpp"
 
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/server/object.hpp>
@@ -14,6 +16,7 @@
 #include <xyz/openbmc_project/Collection/DeleteAll/server.hpp>
 #include <xyz/openbmc_project/Network/EthernetInterface/server.hpp>
 #include <xyz/openbmc_project/Network/MACAddress/server.hpp>
+#include <xyz/openbmc_project/Network/StaticGateway/server.hpp>
 #include <xyz/openbmc_project/Network/VLAN/server.hpp>
 #include <xyz/openbmc_project/Object/Delete/server.hpp>
 
@@ -31,6 +34,7 @@ using Ifaces = sdbusplus::server::object_t<
     sdbusplus::xyz::openbmc_project::Network::server::MACAddress,
     sdbusplus::xyz::openbmc_project::Network::IP::server::Create,
     sdbusplus::xyz::openbmc_project::Network::Neighbor::server::CreateStatic,
+    sdbusplus::xyz::openbmc_project::Network::StaticGateway::server::Create,
     sdbusplus::xyz::openbmc_project::Collection::server::DeleteAll>;
 
 using VlanIfaces = sdbusplus::server::object_t<
@@ -45,6 +49,8 @@ using EthernetInterfaceIntf =
     sdbusplus::xyz::openbmc_project::Network::server::EthernetInterface;
 using MacAddressIntf =
     sdbusplus::xyz::openbmc_project::Network::server::MACAddress;
+using StaticGatewayIntf =
+    sdbusplus::xyz::openbmc_project::Network::server::StaticGateway;
 
 using ServerList = std::vector<std::string>;
 using ObjectPath = sdbusplus::message::object_path;
@@ -94,8 +100,13 @@ class EthernetInterface : public Ifaces
     std::unordered_map<stdplus::InAnyAddr, std::unique_ptr<Neighbor>>
         staticNeighbors;
 
+    /** @brief Persistent map of static route dbus objects and their names */
+    std::unordered_map<std::string, std::unique_ptr<StaticGateway>>
+        staticGateways;
+
     void addAddr(const AddressInfo& info);
     void addStaticNeigh(const NeighborInfo& info);
+    void addStaticGateway(const StaticGatewayInfo& info);
 
     /** @brief Updates the interface information based on new InterfaceInfo */
     void updateInfo(const InterfaceInfo& info, bool skipSignal = false);
@@ -107,6 +118,10 @@ class EthernetInterface : public Ifaces
     /** @brief Function used to load the nameservers.
      */
     void loadNameServers(const config::Parser& config);
+
+    /** @brief Function used to load the static routes.
+     */
+    void loadStaticGateways(const config::Parser& config);
 
     /** @brief Function to create ipAddress dbus object.
      *  @param[in] addressType - Type of ip address.
@@ -122,6 +137,14 @@ class EthernetInterface : public Ifaces
      *  @param[in] macAddress - Low level MAC address.
      */
     ObjectPath neighbor(std::string ipAddress, std::string macAddress) override;
+
+    /** @brief Function to create static route dbus object.
+     *  @param[in] destination - Destination IP address.
+     *  @param[in] gateway - Gateway
+     *  @parma[in] prefixLength - Number of network bits.
+     */
+    ObjectPath staticGateway(std::string gateway, size_t prefixLength,
+                             IP::Protocol protocolType) override;
 
     /** Set value of DHCPEnabled */
     DHCPConf dhcpEnabled() const override;

--- a/src/meson.build
+++ b/src/meson.build
@@ -47,6 +47,7 @@ networkd_lib = static_library(
   'ethernet_interface.cpp',
   'neighbor.cpp',
   'ipaddress.cpp',
+  'static_gateway.cpp',
   'netlink.cpp',
   'network_manager.cpp',
   'rtnetlink.cpp',

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -196,6 +196,7 @@ void Manager::createInterface(const AllIntfInfo& info, bool enabled)
         bus, *this, info, objPath.str, config, enabled);
     intf->loadNameServers(config);
     intf->loadNTPServers(config);
+    intf->loadStaticGateways(config);
     auto ptr = intf.get();
     interfaces.insert_or_assign(*info.intf.name, std::move(intf));
     interfacesByIdx.insert_or_assign(info.intf.idx, ptr);

--- a/src/static_gateway.cpp
+++ b/src/static_gateway.cpp
@@ -1,0 +1,84 @@
+#include "static_gateway.hpp"
+
+#include "ethernet_interface.hpp"
+#include "network_manager.hpp"
+
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/elog.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+
+#include <string>
+
+namespace phosphor
+{
+namespace network
+{
+
+static auto makeObjPath(std::string_view root, std::string addr)
+{
+    auto ret = sdbusplus::message::object_path(std::string(root));
+    ret /= addr;
+    return ret;
+}
+
+StaticGateway::StaticGateway(sdbusplus::bus_t& bus, std::string_view objRoot,
+                             stdplus::PinnedRef<EthernetInterface> parent,
+                             std::string gateway, size_t prefixLength,
+                             IP::Protocol protocolType) :
+    StaticGateway(bus, makeObjPath(objRoot, gateway), parent, gateway,
+                  prefixLength, protocolType)
+{}
+
+StaticGateway::StaticGateway(sdbusplus::bus_t& bus,
+                             sdbusplus::message::object_path objPath,
+                             stdplus::PinnedRef<EthernetInterface> parent,
+                             std::string gateway, size_t prefixLength,
+                             IP::Protocol protocolType) :
+    StaticGatewayObj(bus, objPath.str.c_str(),
+                     StaticGatewayObj::action::defer_emit),
+    parent(parent), objPath(std::move(objPath))
+{
+    StaticGatewayObj::gateway(gateway, true);
+    StaticGatewayObj::prefixLength(prefixLength, true);
+    StaticGatewayObj::protocolType(protocolType, true);
+    emit_object_added();
+}
+
+void StaticGateway::delete_()
+{
+    auto& staticGateways = parent.get().staticGateways;
+    std::unique_ptr<StaticGateway> ptr;
+    for (auto it = staticGateways.begin(); it != staticGateways.end(); ++it)
+    {
+        if (it->second.get() == this)
+        {
+            ptr = std::move(it->second);
+            staticGateways.erase(it);
+            break;
+        }
+    }
+
+    parent.get().writeConfigurationFile();
+    parent.get().manager.get().reloadConfigs();
+}
+
+using sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
+using REASON =
+    phosphor::logging::xyz::openbmc_project::Common::NotAllowed::REASON;
+using phosphor::logging::elog;
+
+std::string StaticGateway::gateway(std::string /*gateway*/)
+{
+    elog<NotAllowed>(REASON("Property update is not allowed"));
+}
+
+size_t StaticGateway::prefixLength(size_t /*prefixLength*/)
+{
+    elog<NotAllowed>(REASON("Property update is not allowed"));
+}
+IP::Protocol StaticGateway::protocolType(IP::Protocol /*protocolType*/)
+{
+    elog<NotAllowed>(REASON("Property update is not allowed"));
+}
+} // namespace network
+} // namespace phosphor

--- a/src/static_gateway.hpp
+++ b/src/static_gateway.hpp
@@ -1,0 +1,79 @@
+#pragma once
+#include "types.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/message/native_types.hpp>
+#include <sdbusplus/server/object.hpp>
+#include <stdplus/pinned.hpp>
+#include <xyz/openbmc_project/Network/IP/server.hpp>
+#include <xyz/openbmc_project/Network/StaticGateway/server.hpp>
+#include <xyz/openbmc_project/Object/Delete/server.hpp>
+
+#include <string_view>
+
+namespace phosphor
+{
+namespace network
+{
+
+using StaticGatewayIntf =
+    sdbusplus::xyz::openbmc_project::Network::server::StaticGateway;
+
+using StaticGatewayObj = sdbusplus::server::object_t<
+    StaticGatewayIntf, sdbusplus::xyz::openbmc_project::Object::server::Delete>;
+
+using IP = sdbusplus::xyz::openbmc_project::Network::server::IP;
+
+class EthernetInterface;
+
+/** @class StaticGateway
+ *  @brief OpenBMC network static gateway implementation.
+ *  @details A concrete implementation for the
+ *  xyz.openbmc_project.Network.StaticGateway dbus interface.
+ */
+class StaticGateway : public StaticGatewayObj
+{
+  public:
+    /** @brief Constructor to put object onto bus at a dbus path.
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] objRoot - Path to attach at.
+     *  @param[in] parent - Parent object.
+     *  @param[in] gateway - Gateway address.
+     *  @param[in] prefixLength - Prefix length.
+     */
+    StaticGateway(sdbusplus::bus_t& bus, std::string_view objRoot,
+                  stdplus::PinnedRef<EthernetInterface> parent,
+                  std::string gateway, size_t prefixLength,
+                  IP::Protocol protocolType);
+
+    /** @brief Delete this d-bus object.
+     */
+    void delete_() override;
+
+    using StaticGatewayObj::gateway;
+    std::string gateway(std::string) override;
+    using StaticGatewayObj::prefixLength;
+    size_t prefixLength(size_t) override;
+    using StaticGatewayObj::protocolType;
+    IP::Protocol protocolType(IP::Protocol) override;
+    inline const auto& getObjPath() const
+    {
+        return objPath;
+    }
+
+  private:
+    /** @brief Parent Object. */
+    stdplus::PinnedRef<EthernetInterface> parent;
+
+    /** @brief Dbus object path */
+    sdbusplus::message::object_path objPath;
+
+    StaticGateway(sdbusplus::bus_t& bus,
+                  sdbusplus::message::object_path objPath,
+                  stdplus::PinnedRef<EthernetInterface> parent,
+                  std::string gateway, size_t prefixLength,
+                  IP::Protocol protocolType);
+};
+
+} // namespace network
+} // namespace phosphor

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -79,6 +79,24 @@ struct NeighborInfo
     }
 };
 
+/** @class StaticGatewayInfo
+ *  @brief Information about a static gateway from the kernel
+ */
+struct StaticGatewayInfo
+{
+    unsigned ifidx;
+    size_t prefixLength;
+    std::optional<std::string> destination;
+    std::optional<std::string> gateway;
+    std::optional<std::string> protocol;
+
+    constexpr bool operator==(const StaticGatewayInfo& rhs) const noexcept
+    {
+        return ifidx == rhs.ifidx && prefixLength == rhs.prefixLength &&
+               destination == rhs.destination && gateway == rhs.gateway;
+    }
+};
+
 /** @brief Contains all of the object information about the interface */
 struct AllIntfInfo
 {
@@ -87,6 +105,7 @@ struct AllIntfInfo
     std::optional<stdplus::In6Addr> defgw6 = std::nullopt;
     std::unordered_map<stdplus::SubnetAny, AddressInfo> addrs = {};
     std::unordered_map<stdplus::InAnyAddr, NeighborInfo> staticNeighs = {};
+    std::unordered_map<std::string, StaticGatewayInfo> staticGateways = {};
 };
 
 } // namespace phosphor::network


### PR DESCRIPTION
This commit enables static gateway configuration on EthernetInterface Implements CreateStaticGateway method which creates a new d-bus object with StaticGateway interface.

Tested By:
Run StaticGateway D-bus method and verified D-bus object and configuration.
Delete StaticGateway object
Add IPv6 StaticGateway and delete

Change-Id: I3fbc6f85ede00b6c1949a0ac85f501037a69c831