### PR TITLE
Handle InvalidArgument Error for Out-of-Range MAC addresses

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1138,12 +1138,14 @@ std::string EthernetInterface::macAddress([[maybe_unused]] std::string value)
     {
         newMAC = stdplus::fromStr<stdplus::EtherAddr>(value);
     }
-    catch (const std::invalid_argument&)
+    catch (const std::exception& e)
     {
-        lg2::error("MAC Address {NET_MAC} is not valid", "NET_MAC", value);
-        elog<InvalidArgument>(Argument::ARGUMENT_NAME("MACAddress"),
+        lg2::error("Invalid Ip address {NET_MAC}: {ERROR}", "NET_MAC", value,
+                   "ERROR", e);
+        elog<InvalidArgument>(Argument::ARGUMENT_NAME("netmac"),
                               Argument::ARGUMENT_VALUE(value.c_str()));
     }
+
     if (!newMAC.isUnicast())
     {
         lg2::error("MAC Address {NET_MAC} is not valid", "NET_MAC", value);


### PR DESCRIPTION
Error is not thrown when an out-of-range MAC address is provided. This commit addresses the issue by explicitly handling such cases and returning an InvalidArgument error when a MAC address falls outside the valid range.

Tested By:
Verified the out-of-range MAC address case and ensured proper invalid argument error is thrown.

Change-Id: I508cf267878811fcf70fcce7dfa7ff804b160bc1