### PR TITLE
Fix Default IPv6 static address Origin

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -1149,6 +1149,7 @@ HypEthInterface::DHCPConf HypEthInterface::dhcpEnabled(DHCPConf value)
                 else
                 {
                     method = "IPv6Static";
+                    (itr->second)->origin(HypIP::AddressOrigin::Static);
                     // Reset IPv6 to the defaults only when dhcpv6 is disabled;
                     // if old6/oldra is false (which means static), then
                     // reset shouldn't happen in order to restore the static


### PR DESCRIPTION
IPv6 address origin set to DHCP when DHCPv4 enabled and DHCPv6 is disabled. This commit fixes this issue by setting Origin to Static

Tested By:
Verified VMI IP4/v6 DHCP tests