### PR TITLE
Revert "Fix IPv4 route destination for ethernet interfaces (#200)"

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1230,6 +1230,14 @@ void EthernetInterface::writeConfigurationFile()
                         config.map["RoutingPolicyRule"].emplace_back();
                     routingPolicyFrom["Table"].emplace_back(routingTableId);
                     routingPolicyFrom["From"].emplace_back(routeAddressPrefix);
+                    auto& routingPolicyDestination =
+                        config.map["Route"].emplace_back();
+                    routingPolicyDestination["Table"].emplace_back(
+                        routingTableId);
+                    routingPolicyDestination["GatewayOnLink"].emplace_back(
+                        "true");
+                    routingPolicyDestination["Destination"].emplace_back(
+                        routeAddressPrefix);
                 }
             }
 


### PR DESCRIPTION
This reverts commit ddd8fb2ad215e3a080c673b3112f84f07ee61fa2.
and populates "GatewayOnLink" under [Route] section

Tested by:
Verified Add/Modify IP Address test cases in different network setup Ran network automation test suite