### PR TITLE
Handle IPv4 address for IPv6 Static Default Gateway

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -619,7 +619,17 @@ ObjectPath EthernetInterface::staticRoute(std::string destination,
     InAddrAny addr;
     try
     {
-        addr = ToAddr<InAddrAny>{}(gateway);
+        switch (protocolType)
+        {
+            case IP::Protocol::IPv4:
+                addr = ToAddr<in_addr>{}(gateway);
+                break;
+            case IP::Protocol::IPv6:
+                addr = ToAddr<in6_addr>{}(gateway);
+                break;
+            default:
+                throw std::logic_error("Exhausted protocols");
+        }
     }
     catch (const std::exception& e)
     {

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -29,7 +29,7 @@ constexpr bool validUnicast(in_addr addr) noexcept
 
 constexpr bool validUnicast(in6_addr addr) noexcept
 {
-    return addr != in6_addr{} &&                       // ::/128
+    return addr != in6_addr{} && // ::/128
            addr != in6_addr{0, 0, 0, 0, 0, 0, 0, 0,
                             0, 0, 0, 0, 0, 0, 0, 1} && // ::1/128
            addr.s6_addr[0] != 0xff;                    // ff00::/8


### PR DESCRIPTION
Error is not thrown when an IPV4 address is provided. This commit addresses the issue by explicitly handling such cases and returning an InvalidArgument error when a IPV4address is configured for IPV6 Static Default Gateway field.

Tested By:
Verified the test case and ensured proper
invalid argument error is thrown.

Change-Id: If46dbedd78cd4841a9efbd6c485f9217996d3185