### PR TITLE
Fix IPv4 route destination for ethernet interfaces

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1230,12 +1230,6 @@ void EthernetInterface::writeConfigurationFile()
                         config.map["RoutingPolicyRule"].emplace_back();
                     routingPolicyFrom["Table"].emplace_back(routingTableId);
                     routingPolicyFrom["From"].emplace_back(routeAddressPrefix);
-                    auto& routingPolicyDestination =
-                        config.map["Route"].emplace_back();
-                    routingPolicyDestination["Table"].emplace_back(
-                        routingTableId);
-                    routingPolicyDestination["Destination"].emplace_back(
-                        routeAddressPrefix);
                 }
             }
 


### PR DESCRIPTION
This change was introduced in this https://github.com/ibm-openbmc/phosphor-networkd/commit/7ebc1c02667837a6d41f15c46500ef1ea8f6c8e0 commit causing direct HMC/BMC connection issues

This Fix removes these lines from network configuration which fixes defect https://jazz07.rchland.ibm.com:13443/jazz/web/projects/FPS%20Collaboration#action=com.ibm.team.workitem.viewWorkItem&id=715563

```
[Route]
Destination=192.168.128.0/24
Table=367012575
```
