### PR TITLE
1060: ncsi-timeout: restart ipmi services (no lg2)

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -104,6 +104,14 @@ void EthernetInterface::NCSITimeoutWatch::callback(sdeventplus::source::IO&,
         int fd = intf.handleNCSITimeout();
         if (fd >= 0)
         {
+            // NCSI timeout handling was a success, check if IPMI workaround
+            // needed
+            int rc = intf.handleIpmiOnNCSITimeout(intf.interfaceName());
+            if (rc)
+            {
+                log<level::WARNING>("Error restarting IPMI");
+            }
+
             close(io.get_fd());
             io.set_fd(fd);
             return;
@@ -280,6 +288,94 @@ int EthernetInterface::handleNCSITimeout()
     }
 
     return fd;
+}
+
+bool EthernetInterface::isServiceActive(const std::string& serviceName)
+{
+    std::variant<std::string> serviceState;
+    sdbusplus::message::object_path unitPath;
+
+    auto method = bus.get().new_method_call(
+        "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+        "org.freedesktop.systemd1.Manager", "GetUnit");
+
+    method.append(serviceName);
+
+    try
+    {
+        auto result = bus.get().call(method);
+        result.read(unitPath);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        auto msg = fmt::format("Error in GetUnit call: {}\n", e.what());
+        log<level::ERR>(msg.c_str());
+        return false;
+    }
+
+    method = bus.get().new_method_call(
+        "org.freedesktop.systemd1",
+        static_cast<const std::string&>(unitPath).c_str(),
+        "org.freedesktop.DBus.Properties", "Get");
+
+    method.append("org.freedesktop.systemd1.Unit", "ActiveState");
+
+    try
+    {
+        auto result = bus.get().call(method);
+        result.read(serviceState);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        auto msg = fmt::format("Error in ActiveState Get: {}\n", e.what());
+        log<level::ERR>(msg.c_str());
+        return false;
+    }
+
+    const auto& currentStateStr = std::get<std::string>(serviceState);
+    return currentStateStr == "active" || currentStateStr == "activating";
+}
+
+int EthernetInterface::handleIpmiOnNCSITimeout(const std::string& intfName)
+{
+    // Need to force the network IPMI service to restart after the unbind/bind
+    auto msg = fmt::format("Handling IPMI On NCSI Timeout on {}\n", intfName);
+    log<level::INFO>(msg.c_str());
+
+    // Only run the IPMI workaround if the service is running
+    auto serviceName = std::format("phosphor-ipmi-net@{}.service", intfName);
+    if (isServiceActive(serviceName))
+    {
+        msg = fmt::format("IPMI on {} is active so run the workaround\n",
+                          intfName);
+        log<level::INFO>(msg.c_str());
+
+        // The workaround is to restart the service so it connects back up
+        // to the newly bound network interface
+        try
+        {
+            auto method = bus.get().new_method_call(
+                "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+                "org.freedesktop.systemd1.Manager", "RestartUnit");
+            method.append(serviceName, "replace");
+            bus.get().call_noreply(method);
+        }
+        catch (const sdbusplus::exception_t& e)
+        {
+            msg = fmt::format("Failed to restart service {} : {}\n",
+                              serviceName, e.what());
+            log<level::ERR>(msg.c_str());
+            return -1;
+        }
+    }
+    else
+    {
+        msg = fmt::format("IPMI on {} is not active so no workaround needed\n",
+                          intfName);
+        log<level::INFO>(msg.c_str());
+    }
+
+    return 0;
 }
 
 void EthernetInterface::updateInfo(const InterfaceInfo& info, bool skipSignal)

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -315,6 +315,10 @@ class EthernetInterface : public Ifaces
 
     int handleNCSITimeout();
 
+    bool isServiceActive(const std::string& serviceName);
+
+    int handleIpmiOnNCSITimeout(const std::string& intfName);
+
     std::filesystem::path ncsiTimeoutPath;
     std::filesystem::path ncsiWatchDriver;
     std::string ncsiWatchDeviceName;


### PR DESCRIPTION
When the NCSI timeout is hit, and the workaround is run to unbind and bind the eth device that hit the timeout, external ipmitool communication to the BMC no longer works. The IPMI service is not aware of the unbind/bind so it's monitoring a stale network connection.

The solution for this issue is to restart the corresponding IPMI service after the unbind/bind has occurred. This restart should only be executed if the IPMI service for that ethernet device is enabled.

For testing, a patch in the kernel was utilized to allow the NCSI timeout to be triggered via a write to
/sys/class/net/eth0/test_ncsi_timeout.

Tested:
- Verified that if external IPMI is not enabled (Network IPMI (out-of-band IPMI)) in Policies section of GUI, that the IPMI service is not restarted when an NCSI timeout is detected
- Verified at BMC Ready with CEC power off that if out-of-band IPMI is enabled that the workaround to restart the corresponding IPMI service is run and that ipmitool commands to the BMC continue to work afterwards
- Verified at the same test as above at PHYP Standby (also verified that the host console ssh to port 2200 continued to work fine through the unbind/bind workaround)