### PR TITLE
Fix ipv4 static and DHCP IPaddress coexistence

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -515,13 +515,6 @@ ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
             Argument::ARGUMENT_VALUE(stdplus::toStr(prefixLength).c_str()));
     }
 
-    // TODO This is a workaround to avoid IPv4 static and DHCP IP address
-    // coexistence Disable IPv4 DHCP while configuring IPv4 static address
-    if ((protType == IP::Protocol::IPv4) && dhcpIsEnabled(protType, false))
-    {
-        disableDHCP(protType);
-    }
-
     auto it = addrs.find(*ifaddr);
     if (it == addrs.end())
     {
@@ -541,6 +534,13 @@ ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
 
     writeConfigurationFile();
     manager.get().reloadConfigs();
+
+    // TODO This is a workaround to avoid IPv4 static and DHCP IP address
+    // coexistence Disable IPv4 DHCP while configuring IPv4 static address
+    if ((protType == IP::Protocol::IPv4) && dhcpIsEnabled(protType, false))
+    {
+        disableDHCP(protType);
+    }
 
     return it->second->getObjPath();
 }


### PR DESCRIPTION
There is an intermittent issue of configuring IPv4 static IP when interface already has same DHCP gateway.

Currently when  DHCP gateway configured on interface and new static IP added with the same DHCP gateway then
 DHCP gets disabled and  gateway set to 0.0.0.0, causing issues in applying the new static gateway.

This commit ensures that when DHCP is disabled, configure the static gateway which preventing a temporary loss of network configuration.

Tested by:
Verified configuring static IP with same DHCP gateway 
Verified DHCP enable/disable tests