### PR TITLE
Creating eth object based on BIOS attributess

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -20,12 +20,13 @@ constexpr auto BIOS_SERVICE = "xyz.openbmc_project.BIOSConfigManager";
 constexpr auto BIOS_OBJPATH = "/xyz/openbmc_project/bios_config/manager";
 constexpr auto BIOS_MGR_INTF = "xyz.openbmc_project.BIOSConfig.Manager";
 
-// The total number of vmi attributes in biosTableAttrs is 17
-// 4 attributes of interface 0 - ipv4 address
-// 4 attributes of interface 0 - ipv6 address
-// 4 attributes of interface 1 - ipv4 address
-// 4 attributes of interface 1 - ipv6 address
-constexpr auto BIOS_ATTRS_SIZE = 17;
+// The total number of vmi attributes defined in biosTableAttrs
+// currently is 17 in case of systems with 2 eth interfaces and 9 with single
+// eth interface 4 attributes of interface 0 - ipv4 address 4 attributes of
+// interface 0 - ipv6 address 4 attributes of interface 1 - ipv4 address 4
+// attributes of interface 1 - ipv6 address
+constexpr auto BIOS_ATTRS_SIZE_WITH_IF1 = 17;
+constexpr auto BIOS_ATTRS_SIZE_WITHOUT_IF1 = 9;
 
 biosTableRetAttrValueType HypEthInterface::getAttrFromBiosTable(
     const std::string& attrName)
@@ -79,9 +80,9 @@ void HypEthInterface::watchBaseBiosTable()
         // the biosTableAttrs data member and ip address in bios table are
         // different)
 
-        // the no. of interface supported is two
-        constexpr auto MAX_INTF_SUPPORTED = 2;
-        for (auto i = 0; i < MAX_INTF_SUPPORTED; i++)
+        // the no. of interface supported
+        auto TOTAL_INTF_SUPPORTED = (manager.get().if1Exist()) ? 2 : 1;
+        for (auto i = 0; i < TOTAL_INTF_SUPPORTED; i++)
         {
             std::string intf = "if" + std::to_string(i);
 
@@ -468,8 +469,11 @@ void HypEthInterface::createIPAddressObjects()
     std::string ipGateway;
 
     auto biosTableAttrs = manager.get().getBIOSTableAttrs();
-
-    if (biosTableAttrs.size() < BIOS_ATTRS_SIZE)
+    bool AllAttrCollected =
+        manager.get().if1Exist()
+            ? biosTableAttrs.size() < BIOS_ATTRS_SIZE_WITH_IF1
+            : biosTableAttrs.size() < BIOS_ATTRS_SIZE_WITHOUT_IF1;
+    if (AllAttrCollected)
     {
         lg2::info("Creating ip address object with default values");
         std::optional<stdplus::InAnyAddr> addrv4, addrv6;

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.cpp
@@ -186,7 +186,10 @@ void HypNetworkMgr::setBIOSTableAttrs()
             {
                 const std::string& itemType =
                     std::get<biosBaseAttrType>(item.second);
-
+                if (item.first.rfind("vmi_if1", 0) == 0)
+                {
+                    if1Present = 1;
+                }
                 if (itemType.compare(itemType.size() - intType.size(),
                                      intType.size(), intType) == 0)
                 {
@@ -243,21 +246,23 @@ void HypNetworkMgr::createIfObjects()
     // created during init time to support the static
     // network configurations on the both.
     // create eth0 and eth1 objects
-    lg2::info("Creating eth0 and eth1 objects");
+    log<level::INFO>("Creating eth0 object");
     interfaces.emplace(
         "eth0",
         std::make_unique<HypEthInterface>(
             bus, sdbusplus::message::object_path(objectPath.str + "/eth0"),
             "eth0", *this));
-    interfaces.emplace(
-        "eth1",
-        std::make_unique<HypEthInterface>(
-            bus, sdbusplus::message::object_path(objectPath.str + "/eth1"),
-            "eth1", *this));
-
-    // Create ip address objects for each ethernet interface
     interfaces["eth0"]->createIPAddressObjects();
-    interfaces["eth1"]->createIPAddressObjects();
+    if (if1Present)
+    {
+        log<level::INFO>("Creating eth1 object");
+        interfaces.emplace(
+            "eth1",
+            std::make_unique<HypEthInterface>(
+                bus, sdbusplus::message::object_path(objectPath.str + "/eth1"),
+                "eth1", *this));
+        interfaces["eth1"]->createIPAddressObjects();
+    }
 
     // Call watch method to register for properties changed signal
     // This method can be called only once

--- a/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_network_manager.hpp
@@ -129,6 +129,14 @@ class HypNetworkMgr
         return *systemConf;
     }
 
+    /** @brief checks if if1 related bios attributes present
+     *
+     */
+    inline bool if1Exist()
+    {
+        return if1Present;
+    }
+
   protected:
     /**
      * @brief get Dbus Prop
@@ -158,6 +166,8 @@ class HypNetworkMgr
     /** @brief pointer to system conf object. */
     std::unique_ptr<HypSysConfig> systemConf = nullptr;
 
+    /** @brief interface1 present or not  */
+    bool if1Present = 0;
     /** @brief Persistent map of EthernetInterface dbus
      *         objects and their names
      */


### PR DESCRIPTION
ethernet interfaces1 for vmi should only initialised if corresponding BIOS attribute exists for the same

Tested By :

1) Network hypervisor tree on balcones system
 ```
sha309@gfwa825:~$ ssh service@balco09
(service@balco09) Password: 
root@balco09:~# busctl tree xyz.openbmc_project.Network.Hypervisor
└─ /xyz
  └─ /xyz/openbmc_project
    └─ /xyz/openbmc_project/network
      └─ /xyz/openbmc_project/network/hypervisor
        ├─ /xyz/openbmc_project/network/hypervisor/config
        └─ /xyz/openbmc_project/network/hypervisor/eth0
          ├─ /xyz/openbmc_project/network/hypervisor/eth0/ipv4
          │ └─ /xyz/openbmc_project/network/hypervisor/eth0/ipv4/addr0
          └─ /xyz/openbmc_project/network/hypervisor/eth0/ipv6
            └─ /xyz/openbmc_project/network/hypervisor/eth0/ipv6/addr0
root@balco09:~# 
```