### PR TITLE
Watch NTP server change in timesyncd

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1098,5 +1098,39 @@ void EthernetInterface::reloadConfigs()
     manager.get().reloadConfigs();
 }
 
+void EthernetInterface::watchNTPServers()
+{
+    ntpServerMatch = std::make_unique<sdbusplus::bus::match::match>(
+        bus,
+        "type='signal',member='PropertiesChanged',interface='org.freedesktop."
+        "DBus.Properties',path='/org/freedesktop/timesync1',"
+        "arg0='org.freedesktop.timesync1.Manager'",
+        [this](sdbusplus::message::message& msg) {
+        if (msg.is_method_error())
+        {
+            return;
+        }
+
+        std::string interfaceName;
+        std::map<std::string, std::variant<std::vector<std::string>>>
+            changedProperties;
+        std::vector<std::string> invalidatedProperties;
+
+        msg.read(interfaceName, changedProperties, invalidatedProperties);
+
+        if (interfaceName == "org.freedesktop.timesync1.Manager")
+        {
+            auto it = changedProperties.find("LinkNTPServers");
+            if (it != changedProperties.end())
+            {
+                lg2::info("NTP server ip updated in timesyncd");
+                config::Parser config(config::pathForIntfConf(
+                    manager.get().getConfDir(), interfaceName));
+                loadNTPServers(config);
+            }
+        }
+    });
+}
+
 } // namespace network
 } // namespace phosphor

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -123,6 +123,10 @@ class EthernetInterface : public Ifaces
      */
     void loadStaticGateways(const config::Parser& config);
 
+    /** @brief Function used to watch change in NTP server.
+     */
+    void watchNTPServers();
+
     /** @brief Function to create ipAddress dbus object.
      *  @param[in] addressType - Type of ip address.
      *  @param[in] ipAddress- IP address.
@@ -293,6 +297,8 @@ class EthernetInterface : public Ifaces
     /** @brief Map of DHCP conf objects.
      */
     std::vector<std::unique_ptr<dhcp::Configuration>> dhcpConfigs;
+
+    std::unique_ptr<sdbusplus::bus::match::match> ntpServerMatch;
 };
 
 } // namespace network

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -197,6 +197,7 @@ void Manager::createInterface(const AllIntfInfo& info, bool enabled)
     intf->loadNameServers(config);
     intf->loadNTPServers(config);
     intf->loadStaticGateways(config);
+    intf->watchNTPServers();
     auto ptr = intf.get();
     interfaces.insert_or_assign(*info.intf.name, std::move(intf));
     interfacesByIdx.insert_or_assign(info.intf.idx, ptr);


### PR DESCRIPTION
In phosphor-networkd, network-provided NTP servers are updated only at the time of interface creation. Any modifications to the NTP server are not reflected in networkd until the next restart. As of systemd version 255, timesyncd emits a property changed signal when the LinkNTPServers property is updated. This commit implements a watch for the signal from timesyncd, ensuring that phosphor-networkd loads the updated NTP servers dynamically.

Tested by:

1. Connected the BMC to a DHCP server
2. Configured the DHCP server with the NTP server IP.
3. Verified that timesyncd is updated with the new NTP server IP.
4. Confirmed that phosphor-networkd receives the signal and updates the D-Bus with the latest NTP servers from timesyncd.

Change-Id: I6a58e44795e60490d8bee106548de043be40bfe8