### PR TITLE
Remove logging DHCP state

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1392,8 +1392,6 @@ void EthernetInterface::watchTimeSyncActiveState()
                     std::string activeState = std::get<std::string>(it->second);
                     if (activeState == "active" || activeState == "inactive")
                     {
-                        lg2::info("systemd-timesyncd switched to : {SYD_STATE}",
-                                  "SYD_STATE", activeState);
                         config::Parser config(config::pathForIntfConf(
                             manager.get().getConfDir(), interfaceName()));
                         loadNTPServers(config);


### PR DESCRIPTION
The PR removes writing the DHCP state change to journal log

upstream : https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/71834