### PR TITLE
Add IPv4 routing tables for each ethernet interfaces

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1015,9 +1015,11 @@ void EthernetInterface::writeConfigurationFile()
         {
             if (!dhcp4())
             {
+                auto& gateways = network["Gateway"];
                 auto gateway4 = EthernetInterfaceIntf::defaultGateway();
-                if (!gateway4.empty())
+                if (!gateway4.empty() && prefixLength)
                 {
+                    gateways.emplace_back(gateway4);
                     auto& gateway4route = config.map["Route"].emplace_back();
                     gateway4route["Gateway"].emplace_back(gateway4);
                     gateway4route["GatewayOnLink"].emplace_back("true");


### PR DESCRIPTION
This commit configures separate routing tables for each ethernet interface so that static gateway routes added on that interface (eth0/eth1) will be in added to separate routing tables

Currently there are gateway routing issues when multiple interfaces configured in different subnets

This commit fixes routing configuration issues when static addresses configured on eth0 and eth1 interfaces.

Tested by:
Ran CT/Automation network test cases
Verified routing with eth0 static configuration and eth1 dhcp configuration
Verified routing with eth0 DHCP configuration and eth1 static configuration
Both eth0 and eth1 with static IP configurations

Change-Id: If2103f8a850d554e51084f1ebe1bb15e616a8bec