### PR TITLE
LLDP: Update management ip configuration

### DIFF
--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -534,6 +534,7 @@ void Manager::writeLLDPDConfigurationFile()
     std::ofstream lldpdConfig(lldpFilePath);
 
     lldpdConfig << "configure system description BMC" << std::endl;
+    lldpdConfig << "configure system ip management pattern eth*" << std::endl;
     for (const auto& intf : interfaces)
     {
         bool emitlldp = intf.second->emitLLDP();


### PR DESCRIPTION
This commit updates lldp management ip configuration to list all ip addresses of interfaces

Tested by:
Captured lldpd data from peer helper system

MgmtIP:    9.3.197.172
MgmtIP:    192.168.9.32
MgmtIP:    9009:db8:0:2:192:168:9:50
MgmtIP:    2002:903:15f:325:a94:efff:fe82:5