### PR TITLE
Handle IPv4 address for IPv6 Static Default Gateway

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -617,7 +617,7 @@ ObjectPath EthernetInterface::staticRoute(std::string destination,
     InAddrAny addr;
     try
     {
-        switch(protocolType)
+        switch (protocolType)
         {
             case IP::Protocol::IPv4:
                 addr = ToAddr<in_addr>{}(gateway);

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -617,7 +617,17 @@ ObjectPath EthernetInterface::staticRoute(std::string destination,
     InAddrAny addr;
     try
     {
-        addr = ToAddr<InAddrAny>{}(gateway);
+        switch(protocolType)
+        {
+            case IP::Protocol::IPv4:
+                addr = ToAddr<in_addr>{}(gateway);
+                break;
+            case IP::Protocol::IPv6:
+                addr = ToAddr<in6_addr>{}(gateway);
+                break;
+            default:
+                throw std::logic_error("Exhausted protocols");
+        }
     }
     catch (const std::exception& e)
     {


### PR DESCRIPTION
Error is not thrown when an IPV4 address is provided. This commit addresses the issue by explicitly handling such cases and returning an InvalidArgument error when a IPV4address is configured for IPV6 Static Default Gateway field.

Tested By:
Verified the test case and ensured proper
invalid argument error is thrown.

Change-Id: I3925a40840d20c3d44a44fb6e2ef93672a4ef69e