### PR TITLE
Add routing table entries for on link network

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1222,13 +1222,36 @@ void EthernetInterface::writeConfigurationFile()
                     std::string routeAddressPrefix =
                         generateNetworkRoute(gateway4, prefixLength);
 
+                    // Adding Default route in main routing table with lower
+                    // route priority 10
+                    // These main routing table entries addresses direct
+                    // ethernet on link network routing.
+                    auto& routingPolicyDestination =
+                        config.map["Route"].emplace_back();
+                    routingPolicyDestination["Table"].emplace_back("main");
+                    routingPolicyDestination["Scope"].emplace_back("link");
+                    routingPolicyDestination["Destination"].emplace_back(
+                       routeAddressPrefix);
+                    auto& routingMainPolicyTo =
+                        config.map["RoutingPolicyRule"].emplace_back();
+                    routingMainPolicyTo["Table"].emplace_back("main");
+                    routingMainPolicyTo["Priority"].emplace_back("10");
+                    routingMainPolicyTo["To"].emplace_back(routeAddressPrefix);
+                    auto& routingMainPolicyFrom =
+                        config.map["RoutingPolicyRule"].emplace_back();
+                    routingMainPolicyFrom["Table"].emplace_back("main");
+                    routingMainPolicyFrom["Priority"].emplace_back("10");
+                    routingMainPolicyFrom["From"].emplace_back(routeAddressPrefix);
+
                     auto& routingPolicyTo =
                         config.map["RoutingPolicyRule"].emplace_back();
                     routingPolicyTo["Table"].emplace_back(routingTableId);
+                    routingPolicyTo["Priority"].emplace_back("100");
                     routingPolicyTo["To"].emplace_back(routeAddressPrefix);
                     auto& routingPolicyFrom =
                         config.map["RoutingPolicyRule"].emplace_back();
                     routingPolicyFrom["Table"].emplace_back(routingTableId);
+                    routingPolicyFrom["Priority"].emplace_back("100");
                     routingPolicyFrom["From"].emplace_back(routeAddressPrefix);
                 }
             }

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -1230,14 +1230,6 @@ void EthernetInterface::writeConfigurationFile()
                         config.map["RoutingPolicyRule"].emplace_back();
                     routingPolicyFrom["Table"].emplace_back(routingTableId);
                     routingPolicyFrom["From"].emplace_back(routeAddressPrefix);
-                    auto& routingPolicyDestination =
-                        config.map["Route"].emplace_back();
-                    routingPolicyDestination["Table"].emplace_back(
-                        routingTableId);
-                    routingPolicyDestination["GatewayOnLink"].emplace_back(
-                        "true");
-                    routingPolicyDestination["Destination"].emplace_back(
-                        routeAddressPrefix);
                 }
             }
 

--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -631,7 +631,7 @@ ObjectPath EthernetInterface::ip(IP::Protocol protType, std::string ipaddress,
     }
 
     writeConfigurationFile();
-    manager.get().restartConfigs();
+    manager.get().reloadConfigs();
 
     return it->second->getObjPath();
 }
@@ -731,7 +731,7 @@ ObjectPath EthernetInterface::staticGateway(std::string gateway,
     }
 
     writeConfigurationFile();
-    manager.get().restartConfigs();
+    manager.get().reloadConfigs();
 
     return it->second->getObjPath();
 }
@@ -890,7 +890,7 @@ ServerList EthernetInterface::staticNameServers(ServerList value)
         EthernetInterfaceIntf::staticNameServers(std::move(dnsUniqueValues));
 
     writeConfigurationFile();
-    manager.get().restartConfigs();
+    manager.get().reloadConfigs();
 
     return value;
 }
@@ -1422,7 +1422,7 @@ std::string EthernetInterface::defaultGateway(std::string gateway)
     {
         gateway = EthernetInterfaceIntf::defaultGateway(std::move(gateway));
         writeConfigurationFile();
-        manager.get().restartConfigs();
+        manager.get().reloadConfigs();
     }
     return gateway;
 }
@@ -1434,7 +1434,7 @@ std::string EthernetInterface::defaultGateway6(std::string gateway)
     {
         gateway = EthernetInterfaceIntf::defaultGateway6(std::move(gateway));
         writeConfigurationFile();
-        manager.get().restartConfigs();
+        manager.get().reloadConfigs();
     }
     return gateway;
 }

--- a/src/ipaddress.cpp
+++ b/src/ipaddress.cpp
@@ -112,7 +112,7 @@ void IPAddress::delete_()
     }
 
     parent.get().writeConfigurationFile();
-    parent.get().manager.get().restartConfigs();
+    parent.get().manager.get().reloadConfigs();
 }
 
 } // namespace network

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -48,12 +48,10 @@ static constexpr const char enabledMatch[] =
 
 Manager::Manager(stdplus::PinnedRef<sdbusplus::bus_t> bus,
                  stdplus::PinnedRef<DelayedExecutor> reload,
-                 stdplus::PinnedRef<DelayedExecutor> restart,
                  stdplus::zstring_view objPath,
                  const std::filesystem::path& confDir) :
     ManagerIface(bus, objPath.c_str(), ManagerIface::action::defer_emit),
-    reload(reload), restart(restart), bus(bus), objPath(std::string(objPath)),
-    confDir(confDir),
+    reload(reload), bus(bus), objPath(std::string(objPath)), confDir(confDir),
     systemdNetworkdEnabledMatch(
         bus, enabledMatch,
         [man = stdplus::PinnedRef(*this)](sdbusplus::message_t& m) {
@@ -128,25 +126,6 @@ Manager::Manager(stdplus::PinnedRef<sdbusplus::bus_t> bus,
         }
         self.get().reloadPostHooks.clear();
     });
-
-    restart.get().setCallback([self = stdplus::PinnedRef(*this)]() {
-        try
-        {
-            lg2::info("Restarting systemd-networkd");
-            auto method = self.get().bus.get().new_method_call(
-                "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
-                "org.freedesktop.systemd1.Manager", "RestartUnit");
-
-            method.append("systemd-networkd.service");
-            method.append("replace");
-            self.get().bus.get().call(method);
-        }
-        catch (const sdbusplus::exception_t& ex)
-        {
-            lg2::error("Failed to restart configuration: {ERROR}", "ERROR", ex);
-        }
-    });
-
     std::vector<
         std::tuple<int32_t, std::string, sdbusplus::message::object_path>>
         links;

--- a/src/network_manager.hpp
+++ b/src/network_manager.hpp
@@ -41,13 +41,11 @@ class Manager : public ManagerIface
     /** @brief Constructor to put object onto bus at a dbus path.
      *  @param[in] bus - Bus to attach to.
      *  @param[in] reload - The executor for reloading configs
-     *  @param[in] restart - The executor for restarting configs
      *  @param[in] objPath - Path to attach at.
      *  @param[in] confDir - Network Configuration directory path.
      */
     Manager(stdplus::PinnedRef<sdbusplus::bus_t> bus,
             stdplus::PinnedRef<DelayedExecutor> reload,
-            stdplus::PinnedRef<DelayedExecutor> restart,
             stdplus::zstring_view objPath,
             const std::filesystem::path& confDir);
 
@@ -108,14 +106,6 @@ class Manager : public ManagerIface
         reload.get().schedule();
     }
 
-    /** @brief Arms a timer to tell systemd-network to restart all of the
-     * network configurations
-     */
-    inline void restartConfigs()
-    {
-        restart.get().schedule();
-    }
-
     /** Reload LLDP configuration
      */
     void reloadLLDPService();
@@ -142,9 +132,6 @@ class Manager : public ManagerIface
   protected:
     /** @brief Handle to the object used to trigger reloads of networkd. */
     stdplus::PinnedRef<DelayedExecutor> reload;
-
-    /** @brief Handle to the object used to trigger restart of networkd. */
-    stdplus::PinnedRef<DelayedExecutor> restart;
 
     /** @brief Persistent sdbusplus DBus bus connection. */
     stdplus::PinnedRef<sdbusplus::bus_t> bus;

--- a/src/network_manager_main.cpp
+++ b/src/network_manager_main.cpp
@@ -67,8 +67,7 @@ int main()
     sdbusplus::server::manager_t objManager(bus, DEFAULT_OBJPATH);
 
     stdplus::Pinned<TimerExecutor> reload(event, std::chrono::seconds(3));
-    stdplus::Pinned<TimerExecutor> restart(event, std::chrono::seconds(2));
-    stdplus::Pinned<Manager> manager(bus, reload, restart, DEFAULT_OBJPATH,
+    stdplus::Pinned<Manager> manager(bus, reload, DEFAULT_OBJPATH,
                                      "/etc/systemd/network");
     netlink::Server svr(event, manager);
 

--- a/test/test_ethernet_interface.cpp
+++ b/test/test_ethernet_interface.cpp
@@ -149,7 +149,7 @@ TEST_F(TestEthernetInterface, CheckObjectPath)
 TEST_F(TestEthernetInterface, addStaticNameServers)
 {
     ServerList servers = {"9.1.1.1", "9.2.2.2", "9.3.3.3"};
-    EXPECT_CALL(manager.mockRestart, schedule());
+    EXPECT_CALL(manager.mockReload, schedule());
     interface.staticNameServers(servers);
     config::Parser parser((confDir / "00-bmc-test0.network").native());
     EXPECT_EQ(servers, parser.map.getValueStrings("Network", "DNS"));

--- a/test/test_network_manager.hpp
+++ b/test/test_network_manager.hpp
@@ -20,9 +20,6 @@ struct TestManagerData
     MockExecutor mockReload;
     fu2::unique_function<void()> reloadCb;
 
-    MockExecutor mockRestart;
-    fu2::unique_function<void()> restartCb;
-
     inline MockExecutor& reloadForManager()
     {
         EXPECT_CALL(mockReload, setCallback(testing::_))
@@ -31,15 +28,6 @@ struct TestManagerData
             });
         return mockReload;
     }
-
-    inline MockExecutor& restartForManager()
-    {
-        EXPECT_CALL(mockRestart, setCallback(testing::_))
-            .WillOnce([&](fu2::unique_function<void()>&& cb) {
-                restartCb = std::move(cb);
-            });
-        return mockRestart;
-    }
 };
 
 struct TestManager : TestManagerData, Manager
@@ -47,7 +35,7 @@ struct TestManager : TestManagerData, Manager
     inline TestManager(stdplus::PinnedRef<sdbusplus::bus_t> bus,
                        stdplus::zstring_view path,
                        const std::filesystem::path& dir) :
-        Manager(bus, reloadForManager(), restartForManager(), path, dir)
+        Manager(bus, reloadForManager(), path, dir)
     {}
 
     using Manager::handleAdminState;


### PR DESCRIPTION
This PR Add routing table entries for on link network
and reverts https://github.com/ibm-openbmc/phosphor-networkd/pull/218 https://github.com/ibm-openbmc/phosphor-networkd/pull/200
