### PR TITLE
Add LLDP configuration support

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -157,7 +157,11 @@ EthernetInterface::EthernetInterface(
     EthernetInterfaceIntf::dhcp6(dhcpVal.v6, true);
     EthernetInterfaceIntf::ipv6AcceptRA(getIPv6AcceptRA(config), true);
     EthernetInterfaceIntf::nicEnabled(enabled, true);
-
+    auto lldpVal = parseLLDPConf();
+    if (!lldpVal.empty())
+    {
+        EthernetInterfaceIntf::emitLLDP(lldpVal[interfaceName()], true);
+    }
     EthernetInterfaceIntf::ntpServers(
         config.map.getValueStrings("Network", "NTP"), true);
 
@@ -1310,6 +1314,16 @@ void EthernetInterface::VlanProperties::delete_()
     }
 
     eth.get().manager.get().reloadConfigs();
+}
+
+bool EthernetInterface::emitLLDP(bool value)
+{
+    if (emitLLDP() != EthernetInterfaceIntf::emitLLDP(value))
+    {
+        manager.get().writeLLDPDConfigurationFile();
+        manager.get().reloadLLDPService();
+    }
+    return value;
 }
 
 void EthernetInterface::reloadConfigs()

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -242,6 +242,11 @@ class EthernetInterface : public Ifaces
      */
     void reloadConfigs();
 
+    /** @brief set conf file for LLDP
+     *  @param[in] value - lldp value of the interface.
+     */
+    bool emitLLDP(bool value) override;
+
     using EthernetInterfaceIntf::interfaceName;
     using EthernetInterfaceIntf::linkUp;
     using EthernetInterfaceIntf::mtu;
@@ -250,6 +255,7 @@ class EthernetInterface : public Ifaces
 
     using EthernetInterfaceIntf::defaultGateway;
     using EthernetInterfaceIntf::defaultGateway6;
+    using EthernetInterfaceIntf::emitLLDP;
 
   protected:
     /** @brief get the NTP server list from the timsyncd dbus obj

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -22,6 +22,7 @@
 
 #include <filesystem>
 #include <format>
+#include <fstream>
 
 namespace phosphor
 {
@@ -32,6 +33,12 @@ using namespace phosphor::logging;
 using namespace sdbusplus::xyz::openbmc_project::Common::Error;
 using Argument = xyz::openbmc_project::Common::InvalidArgument;
 using std::literals::string_view_literals::operator""sv;
+
+constexpr auto systemdBusname = "org.freedesktop.systemd1";
+constexpr auto systemdObjPath = "/org/freedesktop/systemd1";
+constexpr auto systemdInterface = "org.freedesktop.systemd1.Manager";
+constexpr auto lldpFilePath = "/etc/lldpd.conf";
+constexpr auto lldpService = "lldpd.service";
 
 static constexpr const char enabledMatch[] =
     "type='signal',sender='org.freedesktop.network1',path_namespace='/org/"
@@ -519,6 +526,45 @@ void Manager::handleAdminState(std::string_view state, unsigned ifidx)
         {
             createInterface(it->second, managed);
         }
+    }
+}
+
+void Manager::writeLLDPDConfigurationFile()
+{
+    std::ofstream lldpdConfig(lldpFilePath);
+
+    for (const auto& intf : interfaces)
+    {
+        bool emitlldp = intf.second->EthernetInterfaceIntf::emitLLDP();
+        if (emitlldp)
+        {
+            lldpdConfig << "configure ports " << intf.second->interfaceName()
+                        << " lldp status tx-only" << std::endl;
+        }
+        else
+        {
+            lldpdConfig << "configure ports " << intf.second->interfaceName()
+                        << " lldp status disabled" << std::endl;
+        }
+    }
+
+    lldpdConfig.close();
+}
+
+void Manager::reloadLLDPService()
+{
+    try
+    {
+        auto method = bus.get().new_method_call(
+            systemdBusname, systemdObjPath, systemdInterface, "RestartUnit");
+        method.append(lldpService, "replace");
+        bus.get().call_noreply(method);
+    }
+    catch (const sdbusplus::exception_t& ex)
+    {
+        lg2::error("Failed to restart service {SERVICE}: {ERR}", "SERVICE",
+                   lldpService, "ERR", ex);
+        elog<InternalFailure>();
     }
 }
 

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -535,7 +535,7 @@ void Manager::writeLLDPDConfigurationFile()
 
     for (const auto& intf : interfaces)
     {
-        bool emitlldp = intf.second->EthernetInterfaceIntf::emitLLDP();
+        bool emitlldp = intf.second->emitLLDP();
         if (emitlldp)
         {
             lldpdConfig << "configure ports " << intf.second->interfaceName()
@@ -564,7 +564,6 @@ void Manager::reloadLLDPService()
     {
         lg2::error("Failed to restart service {SERVICE}: {ERR}", "SERVICE",
                    lldpService, "ERR", ex);
-        elog<InternalFailure>();
     }
 }
 

--- a/src/network_manager.hpp
+++ b/src/network_manager.hpp
@@ -55,6 +55,10 @@ class Manager : public ManagerIface
      */
     void writeToConfigurationFile();
 
+    /** @brief write the lldp conf file
+     */
+    void writeLLDPDConfigurationFile();
+
     /** @brief Adds a single interface to the interface map */
     void addInterface(const InterfaceInfo& info);
     void removeInterface(const InterfaceInfo& info);
@@ -101,6 +105,10 @@ class Manager : public ManagerIface
     {
         reload.get().schedule();
     }
+
+    /** Reload LLDP configuration
+     */
+    void reloadLLDPService();
 
     /** @brief Persistent map of EthernetInterface dbus objects and their names
      */

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -4,6 +4,7 @@
 #include <stdplus/raw.hpp>
 #include <stdplus/zstring_view.hpp>
 
+#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -76,6 +77,10 @@ bool getDHCPProp(const config::Parser& config, DHCPType dhcpType,
  *  @param[in] ip - IPv4 address
  */
 std::string setIPv4AddressLastOctetToZero(const std::string& ip);
+
+/** @brief Read LLDP configuration from lldpd conf file
+ */
+std::map<std::string, bool> parseLLDPConf();
 
 namespace internal
 {


### PR DESCRIPTION
This commit implements EmitLLDP D-bus property to support configuration of enable/disable LLDP of each ethernet interface.

Tested by:
Set EmitLLDP D-bus property on
xyz.openbmc_project.Network.EthernetInterface

 /etc/lldpd.conf configuration populated 
configure ports eth0 lldp status tx-only
configure ports eth1 lldp status disabled

Change-Id: I4ebedff9d3f914219f2f84c861fdee126584a94b