### PR TITLE
Reapply "Avoid ipv4 static and DHCP IPaddress coexistence" (#199)

### DIFF
--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -122,6 +122,10 @@ class EthernetInterface : public Ifaces
      */
     void loadNameServers(const config::Parser& config);
 
+    /** @brief Function used to delete IPv4 static addresses
+     */
+    void deleteStaticIPv4Addresses();
+
     /** @brief Function to create ipAddress dbus object.
      *  @param[in] addressType - Type of ip address.
      *  @param[in] ipAddress- IP address.
@@ -234,6 +238,9 @@ class EthernetInterface : public Ifaces
      *  @param[in] value - lldp value of the interface.
      */
     bool emitLLDP(bool value) override;
+
+    bool dhcpIsEnabled(IP::Protocol family, bool ignoreProtocol);
+    void disableDHCP(IP::Protocol protocol);
 
     using EthernetInterfaceIntf::interfaceName;
     using EthernetInterfaceIntf::linkUp;


### PR DESCRIPTION
Avoid ipv4 static and DHCP IPaddress coexistence

Currently IPv4 Static and DHCP IP addresses coexists, but Static IP configuration can't work while DHCP enabled on the interface.

This commits avoids coexistence, disables DHCPv4 while configuring static IPv4 address and deletes static address while enabling DHCPv4.

This is downstream only change for now, needs discussions in the upstream community
This reverts commit 0438fc63a6054091b732f89e6a9d65b51f47aab3

Tested by:
Enable DHCPv4 with multiple static IPv4 addresses configured on interface.
Configure Static addresses when DHCPv4 enabled on interface.
Verified DHCPv6 Enable/Disable test cases.
Verified Static IPv6 address configuration while enabling DHCP