### PR TITLE
Restart systemd-networkd during static n/w configurations

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -631,7 +631,7 @@ ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
     }
 
     writeConfigurationFile();
-    manager.get().reloadConfigs();
+    manager.get().restartConfigs();
 
     return it->second->getObjPath();
 }
@@ -731,7 +731,7 @@ ObjectPath EthernetInterface::staticGateway(std::string gateway,
     }
 
     writeConfigurationFile();
-    manager.get().reloadConfigs();
+    manager.get().restartConfigs();
 
     return it->second->getObjPath();
 }
@@ -890,7 +890,7 @@ ServerList EthernetInterface::staticNameServers(ServerList value)
         EthernetInterfaceIntf::staticNameServers(std::move(dnsUniqueValues));
 
     writeConfigurationFile();
-    manager.get().reloadConfigs();
+    manager.get().restartConfigs();
 
     return value;
 }
@@ -1422,7 +1422,7 @@ std::string EthernetInterface::defaultGateway(std::string gateway)
     {
         gateway = EthernetInterfaceIntf::defaultGateway(std::move(gateway));
         writeConfigurationFile();
-        manager.get().reloadConfigs();
+        manager.get().restartConfigs();
     }
     return gateway;
 }
@@ -1434,7 +1434,7 @@ std::string EthernetInterface::defaultGateway6(std::string gateway)
     {
         gateway = EthernetInterfaceIntf::defaultGateway6(std::move(gateway));
         writeConfigurationFile();
-        manager.get().reloadConfigs();
+        manager.get().restartConfigs();
     }
     return gateway;
 }

--- a/src/ipaddress.cpp
+++ b/src/ipaddress.cpp
@@ -112,7 +112,7 @@ void IPAddress::delete_()
     }
 
     parent.get().writeConfigurationFile();
-    parent.get().manager.get().reloadConfigs();
+    parent.get().manager.get().restartConfigs();
 }
 
 } // namespace network

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -48,10 +48,12 @@ static constexpr const char enabledMatch[] =
 
 Manager::Manager(stdplus::PinnedRef<sdbusplus::bus_t> bus,
                  stdplus::PinnedRef<DelayedExecutor> reload,
+                 stdplus::PinnedRef<DelayedExecutor> restart,
                  stdplus::zstring_view objPath,
                  const std::filesystem::path& confDir) :
     ManagerIface(bus, objPath.c_str(), ManagerIface::action::defer_emit),
-    reload(reload), bus(bus), objPath(std::string(objPath)), confDir(confDir),
+    reload(reload), restart(restart), bus(bus), objPath(std::string(objPath)),
+    confDir(confDir),
     systemdNetworkdEnabledMatch(
         bus, enabledMatch,
         [man = stdplus::PinnedRef(*this)](sdbusplus::message_t& m) {
@@ -126,6 +128,25 @@ Manager::Manager(stdplus::PinnedRef<sdbusplus::bus_t> bus,
         }
         self.get().reloadPostHooks.clear();
     });
+
+    restart.get().setCallback([self = stdplus::PinnedRef(*this)]() {
+        try
+        {
+            lg2::info("Restarting systemd-networkd");
+            auto method = self.get().bus.get().new_method_call(
+                "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+                "org.freedesktop.systemd1.Manager", "RestartUnit");
+
+            method.append("systemd-networkd.service");
+            method.append("replace");
+            self.get().bus.get().call(method);
+        }
+        catch (const sdbusplus::exception_t& ex)
+        {
+            lg2::error("Failed to restart configuration: {ERROR}", "ERROR", ex);
+        }
+    });
+
     std::vector<
         std::tuple<int32_t, std::string, sdbusplus::message::object_path>>
         links;

--- a/src/network_manager.hpp
+++ b/src/network_manager.hpp
@@ -41,11 +41,13 @@ class Manager : public ManagerIface
     /** @brief Constructor to put object onto bus at a dbus path.
      *  @param[in] bus - Bus to attach to.
      *  @param[in] reload - The executor for reloading configs
+     *  @param[in] restart - The executor for restarting configs
      *  @param[in] objPath - Path to attach at.
      *  @param[in] confDir - Network Configuration directory path.
      */
     Manager(stdplus::PinnedRef<sdbusplus::bus_t> bus,
             stdplus::PinnedRef<DelayedExecutor> reload,
+            stdplus::PinnedRef<DelayedExecutor> restart,
             stdplus::zstring_view objPath,
             const std::filesystem::path& confDir);
 
@@ -106,6 +108,14 @@ class Manager : public ManagerIface
         reload.get().schedule();
     }
 
+    /** @brief Arms a timer to tell systemd-network to restart all of the
+     * network configurations
+     */
+    inline void restartConfigs()
+    {
+        restart.get().schedule();
+    }
+
     /** Reload LLDP configuration
      */
     void reloadLLDPService();
@@ -132,6 +142,9 @@ class Manager : public ManagerIface
   protected:
     /** @brief Handle to the object used to trigger reloads of networkd. */
     stdplus::PinnedRef<DelayedExecutor> reload;
+
+    /** @brief Handle to the object used to trigger restart of networkd. */
+    stdplus::PinnedRef<DelayedExecutor> restart;
 
     /** @brief Persistent sdbusplus DBus bus connection. */
     stdplus::PinnedRef<sdbusplus::bus_t> bus;

--- a/src/network_manager_main.cpp
+++ b/src/network_manager_main.cpp
@@ -67,7 +67,8 @@ int main()
     sdbusplus::server::manager_t objManager(bus, DEFAULT_OBJPATH);
 
     stdplus::Pinned<TimerExecutor> reload(event, std::chrono::seconds(3));
-    stdplus::Pinned<Manager> manager(bus, reload, DEFAULT_OBJPATH,
+    stdplus::Pinned<TimerExecutor> restart(event, std::chrono::seconds(2));
+    stdplus::Pinned<Manager> manager(bus, reload, restart, DEFAULT_OBJPATH,
                                      "/etc/systemd/network");
     netlink::Server svr(event, manager);
 

--- a/test/test_ethernet_interface.cpp
+++ b/test/test_ethernet_interface.cpp
@@ -149,7 +149,7 @@ TEST_F(TestEthernetInterface, CheckObjectPath)
 TEST_F(TestEthernetInterface, addStaticNameServers)
 {
     ServerList servers = {"9.1.1.1", "9.2.2.2", "9.3.3.3"};
-    EXPECT_CALL(manager.mockReload, schedule());
+    EXPECT_CALL(manager.mockRestart, schedule());
     interface.staticNameServers(servers);
     config::Parser parser((confDir / "00-bmc-test0.network").native());
     EXPECT_EQ(servers, parser.map.getValueStrings("Network", "DNS"));

--- a/test/test_network_manager.hpp
+++ b/test/test_network_manager.hpp
@@ -20,6 +20,9 @@ struct TestManagerData
     MockExecutor mockReload;
     fu2::unique_function<void()> reloadCb;
 
+    MockExecutor mockRestart;
+    fu2::unique_function<void()> restartCb;
+
     inline MockExecutor& reloadForManager()
     {
         EXPECT_CALL(mockReload, setCallback(testing::_))
@@ -28,6 +31,15 @@ struct TestManagerData
             });
         return mockReload;
     }
+
+    inline MockExecutor& restartForManager()
+    {
+        EXPECT_CALL(mockRestart, setCallback(testing::_))
+            .WillOnce([&](fu2::unique_function<void()>&& cb) {
+                restartCb = std::move(cb);
+            });
+        return mockRestart;
+    }
 };
 
 struct TestManager : TestManagerData, Manager
@@ -35,7 +47,7 @@ struct TestManager : TestManagerData, Manager
     inline TestManager(stdplus::PinnedRef<sdbusplus::bus_t> bus,
                        stdplus::zstring_view path,
                        const std::filesystem::path& dir) :
-        Manager(bus, reloadForManager(), path, dir)
+        Manager(bus, reloadForManager(), restartForManager(), path, dir)
     {}
 
     using Manager::handleAdminState;


### PR DESCRIPTION
This commit restarts systemd-networkd during static IP address configurations insted of reloading systemd-networkd.

With this change, Linklocal IP goes away when static IP address configured

Tested by:
Ran all static/dhcp network configuration tests