### PR TITLE
Add IPv4 routing tables for each ethernet interfaces

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1135,6 +1135,7 @@ void EthernetInterface::writeConfigurationFile()
                 }
             }
         }
+        uint8_t prefixLength = 0;
         {
             auto& address = network["Address"];
             for (const auto& addr : addrs)
@@ -1144,18 +1145,50 @@ void EthernetInterface::writeConfigurationFile()
                     address.emplace_back(
                         fmt::format("{}/{}", addr.second->address(),
                                     addr.second->prefixLength()));
+                    if (addr.second->type() == IP::Protocol::IPv4)
+                    {
+                        prefixLength = addr.second->prefixLength();
+                    }
                 }
             }
         }
         {
             if (!dhcp4())
             {
+                auto& gateways = network["Gateway"];
                 auto gateway4 = EthernetInterfaceIntf::defaultGateway();
-                if (!gateway4.empty())
+                if (!gateway4.empty() && prefixLength)
                 {
+                    gateways.emplace_back(gateway4);
                     auto& gateway4route = config.map["Route"].emplace_back();
                     gateway4route["Gateway"].emplace_back(gateway4);
                     gateway4route["GatewayOnLink"].emplace_back("true");
+                    // Creating different routing tables for each ethernet
+                    // interface to solve eth0 and eth1 route entry order issues
+                    // Routing table id of "eth0" interface is 10
+                    // Routing table id of "eth1" interface is 20
+                    std::string routingTableId;
+                    if (interfaceName() == "eth0")
+                    {
+                        routingTableId = "10";
+                    }
+                    else if (interfaceName() == "eth1")
+                    {
+                        routingTableId = "20";
+                    }
+                    gateway4route["Table"].emplace_back(routingTableId);
+                    std::string routeAddressPrefix =
+                        setIPv4AddressLastOctetToZero(gateway4);
+                    routeAddressPrefix =
+                        routeAddressPrefix + "/" + std::to_string(prefixLength);
+                    auto& routingPolicyTo =
+                        config.map["RoutingPolicyRule"].emplace_back();
+                    routingPolicyTo["Table"].emplace_back(routingTableId);
+                    routingPolicyTo["To"].emplace_back(routeAddressPrefix);
+                    auto& routingPolicyFrom =
+                        config.map["RoutingPolicyRule"].emplace_back();
+                    routingPolicyFrom["Table"].emplace_back(routingTableId);
+                    routingPolicyFrom["From"].emplace_back(routeAddressPrefix);
                 }
             }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -244,5 +244,30 @@ bool isUnicast(const ether_addr& mac)
 }
 
 } // namespace mac_address
+
+std::string setIPv4AddressLastOctetToZero(const std::string& ip)
+{
+    std::vector<std::string> octets;
+    std::string octet;
+    std::stringstream ss(ip);
+
+    // Split the IP address by '.'
+    while (std::getline(ss, octet, '.'))
+    {
+        octets.push_back(octet);
+    }
+
+    // Modify the last octet
+    if (octets.size() == 4)
+    {
+        octets[3] = "0";
+    }
+
+    std::string modifiedIP =
+        octets[0] + "." + octets[1] + "." + octets[2] + "." + octets[3];
+
+    return modifiedIP;
+}
+
 } // namespace network
 } // namespace phosphor

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -117,6 +117,11 @@ DHCPVal getDHCPValue(const config::Parser& config);
 bool getDHCPProp(const config::Parser& config, DHCPType dhcpType,
                  std::string_view key);
 
+/** @brief Set IPv4 address last octet to zero
+ *  @param[in] ip - IPv4 address
+ */
+std::string setIPv4AddressLastOctetToZero(const std::string& ip);
+
 namespace internal
 {
 


### PR DESCRIPTION
This commit configures separate routing tables for each ethernet interface so that static gateway routes added on that interface (eth0/eth1) will be in added to separate routing tables

Currently there are gateway routing issues when multiple interfaces configured in different subnets

This commit fixes routing configuration issues when static addresses configured on eth0 and eth1 interfaces.

Tested by:
Ran CT/Automation network test cases
Verified routing with eth0 static configuration and eth1 dhcp configuration
Verified routing with eth0 DHCP configuration and eth1 static configuration
Both eth0 and eth1 with static IP configurations

Change-Id: If2103f8a850d554e51084f1ebe1bb15e616a8bec