### PR TITLE
1050: ncsi-timeout: restart ipmi services (no lg2)

### DIFF
--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -314,6 +314,10 @@ class EthernetInterface : public Ifaces
 
     int handleNCSITimeout();
 
+    bool isServiceActive(const std::string& serviceName);
+
+    int handleIpmiOnNCSITimeout(const std::string& intfName);
+
     std::filesystem::path ncsiTimeoutPath;
     std::filesystem::path ncsiWatchDriver;
     std::string ncsiWatchDeviceName;


### PR DESCRIPTION
When the NCSI timeout is hit, and the workaround is run to unbind and bind the eth device that hit the timeout, external ipmitool communication to the BMC no longer works. The IPMI service is not aware of the unbind/bind so it's monitoring a stale network connection.

The solution for this issue is to restart the corresponding IPMI service after the unbind/bind has occurred. This restart should only be executed if the IPMI service for that ethernet device is enabled.

For testing, a patch in the kernel was utilized to allow the NCSI timeout to be triggered via a write to
/sys/class/net/eth0/test_ncsi_timeout.

Tested:
- Verified that if external IPMI is not enabled (Network IPMI (out-of-band IPMI)) in Policies section of GUI, that the IPMI service is not restarted when an NCSI timeout is detected
- Verified at BMC Ready with CEC power off that if out-of-band IPMI is enabled that the workaround to restart the corresponding IPMI service is run and that ipmitool commands to the BMC continue to work afterwards
- Verified at the same test as above at PHYP Standby (also verified that the host console ssh to port 2200 continued to work fine through the unbind/bind workaround)