### PR TITLE
Filter static ntp servers from  ntpservers

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -718,9 +718,22 @@ ServerList EthernetInterface::staticNameServers(ServerList value)
 
 void EthernetInterface::loadNTPServers(const config::Parser& config)
 {
-    EthernetInterfaceIntf::ntpServers(getNTPServerFromTimeSyncd());
-    EthernetInterfaceIntf::staticNTPServers(
-        config.map.getValueStrings("Network", "NTP"));
+    ServerList ntpServerList = getNTPServerFromTimeSyncd();
+    ServerList staticNTPServers = config.map.getValueStrings("Network", "NTP");
+
+    std::unordered_set<std::string> staticNTPServersSet(
+        staticNTPServers.begin(), staticNTPServers.end());
+    ServerList networkSuppliedServers;
+
+    std::copy_if(ntpServerList.begin(), ntpServerList.end(),
+                 std::back_inserter(networkSuppliedServers),
+                 [&staticNTPServersSet](const std::string& server) {
+                     return staticNTPServersSet.find(server) ==
+                            staticNTPServersSet.end();
+                 });
+
+    EthernetInterfaceIntf::ntpServers(networkSuppliedServers);
+    EthernetInterfaceIntf::staticNTPServers(staticNTPServers);
 }
 
 void EthernetInterface::loadNameServers(const config::Parser& config)


### PR DESCRIPTION
EthernetInterface::ntpServers contains both static and dynamic ntpservers. EthernetInterface::ntpServers is returned as network provided ntp servers in redfish response.

This commit filter out static ntp servers from the ntpServers to have it contain only network provided ntp servers.

Tested by:

1. Enable DHCP to fetch NTP servers list from the DHCP server. Do a GET on NetworkProtocol and verify the NetworkSuppliedServers contains NTP servers from DHCP only.

2. Verified it has not altered the behavior of static NTPServers list

Fixes : https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=613774
Upstream : https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/74609

Change-Id: I0cf186cae9159bd56a3166d5921d32d51216cf47