### PR TITLE
1060: Add IPv4 routing tables for ethernet interfaces (#192)

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1186,24 +1186,13 @@ void EthernetInterface::writeConfigurationFile()
                     auto& gateway4route = config.map["Route"].emplace_back();
                     gateway4route["Gateway"].emplace_back(gateway4);
                     gateway4route["GatewayOnLink"].emplace_back("true");
-                    // Creating different routing tables for each ethernet
-                    // interface to solve eth0 and eth1 route entry order issues
-                    // Routing table id of "eth0" interface is 10
-                    // Routing table id of "eth1" interface is 20
-                    std::string routingTableId;
-                    if (interfaceName() == "eth0")
-                    {
-                        routingTableId = "10";
-                    }
-                    else if (interfaceName() == "eth1")
-                    {
-                        routingTableId = "20";
-                    }
+
+                    std::string routingTableId =
+                        std::to_string(generateRouteTableID(interfaceName()));
                     gateway4route["Table"].emplace_back(routingTableId);
                     std::string routeAddressPrefix =
-                        setIPv4AddressLastOctetToZero(gateway4);
-                    routeAddressPrefix = routeAddressPrefix + "/" +
-                                         std::to_string(prefixLength);
+                        generateNetworkRoute(gateway4, prefixLength);
+
                     auto& routingPolicyTo =
                         config.map["RoutingPolicyRule"].emplace_back();
                     routingPolicyTo["Table"].emplace_back(routingTableId);
@@ -1212,6 +1201,12 @@ void EthernetInterface::writeConfigurationFile()
                         config.map["RoutingPolicyRule"].emplace_back();
                     routingPolicyFrom["Table"].emplace_back(routingTableId);
                     routingPolicyFrom["From"].emplace_back(routeAddressPrefix);
+                    auto& routingPolicyDestination =
+                        config.map["Route"].emplace_back();
+                    routingPolicyDestination["Table"].emplace_back(
+                        routingTableId);
+                    routingPolicyDestination["Destination"].emplace_back(
+                        routeAddressPrefix);
                 }
             }
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -118,10 +118,16 @@ DHCPVal getDHCPValue(const config::Parser& config);
 bool getDHCPProp(const config::Parser& config, DHCPType dhcpType,
                  std::string_view key);
 
-/** @brief Set IPv4 address last octet to zero
- *  @param[in] ip - IPv4 address
+/** @brief Generate network route using given gateway and prefix length
+ *  @param[in] gateway - IPv4 address
+ *  @param[in] prefixLength - prefix length of IP address
  */
-std::string setIPv4AddressLastOctetToZero(const std::string& ip);
+std::string generateNetworkRoute(const std::string& gateway, int prefixLength);
+
+/** @brief Generate unique routing table id for given interface
+ *  @param[in] iface - interface name
+ */
+uint32_t generateRouteTableID(const std::string& iface);
 
 namespace internal
 {


### PR DESCRIPTION
#### Add IPv4 routing tables for ethernet interfaces (#192)
```
This commit configures separate routing tables for each ethernet
interface so that static gateway routes added on that interface
(eth0/eth1) will be added to separate routing tables

Currently there are gateway routing issues when multiple interfaces
configured in different subnets

This commit fixes routing configuration issues when static addresses
configured on eth0 and eth1 interfaces.

Tested by:
Ran CT/Automation network test cases
Verified routing with eth0 static configuration and eth1 dhcp
configuration
Verified routing with eth0 DHCP configuration and eth1 static
configuration
Both eth0 and eth1 with static IP configurations
```