### PR TITLE
Hypervisor network: Fix origin issue

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -1099,6 +1099,7 @@ HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled(DHCPConf value)
                 else
                 {
                     method = "IPv4Static";
+                    (itr->second)->origin(HypIP::AddressOrigin::Static);
                     // Reset IPv4 to the defaults only when dhcpv4 is disabled;
                     // if the old4 is false (which means static), then
                     // reset shouldn't happen in order to restore the static


### PR DESCRIPTION
Whenever dhcpv4 is disabled the origin of that ip object was not set back to static. This commit solves the mentioned issue.

Tested By:

'''
PATCH -D patch.txt -d '{"StatelessAddressAutoConfig": {"IPv6AutoConfigEnabled": true}}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0 PATCH -D patch.txt -d '{"DHCPv4" : {"DHCPEnabled": true}}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0 PATCH -D patch.txt -d '{"DHCPv4" : {"DHCPEnabled": false}}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0 '''