### PR TITLE
Add IPv4 routing tables for each ethernet interfaces

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1124,24 +1124,13 @@ void EthernetInterface::writeConfigurationFile()
                     auto& gateway4route = config.map["Route"].emplace_back();
                     gateway4route["Gateway"].emplace_back(gateway4);
                     gateway4route["GatewayOnLink"].emplace_back("true");
-                    // Creating different routing tables for each ethernet
-                    // interface to solve eth0 and eth1 route entry order issues
-                    // Routing table id of "eth0" interface is 10
-                    // Routing table id of "eth1" interface is 20
-                    std::string routingTableId;
-                    if (interfaceName() == "eth0")
-                    {
-                        routingTableId = "10";
-                    }
-                    else if (interfaceName() == "eth1")
-                    {
-                        routingTableId = "20";
-                    }
+
+                    std::string routingTableId =
+                        std::to_string(generateRouteTableID(interfaceName()));
                     gateway4route["Table"].emplace_back(routingTableId);
                     std::string routeAddressPrefix =
-                        setIPv4AddressLastOctetToZero(gateway4);
-                    routeAddressPrefix =
-                        routeAddressPrefix + "/" + std::to_string(prefixLength);
+                        generateNetworkRoute(gateway4, prefixLength);
+
                     auto& routingPolicyTo =
                         config.map["RoutingPolicyRule"].emplace_back();
                     routingPolicyTo["Table"].emplace_back(routingTableId);
@@ -1150,6 +1139,12 @@ void EthernetInterface::writeConfigurationFile()
                         config.map["RoutingPolicyRule"].emplace_back();
                     routingPolicyFrom["Table"].emplace_back(routingTableId);
                     routingPolicyFrom["From"].emplace_back(routeAddressPrefix);
+                    auto& routingPolicyDestination =
+                        config.map["Route"].emplace_back();
+                    routingPolicyDestination["Table"].emplace_back(
+                        routingTableId);
+                    routingPolicyDestination["Destination"].emplace_back(
+                        routeAddressPrefix);
                 }
             }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5,6 +5,7 @@
 #include "config_parser.hpp"
 #include "types.hpp"
 
+#include <arpa/inet.h>
 #include <sys/wait.h>
 
 #include <phosphor-logging/elog-errors.hpp>
@@ -286,6 +287,37 @@ std::map<std::string, bool> parseLLDPConf()
     }
     lldpdConfig.close();
     return portStatus;
+}
+
+uint32_t generateRouteTableID(const std::string& iface)
+{
+    size_t hash = std::hash<std::string>{}(iface);
+    uint32_t id = static_cast<uint32_t>(hash & 0xFFFFFFFF);
+
+    return (id == 0) ? 1 : id;
+}
+
+std::string generateNetworkRoute(const std::string& ip, int prefixLength)
+{
+    in_addr addr{};
+    if ((inet_pton(AF_INET, ip.c_str(), &addr) != 1) || (prefixLength < 0) ||
+        (prefixLength > 32))
+    {
+        return {};
+    }
+
+    uint32_t ipInt = ntohl(addr.s_addr);
+    uint32_t mask = (prefixLength == 0) ? 0 : (~0U << (32 - prefixLength));
+    uint32_t networkInt = ipInt & mask;
+
+    in_addr networkAddr{};
+    networkAddr.s_addr = htonl(networkInt);
+
+    std::array<char, INET_ADDRSTRLEN> buf{};
+    if (!inet_ntop(AF_INET, &networkAddr, buf.data(), buf.size()))
+        return {};
+
+    return std::string(buf.data()) + "/" + std::to_string(prefixLength);
 }
 
 } // namespace network

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -82,6 +82,17 @@ std::string setIPv4AddressLastOctetToZero(const std::string& ip);
  */
 std::map<std::string, bool> parseLLDPConf();
 
+/** @brief Generate network route using given gateway and prefix length
+ *  @param[in] gateway - IPv4 address
+ *  @param[in] prefixLength - prefix length of IP address
+ */
+std::string generateNetworkRoute(const std::string& gateway, int prefixLength);
+
+/** @brief Generate unique routing table id for given interface
+ *  @param[in] iface - interface name
+ */
+uint32_t generateRouteTableID(const std::string& iface);
+
 namespace internal
 {
 


### PR DESCRIPTION
This commit configures separate routing tables for each ethernet interface so that static gateway routes added on that interface (eth0/eth1) will be added to separate routing tables

Currently there are gateway routing issues when multiple interfaces configured in different subnets

This commit fixes routing configuration issues when static addresses configured on eth0 and eth1 interfaces.

Tested by:
Ran CT/Automation network test cases
Verified routing with eth0 static configuration and eth1 dhcp configuration
Verified routing with eth0 DHCP configuration and eth1 static configuration
Both eth0 and eth1 with static IP configurations

Change-Id: If2103f8a850d554e51084f1ebe1bb15e616a8bec