### PR TITLE
1110 GHE: Networkd default config to disable eth1 IPv4 linklocal

### DIFF
--- a/60-phosphor-networkd-default.network.in
+++ b/60-phosphor-networkd-default.network.in
@@ -1,4 +1,6 @@
 [Match]
+Name=eth0
+Name=!lo
 Type=ether
 [Network]
 DHCP=true

--- a/60-phosphor-networkd-eth1-default.network.in
+++ b/60-phosphor-networkd-eth1-default.network.in
@@ -1,4 +1,6 @@
 [Match]
+Name=eth1
+Name=!lo
 Type=ether
 [Network]
 DHCP=true


### PR DESCRIPTION
There was an issue while having IPv4 linklocal address on both ethernet interfaces, so it was decided to turn off IPv4 link local on eth1 interface.

This commit modifies factory reset default configuration files to disable IPv4 linklocal address on eth1 interface.