### PR TITLE
Add IPv4 routing tables for ethernet interfaces

### DIFF
--- a/src/util.hpp
+++ b/src/util.hpp
@@ -117,10 +117,16 @@ DHCPVal getDHCPValue(const config::Parser& config);
 bool getDHCPProp(const config::Parser& config, DHCPType dhcpType,
                  std::string_view key);
 
-/** @brief Set IPv4 address last octet to zero
- *  @param[in] ip - IPv4 address
+/** @brief Generate network route using given gateway and prefix length
+ *  @param[in] gateway - IPv4 address
+ *  @param[in] prefixLength - prefix length of IP address
  */
-std::string setIPv4AddressLastOctetToZero(const std::string& ip);
+std::string generateNetworkRoute(const std::string& gateway, int prefixLength);
+
+/** @brief Generate unique routing table id for given interface
+ *  @param[in] iface - interface name
+ */
+uint32_t generateRouteTableID(const std::string& iface);
 
 namespace internal
 {


### PR DESCRIPTION
This commit configures separate routing tables for each ethernet interface so that static gateway routes added on that interface (eth0/eth1) will be added to separate routing tables

Currently there are gateway routing issues when multiple interfaces configured in different subnets

This commit fixes routing configuration issues when static addresses configured on eth0 and eth1 interfaces.

Tested by:
Ran CT/Automation network test cases
Verified routing with eth0 static configuration and eth1 dhcp configuration
Verified routing with eth0 DHCP configuration and eth1 static configuration
Both eth0 and eth1 with static IP configurations