### PR TITLE
Hypervisor: Fix patching defaultGateway6 with null

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -567,6 +567,8 @@ void HypIPAddress::delete_()
     {
         resetBaseBiosTableAttrs("IPv6");
     }
+    // Set enabled property to false
+    HypIPAddress::enabled(false);
 }
 
 } // namespace network


### PR DESCRIPTION
When IPv6 default gateway property is deleted from bmcweb, bmcweb internally sets it to the default value "::". But hypervisor-networkd throws invalid argument error on setting it with "::".

This commit fixes this issue by handling "::" or empty gateway during the set operation.

Fixes: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=685272

Tested By:

[1] PATCH '{"IPv6StaticAddresses":[null]}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0