### PR TITLE
Watch NTP server change in timesyncd

### DIFF
--- a/src/network_manager.hpp
+++ b/src/network_manager.hpp
@@ -167,6 +167,18 @@ class Manager : public ManagerIface
 
     /** @brief Creates the interface in the maps */
     void createInterface(const AllIntfInfo& info, bool enabled);
+
+  private:
+    /** @brief Function used to watch change in NTP server.
+     */
+    void watchNTPServers(EthernetInterface* intf);
+
+    /** @brief Function to watch status of systemd timesyncd.
+     */
+    void watchTimeSyncActiveState(EthernetInterface* intf);
+
+    std::unique_ptr<sdbusplus::bus::match::match> ntpServerMatch;
+    std::unique_ptr<sdbusplus::bus::match::match> activeStateMatch;
 };
 
 } // namespace network


### PR DESCRIPTION
In phosphor-networkd, network-provided NTP servers are updated only at the time of interface creation. Any modifications to the NTP server are not reflected in networkd until the next restart. As of systemd version 255, timesyncd emits a property changed signal when the LinkNTPServers property is updated. This commit implements a watch for the signal from timesyncd, ensuring that phosphor-networkd loads the updated NTP servers dynamically.

Also, any change in the dynamic NTP servers when system is in manual mode as the timesyncd is disabled. However the change is not updated even when the system is switched to NTP mode. This commit also consists of the changes to the reload the NTP servers whenever it switches from manual to NTP mode.

Tested by:

1. Connected the BMC to a DHCP server
2. Configured the DHCP server with the NTP server IP.
3. Verified that timesyncd is updated with the new NTP server IP.
4. Confirmed that phosphor-networkd receives the signal and updates the D-Bus with the latest NTP servers from timesyncd.
5. Switched to manual mode, updated the NTP servers in DHCP. Verified the updated NTP server is reflected in networkd.

Upstream : https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/71834

Change-Id: I6a58e44795e60490d8bee106548de043be40bfe8