### PR TITLE
Fix NTP server watch from timesyncd

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1228,21 +1228,21 @@ void EthernetInterface::watchNTPServers()
             return;
         }
 
-        std::string interfaceName;
+        std::string interface;
         std::map<std::string, std::variant<std::vector<std::string>>>
             changedProperties;
         std::vector<std::string> invalidatedProperties;
 
-        msg.read(interfaceName, changedProperties, invalidatedProperties);
+        msg.read(interface, changedProperties, invalidatedProperties);
 
-        if (interfaceName == "org.freedesktop.timesync1.Manager")
+        if (interface == "org.freedesktop.timesync1.Manager")
         {
             auto it = changedProperties.find("LinkNTPServers");
             if (it != changedProperties.end())
             {
                 lg2::info("NTP server ip updated in timesyncd");
                 config::Parser config(config::pathForIntfConf(
-                    manager.get().getConfDir(), interfaceName));
+                    manager.get().getConfDir(), interfaceName()));
                 loadNTPServers(config);
             }
         }

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -305,6 +305,7 @@ class EthernetInterface : public Ifaces
      *  @returns true/false value if the address is static
      */
     bool originIsManuallyAssigned(IP::AddressOrigin origin);
+
     std::unique_ptr<sdbusplus::bus::match::match> ntpServerMatch;
 };
 


### PR DESCRIPTION
This PR fixes the bug introduced in https://github.com/ibm-openbmc/phosphor-networkd/pull/144

Fixes : https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=638710
Upstream : https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/71834/3/src/ethernet_interface.hpp

Tested by:

1. Connected the BMC to a DHCP server
2. Configured the DHCP server with the NTP server IP.
3. Verified that timesyncd is updated with the new NTP server IP.
4. Confirmed that phosphor-networkd receives the signal and updates the D-Bus with the latest NTP servers from timesyncd.
5. Confirmed that the static IP provided is updated in d-bus and returned in redfish response as expected

Change-Id: I6a58e44795e60490d8bee106548de043be40bfe8