### PR TITLE
Remove linklocal IP address when static ipv4 address configured

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -631,8 +631,7 @@ ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
     }
 
     writeConfigurationFile();
-    manager.get().reloadConfigs();
-
+    manager.get().restartSystemdUnit("systemd-networkd.service");
     return it->second->getObjPath();
 }
 
@@ -1230,6 +1229,15 @@ void EthernetInterface::writeConfigurationFile()
                         config.map["RoutingPolicyRule"].emplace_back();
                     routingPolicyFrom["Table"].emplace_back(routingTableId);
                     routingPolicyFrom["From"].emplace_back(routeAddressPrefix);
+
+                    auto& routingPolicyDestination =
+                        config.map["Route"].emplace_back();
+                    routingPolicyDestination["Table"].emplace_back(
+                        routingTableId);
+                    routingPolicyDestination["GatewayOnLink"].emplace_back(
+                        "true");
+                    routingPolicyDestination["Destination"].emplace_back(
+                        routeAddressPrefix);
                 }
             }
 
@@ -1414,7 +1422,7 @@ std::string EthernetInterface::defaultGateway(std::string gateway)
     {
         gateway = EthernetInterfaceIntf::defaultGateway(std::move(gateway));
         writeConfigurationFile();
-        manager.get().reloadConfigs();
+        manager.get().restartSystemdUnit("systemd-networkd.service");
     }
     return gateway;
 }

--- a/src/ipaddress.cpp
+++ b/src/ipaddress.cpp
@@ -112,7 +112,7 @@ void IPAddress::delete_()
     }
 
     parent.get().writeConfigurationFile();
-    parent.get().manager.get().reloadConfigs();
+    parent.get().manager.get().restartSystemdUnit("systemd-networkd.service");
 }
 
 } // namespace network

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -569,5 +569,23 @@ void Manager::reloadLLDPService()
     }
 }
 
+void Manager::restartSystemdUnit(const std::string& unit)
+{
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+        auto method = bus.new_method_call(
+            "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+            "org.freedesktop.systemd1.Manager", "RestartUnit");
+        method.append(unit, "replace");
+        bus.call_noreply(method);
+    }
+    catch (const sdbusplus::exception_t& ex)
+    {
+        lg2::error("Failed to restart service {SERVICE}: {ERR}", "SERVICE",
+                   unit, "ERR", ex);
+    }
+}
+
 } // namespace network
 } // namespace phosphor

--- a/src/network_manager.hpp
+++ b/src/network_manager.hpp
@@ -110,6 +110,10 @@ class Manager : public ManagerIface
      */
     void reloadLLDPService();
 
+    /** Restart systemd service unit
+     */
+    void restartSystemdUnit(const std::string& unit);
+
     /** @brief Persistent map of EthernetInterface dbus objects and their names
      */
     stdplus::string_umap<std::unique_ptr<EthernetInterface>> interfaces;


### PR DESCRIPTION
This commit configures systemd-networkd to remove IPv4 link local address when IPv4
 static address assigned on interface and adds link local IP back when static ip address deleted
 
 Tested By:
 Verified Add/Modify IP Address test cases in different network setup
 Ran network automation test suite 