### PR TITLE
clang-format: re-format for clang-18

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -87,7 +87,7 @@ IndentWidth:     4
 IndentWrappedFunctionNames: true
 InsertNewlineAtEOF: true
 KeepEmptyLinesAtTheStartOfBlocks: false
-LambdaBodyIndentation: OuterScope
+LambdaBodyIndentation: Signature
 LineEnding: LF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
@@ -98,13 +98,14 @@ ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 25
-PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakBeforeFirstCallParameter: 50
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
-PenaltyIndentedWhitespace: 0
+PenaltyIndentedWhitespace: 1
 PointerAlignment: Left
 QualifierAlignment: Left
 ReferenceAlignment: Left

--- a/gen/meson.build
+++ b/gen/meson.build
@@ -5,10 +5,10 @@ sdbuspp_gen_meson_ver = run_command(
     check: true,
 ).stdout().strip().split('\n')[0]
 
-if sdbuspp_gen_meson_ver != 'sdbus++-gen-meson version 7'
+if sdbuspp_gen_meson_ver != 'sdbus++-gen-meson version 9'
     warning('Generated meson files from wrong version of sdbus++-gen-meson.')
     warning(
-        'Expected "sdbus++-gen-meson version 7", got:',
+        'Expected "sdbus++-gen-meson version 9", got:',
         sdbuspp_gen_meson_ver
     )
 endif

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -54,9 +54,8 @@ fs::path pathForIntfDev(const fs::path& dir, std::string_view intf)
     return dir / stdplus::strCat(intf, ".netdev"sv);
 }
 
-const std::string*
-    SectionMap::getLastValueString(std::string_view section,
-                                   std::string_view key) const noexcept
+const std::string* SectionMap::getLastValueString(
+    std::string_view section, std::string_view key) const noexcept
 {
     auto sit = find(section);
     if (sit == end())

--- a/src/dhcp_configuration.cpp
+++ b/src/dhcp_configuration.cpp
@@ -17,12 +17,10 @@ namespace dhcp
 using namespace phosphor::network;
 using namespace sdbusplus::xyz::openbmc_project::Common::Error;
 
-Configuration::Configuration(sdbusplus::bus_t& bus,
-                             stdplus::const_zstring objPath,
-                             stdplus::PinnedRef<EthernetInterface> parent,
-                             DHCPType type) :
-    Iface(bus, objPath.c_str(), Iface::action::defer_emit),
-    parent(parent)
+Configuration::Configuration(
+    sdbusplus::bus_t& bus, stdplus::const_zstring objPath,
+    stdplus::PinnedRef<EthernetInterface> parent, DHCPType type) :
+    Iface(bus, objPath.c_str(), Iface::action::defer_emit), parent(parent)
 {
     config::Parser conf(config::pathForIntfConf(
         parent.get().manager.get().getConfDir(), parent.get().interfaceName()));

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -85,8 +85,7 @@ static bool validIntfIP(Addr a) noexcept
 
 EthernetInterface::NCSITimeoutWatch::NCSITimeoutWatch(const std::string& ifname,
                                                       int file) :
-    ifname(ifname),
-    fd(std::forward<int>(file)),
+    ifname(ifname), fd(std::forward<int>(file)),
     io(sdeventplus::Event::get_default(), fd.get(), EPOLLPRI | EPOLLERR,
        std::bind(&NCSITimeoutWatch::callback, this, std::placeholders::_1,
                  std::placeholders::_2, std::placeholders::_3))
@@ -100,24 +99,24 @@ void EthernetInterface::NCSITimeoutWatch::callback(sdeventplus::source::IO&,
 
     if (r < 2)
     {
-        auto msg = fmt::format("Failed to read {} ncsi_timeout {}\n", ifname,
-                               r);
+        auto msg =
+            fmt::format("Failed to read {} ncsi_timeout {}\n", ifname, r);
         log<level::ERR>(msg.c_str());
         return;
     }
 
     if (data[0] != '0')
     {
-        auto msg = fmt::format("{} NCSI timeout, setting link down/up\n",
-                               ifname);
+        auto msg =
+            fmt::format("{} NCSI timeout, setting link down/up\n", ifname);
         log<level::WARNING>(msg.c_str());
 
         // Clears the ncsi_timeout - link down should proceed despite error
         r = write(fd.get(), data, sizeof(data));
         if (r < 0)
         {
-            auto msg = fmt::format("Failed to write {} ncsi_timeout {}\n",
-                                   ifname, r);
+            auto msg =
+                fmt::format("Failed to write {} ncsi_timeout {}\n", ifname, r);
             log<level::ERR>(msg.c_str());
         }
 
@@ -133,30 +132,26 @@ void EthernetInterface::NCSITimeoutWatch::callback(sdeventplus::source::IO&,
     r = lseek(fd.get(), 0, SEEK_SET);
     if (r < 0)
     {
-        auto msg = fmt::format("Failed to seek {} ncsi_timeout {}\n", ifname,
-                               r);
+        auto msg =
+            fmt::format("Failed to seek {} ncsi_timeout {}\n", ifname, r);
         log<level::ERR>(msg.c_str());
     }
 }
 
-EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
-                                     stdplus::PinnedRef<Manager> manager,
-                                     const AllIntfInfo& info,
-                                     std::string_view objRoot,
-                                     const config::Parser& config,
-                                     bool enabled) :
+EthernetInterface::EthernetInterface(
+    stdplus::PinnedRef<sdbusplus::bus_t> bus,
+    stdplus::PinnedRef<Manager> manager, const AllIntfInfo& info,
+    std::string_view objRoot, const config::Parser& config, bool enabled) :
     EthernetInterface(bus, manager, info, makeObjPath(objRoot, *info.intf.name),
                       config, enabled)
 {}
 
-EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
-                                     stdplus::PinnedRef<Manager> manager,
-                                     const AllIntfInfo& info,
-                                     std::string&& objPath,
-                                     const config::Parser& config,
-                                     bool enabled) :
-    Ifaces(bus, objPath.c_str(), Ifaces::action::defer_emit),
-    manager(manager), bus(bus), objPath(std::move(objPath))
+EthernetInterface::EthernetInterface(
+    stdplus::PinnedRef<sdbusplus::bus_t> bus,
+    stdplus::PinnedRef<Manager> manager, const AllIntfInfo& info,
+    std::string&& objPath, const config::Parser& config, bool enabled) :
+    Ifaces(bus, objPath.c_str(), Ifaces::action::defer_emit), manager(manager),
+    bus(bus), objPath(std::move(objPath))
 {
     interfaceName(*info.intf.name, true);
     auto dhcpVal = getDHCPValue(config);
@@ -329,10 +324,10 @@ void EthernetInterface::addStaticNeigh(const NeighborInfo& info)
     }
     else
     {
-        staticNeighbors.emplace(*info.addr, std::make_unique<Neighbor>(
-                                                bus, std::string_view(objPath),
-                                                *this, *info.addr, *info.mac,
-                                                Neighbor::State::Permanent));
+        staticNeighbors.emplace(
+            *info.addr, std::make_unique<Neighbor>(
+                            bus, std::string_view(objPath), *this, *info.addr,
+                            *info.mac, Neighbor::State::Permanent));
     }
 }
 
@@ -562,12 +557,12 @@ bool EthernetInterface::dhcp6(bool value)
 EthernetInterface::DHCPConf EthernetInterface::dhcpEnabled(DHCPConf value)
 {
     auto old4 = EthernetInterfaceIntf::dhcp4();
-    auto new4 = EthernetInterfaceIntf::dhcp4(value == DHCPConf::v4 ||
-                                             value == DHCPConf::v4v6stateless ||
-                                             value == DHCPConf::both);
+    auto new4 = EthernetInterfaceIntf::dhcp4(
+        value == DHCPConf::v4 || value == DHCPConf::v4v6stateless ||
+        value == DHCPConf::both);
     auto old6 = EthernetInterfaceIntf::dhcp6();
-    auto new6 = EthernetInterfaceIntf::dhcp6(value == DHCPConf::v6 ||
-                                             value == DHCPConf::both);
+    auto new6 = EthernetInterfaceIntf::dhcp6(
+        value == DHCPConf::v6 || value == DHCPConf::both);
     auto oldra = EthernetInterfaceIntf::ipv6AcceptRA();
     auto newra = EthernetInterfaceIntf::ipv6AcceptRA(
         value == DHCPConf::v6stateless || value == DHCPConf::v4v6stateless ||
@@ -621,8 +616,9 @@ bool EthernetInterface::nicEnabled(bool value)
     {
         // We only need to bring down the interface, networkd will always bring
         // up managed interfaces
-        manager.get().addReloadPreHook(
-            [ifname = interfaceName()]() { system::setNICUp(ifname, false); });
+        manager.get().addReloadPreHook([ifname = interfaceName()]() {
+            system::setNICUp(ifname, false);
+        });
     }
     manager.get().reloadConfigs();
 
@@ -677,8 +673,8 @@ void EthernetInterface::loadNameServers(const config::Parser& config)
 
 void EthernetInterface::loadStaticGateways(const config::Parser& config)
 {
-    std::vector<std::string> gateways = config.map.getValueStrings("Route",
-                                                                   "Gateway");
+    std::vector<std::string> gateways =
+        config.map.getValueStrings("Route", "Gateway");
     for (uint8_t i = 0; i < gateways.size(); i++)
     {
         std::optional<stdplus::InAnyAddr> addr;
@@ -700,9 +696,9 @@ void EthernetInterface::loadStaticGateways(const config::Parser& config)
 ServerList EthernetInterface::getNTPServerFromTimeSyncd()
 {
     ServerList servers; // Variable to capture the NTP Server IPs
-    auto method = bus.get().new_method_call(TIMESYNCD_SERVICE,
-                                            TIMESYNCD_SERVICE_PATH,
-                                            PROPERTY_INTERFACE, METHOD_GET);
+    auto method =
+        bus.get().new_method_call(TIMESYNCD_SERVICE, TIMESYNCD_SERVICE_PATH,
+                                  PROPERTY_INTERFACE, METHOD_GET);
 
     method.append(TIMESYNCD_INTERFACE, "LinkNTPServers");
 
@@ -1017,8 +1013,8 @@ void EthernetInterface::writeConfigurationFile()
         }
     }
 
-    auto path = config::pathForIntfConf(manager.get().getConfDir(),
-                                        interfaceName());
+    auto path =
+        config::pathForIntfConf(manager.get().getConfDir(), interfaceName());
     config.writeFile(path);
     lg2::info("Wrote networkd file: {CFG_FILE}", "CFG_FILE", path);
     writeUpdatedTime(manager, path);
@@ -1200,8 +1196,9 @@ void EthernetInterface::VlanProperties::delete_()
     if (eth.get().ifIdx > 0)
     {
         // We need to forcibly delete the interface as systemd does not
-        eth.get().manager.get().addReloadPostHook(
-            [idx = eth.get().ifIdx]() { system::deleteIntf(idx); });
+        eth.get().manager.get().addReloadPostHook([idx = eth.get().ifIdx]() {
+            system::deleteIntf(idx);
+        });
 
         // Ignore the interface so the reload doesn't re-query it
         eth.get().manager.get().ignoredIntf.emplace(eth.get().ifIdx);
@@ -1223,30 +1220,29 @@ void EthernetInterface::watchNTPServers()
         "DBus.Properties',path='/org/freedesktop/timesync1',"
         "arg0='org.freedesktop.timesync1.Manager'",
         [this](sdbusplus::message::message& msg) {
-        if (msg.is_method_error())
-        {
-            return;
-        }
-
-        std::string interface;
-        std::map<std::string, std::variant<std::vector<std::string>>>
-            changedProperties;
-        std::vector<std::string> invalidatedProperties;
-
-        msg.read(interface, changedProperties, invalidatedProperties);
-
-        if (interface == "org.freedesktop.timesync1.Manager")
-        {
-            auto it = changedProperties.find("LinkNTPServers");
-            if (it != changedProperties.end())
+            if (msg.is_method_error())
             {
-                lg2::info("NTP server ip updated in timesyncd");
-                config::Parser config(config::pathForIntfConf(
-                    manager.get().getConfDir(), interfaceName()));
-                loadNTPServers(config);
+                return;
             }
-        }
-    });
+
+            std::string interface;
+            std::map<std::string, std::variant<std::vector<std::string>>>
+                changedProperties;
+            std::vector<std::string> invalidatedProperties;
+            msg.read(interface, changedProperties, invalidatedProperties);
+
+            if (interface == "org.freedesktop.timesync1.Manager")
+            {
+                auto it = changedProperties.find("LinkNTPServers");
+                if (it != changedProperties.end())
+                {
+                    lg2::info("NTP server ip updated in timesyncd");
+                    config::Parser config(config::pathForIntfConf(
+                        manager.get().getConfDir(), interfaceName()));
+                    loadNTPServers(config);
+                }
+            }
+        });
 }
 
 } // namespace network

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -345,8 +345,8 @@ void HypEthInterface::watchBaseBiosTable()
 
                     // Get prefix length
                     if ((attr.first)
-                            .ends_with(intf + "_" + protocol +
-                                       "_prefix_length"))
+                            .ends_with(
+                                intf + "_" + protocol + "_prefix_length"))
                     {
                         uint8_t currPrefixLen = static_cast<uint8_t>(
                             std::get<int64_t>(attr.second));
@@ -487,8 +487,8 @@ void HypEthInterface::createIPAddressObjects()
             addrs.emplace("eth0/v4",
                           std::make_unique<HypIPAddress>(
                               bus,
-                              sdbusplus::message::object_path(objectPath.str +
-                                                              "/ipv4/addr0"),
+                              sdbusplus::message::object_path(
+                                  objectPath.str + "/ipv4/addr0"),
                               *this, *ifaddrv4, "0.0.0.0",
                               HypIP::AddressOrigin::Static, intfLabel));
 
@@ -496,8 +496,8 @@ void HypEthInterface::createIPAddressObjects()
             addrs.emplace("eth0/v6",
                           std::make_unique<HypIPAddress>(
                               bus,
-                              sdbusplus::message::object_path(objectPath.str +
-                                                              "/ipv6/addr0"),
+                              sdbusplus::message::object_path(
+                                  objectPath.str + "/ipv6/addr0"),
                               *this, *ifaddrv6,
                               "::", HypIP::AddressOrigin::Static, intfLabel));
         }
@@ -509,8 +509,8 @@ void HypEthInterface::createIPAddressObjects()
             addrs.emplace("eth1/v4",
                           std::make_unique<HypIPAddress>(
                               bus,
-                              sdbusplus::message::object_path(objectPath.str +
-                                                              "/ipv4/addr0"),
+                              sdbusplus::message::object_path(
+                                  objectPath.str + "/ipv4/addr0"),
                               *this, *ifaddrv4, "0.0.0.0",
                               HypIP::AddressOrigin::Static, intfLabel));
 
@@ -518,8 +518,8 @@ void HypEthInterface::createIPAddressObjects()
             addrs.emplace("eth1/v6",
                           std::make_unique<HypIPAddress>(
                               bus,
-                              sdbusplus::message::object_path(objectPath.str +
-                                                              "/ipv6/addr0"),
+                              sdbusplus::message::object_path(
+                                  objectPath.str + "/ipv6/addr0"),
                               *this, *ifaddrv6,
                               "::", HypIP::AddressOrigin::Static, intfLabel));
         }
@@ -992,12 +992,12 @@ ObjectPath HypEthInterface::ip(HypIP::Protocol protType, std::string ipaddress,
 HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled(DHCPConf value)
 {
     auto old4 = HypEthernetIntf::dhcp4();
-    auto new4 = HypEthernetIntf::dhcp4(value == DHCPConf::v4 ||
-                                       value == DHCPConf::v4v6stateless ||
-                                       value == DHCPConf::both);
+    auto new4 = HypEthernetIntf::dhcp4(
+        value == DHCPConf::v4 || value == DHCPConf::v4v6stateless ||
+        value == DHCPConf::both);
     auto old6 = HypEthernetIntf::dhcp6();
-    auto new6 = HypEthernetIntf::dhcp6(value == DHCPConf::v6 ||
-                                       value == DHCPConf::both);
+    auto new6 = HypEthernetIntf::dhcp6(
+        value == DHCPConf::v6 || value == DHCPConf::both);
     auto oldra = HypEthernetIntf::ipv6AcceptRA();
     auto newra = HypEthernetIntf::ipv6AcceptRA(
         value == DHCPConf::v6stateless || value == DHCPConf::v4v6stateless ||

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -38,12 +38,11 @@ struct Proto<stdplus::In6Addr>
     static inline constexpr auto value = HypIP::Protocol::IPv6;
 };
 
-HypIPAddress::HypIPAddress(sdbusplus::bus::bus& bus,
-                           sdbusplus::message::object_path objPath,
-                           stdplus::PinnedRef<HypEthInterface> parent,
-                           stdplus::SubnetAny addr, const std::string& gateway,
-                           HypIP::AddressOrigin origin,
-                           const std::string& intf) :
+HypIPAddress::HypIPAddress(
+    sdbusplus::bus::bus& bus, sdbusplus::message::object_path objPath,
+    stdplus::PinnedRef<HypEthInterface> parent, stdplus::SubnetAny addr,
+    const std::string& gateway, HypIP::AddressOrigin origin,
+    const std::string& intf) :
     HypIPIfaces(bus, objPath.str.c_str(), HypIPIfaces::action::defer_emit),
     intf(std::move(intf)), parent(parent), objectPath(std::move(objPath))
 {
@@ -361,8 +360,8 @@ uint8_t HypIPAddress::prefixLength(uint8_t value)
     for (auto& it : parent.get().getBiosAttrsMap())
     {
         if ((it.first.compare(it.first.size() - prefixLenAttrName.size(),
-                              prefixLenAttrName.size(),
-                              prefixLenAttrName) == 0) &&
+                              prefixLenAttrName.size(), prefixLenAttrName) ==
+             0) &&
             (std::get<int64_t>(it.second) == length))
         {
             parent.get().setIpPropsInMap(it.first, value, "Integer");

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
@@ -114,7 +114,6 @@ void HypNetworkMgr::setBIOSTableAttrs()
         std::vector<std::string> interfaces;
         interfaces.emplace_back(biosMgrIntf);
         auto depth = 0;
-
         auto mapperCall = bus.get().new_method_call(mapperBus, mapperObj,
                                                     mapperIntf, "GetSubTree");
 

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
@@ -71,8 +71,7 @@ class HypNetworkMgr
      */
     HypNetworkMgr(stdplus::PinnedRef<sdbusplus::bus_t> bus,
                   stdplus::zstring_view path) :
-        bus(bus),
-        objectPath(std::string(path)){};
+        bus(bus), objectPath(std::string(path)) {};
 
     /** @brief Get the BaseBiosTable attributes
      *

--- a/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_nw_config_serialize.cpp
@@ -13,9 +13,8 @@ namespace persistdata
 
 void serialize(const NwConfigPropMap& list, std::string intf, std::string type)
 {
-    std::string filePath = HYP_NW_CONFIG_PERSIST_PATH + intf + "_" + type +
-                           "_network";
-
+    std::string filePath =
+        HYP_NW_CONFIG_PERSIST_PATH + intf + "_" + type + "_network";
     // Create directory if it doesnot exist
     if (!std::filesystem::exists(HYP_NW_CONFIG_PERSIST_PATH.c_str()))
     {
@@ -51,8 +50,8 @@ void serialize(const NwConfigPropMap& list, std::string intf, std::string type)
 
 bool deserialize(NwConfigPropMap& list, std::string intf, std::string type)
 {
-    std::string filePath = HYP_NW_CONFIG_PERSIST_PATH + intf + "_" + type +
-                           "_network";
+    std::string filePath =
+        HYP_NW_CONFIG_PERSIST_PATH + intf + "_" + type + "_network";
 
     try
     {

--- a/src/ibm/hypervisor-network-mgr-src/hyp_sys_config.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_sys_config.hpp
@@ -43,9 +43,8 @@ class HypSysConfig : public Iface
     HypSysConfig(stdplus::PinnedRef<sdbusplus::bus_t> bus,
                  sdbusplus::message::object_path objPath,
                  stdplus::PinnedRef<HypNetworkMgr> parent) :
-        Iface(bus, objPath.str.c_str(), Iface::action::defer_emit),
-        bus(bus), manager(parent){};
-
+        Iface(bus, objPath.str.c_str(), Iface::action::defer_emit), bus(bus),
+        manager(parent) {};
     /** @brief set the hostname of the system.
      *  @param[in] name - host name of the system.
      */

--- a/src/inventory_mac.cpp
+++ b/src/inventory_mac.cpp
@@ -86,8 +86,8 @@ stdplus::EtherAddr getfromInventory(sdbusplus::bus_t& bus,
 
     auto depth = 0;
 
-    auto mapperCall = bus.new_method_call(mapperBus, mapperObj, mapperIntf,
-                                          "GetSubTree");
+    auto mapperCall =
+        bus.new_method_call(mapperBus, mapperObj, mapperIntf, "GetSubTree");
 
     mapperCall.append(invRoot, depth, interfaces);
 
@@ -177,8 +177,8 @@ bool setInventoryMACOnSystem(sdbusplus::bus_t& bus, const std::string& intfname)
             for (const auto& keys : configJson.items())
             {
                 if (!(std::find(first_boot_status.begin(),
-                                first_boot_status.end(),
-                                keys.key()) != first_boot_status.end()))
+                                first_boot_status.end(), keys.key()) !=
+                      first_boot_status.end()))
                 {
                     lg2::info("Interface {NET_INTF} MAC is NOT set from VPD",
                               "NET_INTF", keys.key());

--- a/src/ncsi_util.cpp
+++ b/src/ncsi_util.cpp
@@ -69,8 +69,7 @@ class Command
     Command(
         int ncsiCmd, int operation = DEFAULT_VALUE,
         std::span<const unsigned char> p = std::span<const unsigned char>()) :
-        ncsi_cmd(ncsiCmd),
-        operation(operation), payload(p)
+        ncsi_cmd(ncsiCmd), operation(operation), payload(p)
     {}
 
     int ncsi_cmd;
@@ -257,8 +256,8 @@ CallBack sendCallBack = [](struct nl_msg* msg, void* arg) {
     }
 
     auto data_len = nla_len(tb[NCSI_ATTR_DATA]) - sizeof(NCSIPacketHeader);
-    unsigned char* data = (unsigned char*)nla_data(tb[NCSI_ATTR_DATA]) +
-                          sizeof(NCSIPacketHeader);
+    unsigned char* data =
+        (unsigned char*)nla_data(tb[NCSI_ATTR_DATA]) + sizeof(NCSIPacketHeader);
 
     // Dump the response to stdout. Enhancement: option to save response data
     auto str = toHexStr(std::span<const unsigned char>(data, data_len));
@@ -347,8 +346,8 @@ int applyCmd(int ifindex, const Command& cmd, int package = DEFAULT_VALUE,
 
     if (cmd.operation != DEFAULT_VALUE)
     {
-        std::vector<unsigned char> pl(sizeof(NCSIPacketHeader) +
-                                      cmd.payload.size());
+        std::vector<unsigned char> pl(
+            sizeof(NCSIPacketHeader) + cmd.payload.size());
         NCSIPacketHeader* hdr = (NCSIPacketHeader*)pl.data();
 
         std::copy(cmd.payload.begin(), cmd.payload.end(),

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -48,32 +48,33 @@ Manager::Manager(stdplus::PinnedRef<sdbusplus::bus_t> bus,
     systemdNetworkdEnabledMatch(
         bus, enabledMatch,
         [man = stdplus::PinnedRef(*this)](sdbusplus::message_t& m) {
-    std::string intf;
-    std::unordered_map<std::string, std::variant<std::string>> values;
-    try
-    {
-        m.read(intf, values);
-        auto it = values.find("AdministrativeState");
-        if (it == values.end())
-        {
-            return;
-        }
-        const std::string_view obj = m.get_path();
-        auto sep = obj.rfind('/');
-        if (sep == obj.npos || sep + 3 > obj.size())
-        {
-            throw std::invalid_argument("Invalid obj path");
-        }
-        auto ifidx = stdplus::StrToInt<10, uint16_t>{}(obj.substr(sep + 3));
-        const auto& state = std::get<std::string>(it->second);
-        man.get().handleAdminState(state, ifidx);
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error("AdministrativeState match parsing failed: {ERROR}", "ERROR",
-                   e);
-    }
-})
+            std::string intf;
+            std::unordered_map<std::string, std::variant<std::string>> values;
+            try
+            {
+                m.read(intf, values);
+                auto it = values.find("AdministrativeState");
+                if (it == values.end())
+                {
+                    return;
+                }
+                const std::string_view obj = m.get_path();
+                auto sep = obj.rfind('/');
+                if (sep == obj.npos || sep + 3 > obj.size())
+                {
+                    throw std::invalid_argument("Invalid obj path");
+                }
+                auto ifidx =
+                    stdplus::StrToInt<10, uint16_t>{}(obj.substr(sep + 3));
+                const auto& state = std::get<std::string>(it->second);
+                man.get().handleAdminState(state, ifidx);
+            }
+            catch (const std::exception& e)
+            {
+                lg2::error("AdministrativeState match parsing failed: {ERROR}",
+                           "ERROR", e);
+            }
+        })
 {
     reload.get().setCallback([self = stdplus::PinnedRef(*this)]() {
         for (auto& hook : self.get().reloadPreHooks)
@@ -139,8 +140,8 @@ Manager::Manager(stdplus::PinnedRef<sdbusplus::bus_t> bus,
     {
         unsigned ifidx = std::get<0>(link);
         stdplus::ToStrHandle<stdplus::IntToStr<10, unsigned>> tsh;
-        auto obj = stdplus::strCat("/org/freedesktop/network1/link/_3"sv,
-                                   tsh(ifidx));
+        auto obj =
+            stdplus::strCat("/org/freedesktop/network1/link/_3"sv, tsh(ifidx));
         auto req =
             bus.get().new_method_call("org.freedesktop.network1", obj.c_str(),
                                       "org.freedesktop.DBus.Properties", "Get");
@@ -364,34 +365,36 @@ void Manager::addDefGw(unsigned ifidx, stdplus::InAnyAddr addr)
     {
         std::visit(
             [&](auto addr) {
-            if constexpr (std::is_same_v<stdplus::In4Addr, decltype(addr)>)
-            {
-                it->second.defgw4.emplace(addr);
-            }
-            else
-            {
-                static_assert(std::is_same_v<stdplus::In6Addr, decltype(addr)>);
-                it->second.defgw6.emplace(addr);
-            }
-        },
-            addr);
-        if (auto it = interfacesByIdx.find(ifidx); it != interfacesByIdx.end())
-        {
-            std::visit(
-                [&](auto addr) {
                 if constexpr (std::is_same_v<stdplus::In4Addr, decltype(addr)>)
                 {
-                    it->second->EthernetInterfaceIntf::defaultGateway(
-                        stdplus::toStr(addr));
+                    it->second.defgw4.emplace(addr);
                 }
                 else
                 {
                     static_assert(
                         std::is_same_v<stdplus::In6Addr, decltype(addr)>);
-                    it->second->EthernetInterfaceIntf::defaultGateway6(
-                        stdplus::toStr(addr));
+                    it->second.defgw6.emplace(addr);
                 }
             },
+            addr);
+        if (auto it = interfacesByIdx.find(ifidx); it != interfacesByIdx.end())
+        {
+            std::visit(
+                [&](auto addr) {
+                    if constexpr (std::is_same_v<stdplus::In4Addr,
+                                                 decltype(addr)>)
+                    {
+                        it->second->EthernetInterfaceIntf::defaultGateway(
+                            stdplus::toStr(addr));
+                    }
+                    else
+                    {
+                        static_assert(
+                            std::is_same_v<stdplus::In6Addr, decltype(addr)>);
+                        it->second->EthernetInterfaceIntf::defaultGateway6(
+                            stdplus::toStr(addr));
+                    }
+                },
                 addr);
         }
     }
@@ -407,46 +410,52 @@ void Manager::removeDefGw(unsigned ifidx, stdplus::InAnyAddr addr)
     {
         std::visit(
             [&](auto addr) {
-            if constexpr (std::is_same_v<stdplus::In4Addr, decltype(addr)>)
-            {
-                if (it->second.defgw4 == addr)
-                {
-                    it->second.defgw4.reset();
-                }
-            }
-            else
-            {
-                static_assert(std::is_same_v<stdplus::In6Addr, decltype(addr)>);
-                if (it->second.defgw6 == addr)
-                {
-                    it->second.defgw6.reset();
-                }
-            }
-        },
-            addr);
-        if (auto it = interfacesByIdx.find(ifidx); it != interfacesByIdx.end())
-        {
-            std::visit(
-                [&](auto addr) {
                 if constexpr (std::is_same_v<stdplus::In4Addr, decltype(addr)>)
                 {
-                    stdplus::ToStrHandle<stdplus::ToStr<stdplus::In4Addr>> tsh;
-                    if (it->second->defaultGateway() == tsh(addr))
+                    if (it->second.defgw4 == addr)
                     {
-                        it->second->EthernetInterfaceIntf::defaultGateway("");
+                        it->second.defgw4.reset();
                     }
                 }
                 else
                 {
                     static_assert(
                         std::is_same_v<stdplus::In6Addr, decltype(addr)>);
-                    stdplus::ToStrHandle<stdplus::ToStr<stdplus::In6Addr>> tsh;
-                    if (it->second->defaultGateway6() == tsh(addr))
+                    if (it->second.defgw6 == addr)
                     {
-                        it->second->EthernetInterfaceIntf::defaultGateway6("");
+                        it->second.defgw6.reset();
                     }
                 }
             },
+            addr);
+        if (auto it = interfacesByIdx.find(ifidx); it != interfacesByIdx.end())
+        {
+            std::visit(
+                [&](auto addr) {
+                    if constexpr (std::is_same_v<stdplus::In4Addr,
+                                                 decltype(addr)>)
+                    {
+                        stdplus::ToStrHandle<stdplus::ToStr<stdplus::In4Addr>>
+                            tsh;
+                        if (it->second->defaultGateway() == tsh(addr))
+                        {
+                            it->second->EthernetInterfaceIntf::defaultGateway(
+                                "");
+                        }
+                    }
+                    else
+                    {
+                        static_assert(
+                            std::is_same_v<stdplus::In6Addr, decltype(addr)>);
+                        stdplus::ToStrHandle<stdplus::ToStr<stdplus::In6Addr>>
+                            tsh;
+                        if (it->second->defaultGateway6() == tsh(addr))
+                        {
+                            it->second->EthernetInterfaceIntf::defaultGateway6(
+                                "");
+                        }
+                    }
+                },
                 addr);
         }
     }

--- a/src/rtnetlink_server.cpp
+++ b/src/rtnetlink_server.cpp
@@ -123,8 +123,8 @@ static stdplus::ManagedFd makeSock()
 Server::Server(sdeventplus::Event& event, Manager& manager) :
     sock(makeSock()),
     io(event, sock.get(), EPOLLIN | EPOLLET, [&](auto&&... args) {
-    return eventHandler(manager, std::forward<decltype(args)>(args)...);
-})
+        return eventHandler(manager, std::forward<decltype(args)>(args)...);
+    })
 {
     auto cb = [&](const nlmsghdr& hdr, std::string_view data) {
         handler(manager, hdr, data);

--- a/src/system_configuration.cpp
+++ b/src/system_configuration.cpp
@@ -26,34 +26,35 @@ static constexpr char propMatch[] =
 
 SystemConfiguration::SystemConfiguration(
     stdplus::PinnedRef<sdbusplus::bus_t> bus, stdplus::const_zstring objPath) :
-    Iface(bus, objPath.c_str(), Iface::action::defer_emit),
-    bus(bus), hostnamePropMatch(
-                  bus, propMatch,
-                  [sc = stdplus::PinnedRef(*this)](sdbusplus::message_t& m) {
-    std::string intf;
-    std::unordered_map<std::string, std::variant<std::string>> values;
-    try
-    {
-        m.read(intf, values);
-        auto it = values.find("Hostname");
-        if (it == values.end())
-        {
-            return;
-        }
-        sc.get().Iface::hostName(std::get<std::string>(it->second));
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error("Hostname match parsing failed: {ERROR}", "ERROR", e);
-    }
-})
+    Iface(bus, objPath.c_str(), Iface::action::defer_emit), bus(bus),
+    hostnamePropMatch(
+        bus, propMatch,
+        [sc = stdplus::PinnedRef(*this)](sdbusplus::message_t& m) {
+            std::string intf;
+            std::unordered_map<std::string, std::variant<std::string>> values;
+            try
+            {
+                m.read(intf, values);
+                auto it = values.find("Hostname");
+                if (it == values.end())
+                {
+                    return;
+                }
+                sc.get().Iface::hostName(std::get<std::string>(it->second));
+            }
+            catch (const std::exception& e)
+            {
+                lg2::error("Hostname match parsing failed: {ERROR}", "ERROR",
+                           e);
+            }
+        })
 {
     try
     {
         std::variant<std::string> name;
-        auto req = bus.get().new_method_call(HOSTNAMED_SVC, HOSTNAMED_OBJ,
-                                             "org.freedesktop.DBus.Properties",
-                                             "Get");
+        auto req =
+            bus.get().new_method_call(HOSTNAMED_SVC, HOSTNAMED_OBJ,
+                                      "org.freedesktop.DBus.Properties", "Get");
 
         req.append(HOSTNAMED_INTF, "Hostname");
         auto reply = req.call();

--- a/src/system_queries.cpp
+++ b/src/system_queries.cpp
@@ -27,8 +27,8 @@ using std::literals::string_view_literals::operator""sv;
 static stdplus::Fd& getIFSock()
 {
     using namespace stdplus::fd;
-    static auto fd = socket(SocketDomain::INet, SocketType::Datagram,
-                            SocketProto::IP);
+    static auto fd =
+        socket(SocketDomain::INet, SocketType::Datagram, SocketProto::IP);
     return fd;
 }
 
@@ -88,8 +88,9 @@ EthInfo getEthInfo(stdplus::zstring_view ifname)
     return optionalIFReq(
                ifname, SIOCETHTOOL, "ETHTOOL"sv,
                [&](const ifreq&) {
-        return EthInfo{.autoneg = edata.autoneg != 0, .speed = edata.speed};
-    },
+                   return EthInfo{.autoneg = edata.autoneg != 0,
+                                  .speed = edata.speed};
+               },
                &edata)
         .value_or(EthInfo{});
 }
@@ -120,16 +121,17 @@ void deleteIntf(unsigned idx)
     ifinfomsg msg = {};
     msg.ifi_family = AF_UNSPEC;
     msg.ifi_index = idx;
-    netlink::performRequest(NETLINK_ROUTE, RTM_DELLINK, NLM_F_REPLACE, msg,
-                            [&](const nlmsghdr& hdr, std::string_view data) {
-        int err = 0;
-        if (hdr.nlmsg_type == NLMSG_ERROR)
-        {
-            err = netlink::extractRtData<nlmsgerr>(data).error;
-        }
-        throw std::runtime_error(
-            std::format("Failed to delete `{}`: {}", idx, strerror(err)));
-    });
+    netlink::performRequest(
+        NETLINK_ROUTE, RTM_DELLINK, NLM_F_REPLACE, msg,
+        [&](const nlmsghdr& hdr, std::string_view data) {
+            int err = 0;
+            if (hdr.nlmsg_type == NLMSG_ERROR)
+            {
+                err = netlink::extractRtData<nlmsgerr>(data).error;
+            }
+            throw std::runtime_error(
+                std::format("Failed to delete `{}`: {}", idx, strerror(err)));
+        });
 }
 
 } // namespace phosphor::network::system

--- a/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
+++ b/test/ibm/hypervisor-network-mgr-test/test_hyp_ethernet_interface.cpp
@@ -30,9 +30,8 @@ class TestHypEthernetInterface : public testing::Test
         interface.createIPAddrObj();
     }
 
-    static MockHypEthernetInterface
-        makeInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
-                      HypNetworkMgr& manager)
+    static MockHypEthernetInterface makeInterface(
+        stdplus::PinnedRef<sdbusplus::bus_t> bus, HypNetworkMgr& manager)
     {
         return {bus,
                 sdbusplus::message::object_path(

--- a/test/mock_syscall.cpp
+++ b/test/mock_syscall.cpp
@@ -105,8 +105,8 @@ ssize_t sendmsg_link_dump(std::queue<std::string>& msgs, std::string_view in)
         const auto nlbegin = msgBuf.size();
         msgBuf.append(NLMSG_SPACE(sizeof(ifinfomsg)), '\0');
         {
-            auto& info = *reinterpret_cast<ifinfomsg*>(msgBuf.data() + nlbegin +
-                                                       NLMSG_HDRLEN);
+            auto& info = *reinterpret_cast<ifinfomsg*>(
+                msgBuf.data() + nlbegin + NLMSG_HDRLEN);
             info.ifi_index = i.idx;
             info.ifi_flags = i.flags;
         }

--- a/test/test_ethernet_interface.cpp
+++ b/test/test_ethernet_interface.cpp
@@ -39,9 +39,8 @@ class TestEthernetInterface : public stdplus::gtest::TestWithTmp
 
     {}
 
-    static MockEthernetInterface
-        makeInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
-                      TestManager& manager)
+    static MockEthernetInterface makeInterface(
+        stdplus::PinnedRef<sdbusplus::bus_t> bus, TestManager& manager)
     {
         AllIntfInfo info{InterfaceInfo{
             .type = ARPHRD_ETHER, .idx = 1, .flags = 0, .name = "test0"}};
@@ -82,12 +81,13 @@ TEST_F(TestEthernetInterface, Fields)
     constexpr stdplus::EtherAddr mac{0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
     constexpr unsigned mtu = 150;
 
-    AllIntfInfo info{InterfaceInfo{.type = ARPHRD_ETHER,
-                                   .idx = 2,
-                                   .flags = IFF_RUNNING,
-                                   .name = "test1",
-                                   .mac = mac,
-                                   .mtu = mtu}};
+    AllIntfInfo info{InterfaceInfo{
+        .type = ARPHRD_ETHER,
+        .idx = 2,
+        .flags = IFF_RUNNING,
+        .name = "test1",
+        .mac = mac,
+        .mtu = mtu}};
     MockEthernetInterface intf(bus, manager, info,
                                "/xyz/openbmc_test/network"sv, config::Parser());
 

--- a/test/test_network_manager.hpp
+++ b/test/test_network_manager.hpp
@@ -24,8 +24,8 @@ struct TestManagerData
     {
         EXPECT_CALL(mockReload, setCallback(testing::_))
             .WillOnce([&](fu2::unique_function<void()>&& cb) {
-            reloadCb = std::move(cb);
-        });
+                reloadCb = std::move(cb);
+            });
         return mockReload;
     }
 };

--- a/test/test_rtnetlink.cpp
+++ b/test/test_rtnetlink.cpp
@@ -55,12 +55,13 @@ TEST(IntfFromRtm, AllAttrs)
     msg.mtu_hdr.rta_len = RTA_LENGTH(sizeof(msg.mtu));
 
     auto info = intfFromRtm(stdplus::raw::asView<char>(msg));
-    auto expected = InterfaceInfo{.type = 4,
-                                  .idx = 1,
-                                  .flags = 2,
-                                  .name = "eth0",
-                                  .mac = ether_addr{0, 1, 2, 3, 4, 5},
-                                  .mtu = 50};
+    auto expected = InterfaceInfo{
+        .type = 4,
+        .idx = 1,
+        .flags = 2,
+        .name = "eth0",
+        .mac = ether_addr{0, 1, 2, 3, 4, 5},
+        .mtu = 50};
     EXPECT_EQ(info, expected);
 }
 


### PR DESCRIPTION
clang-format-18 isn't compatible with the clang-format-17 output, so we need to reformat the code with the latest version.  The way clang-18 handles lambda formatting also changed, so we have made changes to the organization default style format to better handle lambda formatting.

See I5e08687e696dd240402a2780158664b7113def0e for updated style. See Iea0776aaa7edd483fa395e23de25ebf5a6288f71 for clang-18 enablement.

Change-Id: I335e0c726360eaae85b9b54c16b5dcbe4a3f182e