### PR TITLE
Add LLDP configuration support

### DIFF
--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -210,6 +210,7 @@ void Manager::createInterface(const AllIntfInfo& info, bool enabled)
     auto ptr = intf.get();
     interfaces.insert_or_assign(*info.intf.name, std::move(intf));
     interfacesByIdx.insert_or_assign(info.intf.idx, ptr);
+    loadDefaultLLDPConfig();
 }
 
 void Manager::addInterface(const InterfaceInfo& info)
@@ -527,6 +528,21 @@ void Manager::handleAdminState(std::string_view state, unsigned ifidx)
             createInterface(it->second, managed);
         }
     }
+}
+
+void Manager::loadDefaultLLDPConfig()
+{
+    std::ofstream lldpdConfig(lldpFilePath);
+
+    lldpdConfig << "configure system description BMC" << std::endl;
+
+    for (const auto& intf : interfaces)
+    {
+        lldpdConfig << "configure ports " << intf.second->interfaceName()
+                    << " lldp status disabled" << std::endl;
+    }
+
+    lldpdConfig.close();
 }
 
 void Manager::writeLLDPDConfigurationFile()

--- a/src/network_manager.hpp
+++ b/src/network_manager.hpp
@@ -110,6 +110,10 @@ class Manager : public ManagerIface
      */
     void reloadLLDPService();
 
+    /** Load default LLDP configuration
+     */
+    void loadDefaultLLDPConfig();
+
     /** @brief Persistent map of EthernetInterface dbus objects and their names
      */
     stdplus::string_umap<std::unique_ptr<EthernetInterface>> interfaces;


### PR DESCRIPTION
This commit implements EmitLLDP D-bus property to support configuration of enable/disable LLDP of each ethernet interface.

Tested by:
Set EmitLLDP D-bus property on
xyz.openbmc_project.Network.EthernetInterface

Change-Id: I4ebedff9d3f914219f2f84c861fdee126584a94b