### PR TITLE
Watch NTP server change in timesyncd

### DIFF
--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -130,6 +130,10 @@ class EthernetInterface : public Ifaces
      */
     void watchNTPServers();
 
+    /** @brief Function to watch status of systemd timesyncd.
+     */
+    void watchTimeSyncActiveState();
+
     /** @brief Function to create ipAddress dbus object.
      *  @param[in] addressType - Type of ip address.
      *  @param[in] ipAddress- IP address.
@@ -307,6 +311,7 @@ class EthernetInterface : public Ifaces
     bool originIsManuallyAssigned(IP::AddressOrigin origin);
 
     std::unique_ptr<sdbusplus::bus::match::match> ntpServerMatch;
+    std::unique_ptr<sdbusplus::bus::match::match> activeStateMatch;
 
     int handleNCSITimeout();
 

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -199,6 +199,7 @@ void Manager::createInterface(const AllIntfInfo& info, bool enabled)
     intf->loadNTPServers(config);
     intf->loadStaticGateways(config);
     intf->watchNTPServers();
+    intf->watchTimeSyncActiveState();
     auto ptr = intf.get();
     interfaces.insert_or_assign(*info.intf.name, std::move(intf));
     interfacesByIdx.insert_or_assign(info.intf.idx, ptr);


### PR DESCRIPTION
Any change in the dynamic NTP servers when system is in manual mode as the timesyncd is disabled. However the change is not updated even when the system is switched to NTP mode. This commit also consists of the changes to the reload the NTP servers whenever it switches from manual to NTP mode.

Tested by:
Switched to manual mode, updated the NTP servers in DHCP. Verified the updated NTP server is reflected in networkd when switched back to manual.

Fixes : https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=649008
Upstream : https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/71834

Change-Id: I6a58e44795e60490d8bee106548de043be40bfe8