### PR TITLE
Add separate static IPv4 routing tables for each ethernet interface

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -942,6 +942,7 @@ void EthernetInterface::writeConfigurationFile()
                 dnss.emplace_back(dns);
             }
         }
+        uint8_t prefixLength = 0;
         {
             auto& address = network["Address"];
             for (const auto& addr : addrs)
@@ -949,6 +950,10 @@ void EthernetInterface::writeConfigurationFile()
                 if (originIsManuallyAssigned(addr.second->origin()))
                 {
                     address.emplace_back(stdplus::toStr(addr.first));
+                    if (addr.second->type() == IP::Protocol::IPv4)
+                    {
+                        prefixLength = addr.second->prefixLength();
+                    }
                 }
             }
         }
@@ -961,6 +966,32 @@ void EthernetInterface::writeConfigurationFile()
                     auto& gateway4route = config.map["Route"].emplace_back();
                     gateway4route["Gateway"].emplace_back(gateway4);
                     gateway4route["GatewayOnLink"].emplace_back("true");
+                    // Creating different routing tables for each ethernet
+                    // interface to solve eth0 and eth1 route entry order issues
+                    // Routing table id of "eth0" interface is 10
+                    // Routing table id of "eth1" interface is 20
+                    std::string routingTableId;
+                    if (interfaceName() == "eth0")
+                    {
+                        routingTableId = "10";
+                    }
+                    else if (interfaceName() == "eth1")
+                    {
+                        routingTableId = "20";
+                    }
+                    gateway4route["Table"].emplace_back(routingTableId);
+                    std::string routeAddressPrefix =
+                        setIPv4AddressLastOctetToZero(gateway4);
+                    routeAddressPrefix =
+                        routeAddressPrefix + "/" + std::to_string(prefixLength);
+                    auto& routingPolicyTo =
+                        config.map["RoutingPolicyRule"].emplace_back();
+                    routingPolicyTo["Table"].emplace_back(routingTableId);
+                    routingPolicyTo["To"].emplace_back(routeAddressPrefix);
+                    auto& routingPolicyFrom =
+                        config.map["RoutingPolicyRule"].emplace_back();
+                    routingPolicyFrom["Table"].emplace_back(routingTableId);
+                    routingPolicyFrom["From"].emplace_back(routeAddressPrefix);
                 }
             }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -226,5 +226,28 @@ bool getDHCPProp(const config::Parser& config, DHCPType dhcpType,
         .value_or(true);
 }
 
+std::string setIPv4AddressLastOctetToZero(const std::string& ip)
+{
+    std::vector<std::string> octets;
+    std::string octet;
+    std::stringstream ss(ip);
+
+    // Split the IP address by '.'
+    while (std::getline(ss, octet, '.'))
+    {
+        octets.push_back(octet);
+    }
+
+    // Modify the last octet
+    if (octets.size() == 4)
+    {
+        octets[3] = "0";
+    }
+
+    std::string modifiedIP =
+        octets[0] + "." + octets[1] + "." + octets[2] + "." + octets[3];
+    return modifiedIP;
+}
+
 } // namespace network
 } // namespace phosphor

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -72,6 +72,11 @@ DHCPVal getDHCPValue(const config::Parser& config);
 bool getDHCPProp(const config::Parser& config, DHCPType dhcpType,
                  std::string_view key);
 
+/** @brief Set IPv4 address last octet to zero
+ *  @param[in] ip - IPv4 address
+ */
+std::string setIPv4AddressLastOctetToZero(const std::string& ip);
+
 namespace internal
 {
 


### PR DESCRIPTION
This commit configures separate routing tables for each ethernet interface so that
static gateway routes added on that interface (eth0/eth1) will be in added to separate routing tables

Currently there are gateway routing issues when multiple interfaces configured in different subnets
This commit fixes routing configuration issues when static addresses configured on eth0 and eth1 interfaces.

Tested by:
Ran CT/Automation network test cases 
Verified routing with eth0 static configuration and eth1 dhcp configuration
Verified routing with eth0 DHCP configuration and eth1 static configuration
Both eth0 and eth1 with static IP configurations 
