### PR TITLE
Fix ipv4 static and DHCP IPaddress coexistence

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -550,13 +550,6 @@ void EthernetInterface::disableDHCP(IP::Protocol protocol)
 ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
                                  uint8_t prefixLength, std::string)
 {
-    // TODO This is a workaround to avoid IPv4 static and DHCP IP address
-    // coexistence Disable IPv4 DHCP while configuring IPv4 static address
-    if ((protType == IP::Protocol::IPv4) && dhcpIsEnabled(protType, false))
-    {
-        EthernetInterfaceIntf::dhcp4(false, true);
-    }
-
     std::optional<stdplus::InAnyAddr> addr;
     try
     {
@@ -620,6 +613,13 @@ ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
 
     writeConfigurationFile();
     manager.get().reloadConfigs();
+
+    // TODO This is a workaround to avoid IPv4 static and DHCP IP address
+    // coexistence Disable IPv4 DHCP while configuring IPv4 static address
+    if ((protType == IP::Protocol::IPv4) && dhcpIsEnabled(protType, false))
+    {
+        disableDHCP(protType);
+    }
 
     return it->second->getObjPath();
 }


### PR DESCRIPTION
There is an intermittent issue of configuring IPv4 static gateway when interface already has same DHCP gateway.

Tested by:
Verified configuring static IP with same DHCP gateway Verified DHCP enable/disable tests