### PR TITLE
1050: Filter static ntp servers from  ntpservers (#157)

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -838,14 +838,28 @@ void EthernetInterface::loadNTPServers(const config::Parser& config)
             "Failed to get NTP TimeSyncMethod from Systemd Settings");
     }
 
+    ServerList staticNTPServers = config.map.getValueStrings("Network", "NTP");
+
     // Read NTP servers from TimeSyncd only when NTP mode enabled.
     // This check is needed to avoid TimeSyncd calls when Manual mode set.
     if (timeSyncMethod == "xyz.openbmc_project.Time.Synchronization.Method.NTP")
     {
-        EthernetInterfaceIntf::ntpServers(getNTPServerFromTimeSyncd());
+        ServerList ntpServerList = getNTPServerFromTimeSyncd();
+        std::unordered_set<std::string> staticNTPServersSet(
+            staticNTPServers.begin(), staticNTPServers.end());
+        ServerList networkSuppliedServers;
+
+        std::copy_if(ntpServerList.begin(), ntpServerList.end(),
+                     std::back_inserter(networkSuppliedServers),
+                     [&staticNTPServersSet](const std::string& server) {
+                         return staticNTPServersSet.find(server) ==
+                                staticNTPServersSet.end();
+                     });
+
+        EthernetInterfaceIntf::ntpServers(networkSuppliedServers);
     }
-    EthernetInterfaceIntf::staticNTPServers(
-        config.map.getValueStrings("Network", "NTP"));
+
+    EthernetInterfaceIntf::staticNTPServers(staticNTPServers);
 }
 
 void EthernetInterface::loadNameServers(const config::Parser& config)


### PR DESCRIPTION
#### Filter static ntp servers from  ntpservers (#157)
```
EthernetInterface::ntpServers contains both static and dynamic netservers.
EthernetInterface::ntpServers is returned as network provided ntp servers
in redfish response.

This commit filter out static ntp servers from the ntpServers to have it
contain only network provided ntp servers.

Tested by:

1. Enable DHCP to fetch NTP servers list from the DHCP server. Do a
   GET on NetworkProtocol and verify the NetworkSuppliedServers contains
   NTP servers from DHCP only.

2. Verified it has not altered the behavior of static NTPServers list

Change-Id: I0cf186cae9159bd56a3166d5921d32d51216cf47

Signed-off-by: Jishnu CM <jishnunambiarcm@duck.com>
Co-authored-by: Jishnu CM <jishnunambiarcm@duck.com>```