### PR TITLE
Avoid writing duplicate DNS entries to config file

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -142,8 +142,8 @@ EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
                                      std::string&& objPath,
                                      const config::Parser& config,
                                      bool enabled) :
-    Ifaces(bus, objPath.c_str(), Ifaces::action::defer_emit),
-    manager(manager), bus(bus), objPath(std::move(objPath))
+    Ifaces(bus, objPath.c_str(), Ifaces::action::defer_emit), manager(manager),
+    bus(bus), objPath(std::move(objPath))
 {
     interfaceName(*info.intf.name, true);
     auto dhcpVal = getDHCPValue(config);
@@ -784,6 +784,7 @@ bool EthernetInterface::nicEnabled(bool value)
 
 ServerList EthernetInterface::staticNameServers(ServerList value)
 {
+    std::vector<std::string> dnsUniqueValues;
     for (auto& ip : value)
     {
         try
@@ -798,19 +799,20 @@ ServerList EthernetInterface::staticNameServers(ServerList value)
             elog<InvalidArgument>(Argument::ARGUMENT_NAME("StaticNameserver"),
                                   Argument::ARGUMENT_VALUE(ip.c_str()));
         }
+        if (std::find(dnsUniqueValues.begin(), dnsUniqueValues.end(), ip) ==
+            dnsUniqueValues.end())
+        {
+            dnsUniqueValues.push_back(ip);
+        }
     }
-    try
-    {
-        EthernetInterfaceIntf::staticNameServers(value);
 
-        writeConfigurationFile();
-        manager.get().reloadConfigs();
-    }
-    catch (const InternalFailure& e)
-    {
-        log<level::ERR>("Exception processing DNS entries");
-    }
-    return EthernetInterfaceIntf::staticNameServers();
+    value =
+        EthernetInterfaceIntf::staticNameServers(std::move(dnsUniqueValues));
+
+    writeConfigurationFile();
+    manager.get().reloadConfigs();
+
+    return value;
 }
 
 void EthernetInterface::loadNTPServers(const config::Parser& config)


### PR DESCRIPTION
Currently, we store the dbus DNS values in a vector without checking duplicate entries. which allows duplicate entries to be saved if the user supplies same DNS server settings multiple times.

With this commit, we will check duplicate entries and remove them to get a unique list of DNS values.

Tested By: PATCH -d '{"StaticNameServers":["10.4.5.60", "10.4.5.60"]}'
    https://${bmc_ip}/redfish/v1/Managers/bmc/EthernetInterfaces/eth0

Change-Id: I0c18eb5fec36c4305f1ded4c5e57bbd046ca4576