### PR TITLE
Handle IPv4 address for IPv6 Static Default Gateway

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -557,7 +557,17 @@ ObjectPath EthernetInterface::staticGateway(std::string gateway,
     std::string route;
     try
     {
-        addr.emplace(stdplus::fromStr<stdplus::InAnyAddr>(gateway));
+        switch (protocolType)
+        {
+            case IP::Protocol::IPv4:
+                addr.emplace(stdplus::fromStr<stdplus::In4Addr>(gateway));
+                break;
+            case IP::Protocol::IPv6:
+                addr.emplace(stdplus::fromStr<stdplus::In6Addr>(gateway));
+                break;
+            default:
+                throw std::logic_error("Exhausted protocols");
+        }
         route = gateway;
     }
     catch (const std::exception& e)


### PR DESCRIPTION
Error is not thrown when an IPV4 address is provided. This commit addresses the issue by explicitly handling such cases and returning an InvalidArgument error when a IPV4address is configured for IPV6 Static Default Gateway field.

Tested By:
Verified the test case and ensured proper
invalid argument error is thrown.

Change-Id: Ibc3d2a77ae56f5b23c3f8bca12409693aa2f3ad9