### PR TITLE
LLDP: Implement "ExchangeType" prop to TLVs intf

### DIFF
--- a/src/lldp/lldp_interface.cpp
+++ b/src/lldp/lldp_interface.cpp
@@ -91,6 +91,7 @@ Interface::Interface(sdbusplus::bus_t& bus, Manager& manager,
 {
     // create transmit dbus object once
     transmit = std::make_unique<TLVs>(bus, objPath + "/transmit");
+    transmit->setExchangeType(TLVsIface::LLDPExchangeType::Transmit);
 
     bool enabled = parseLLDPEnabledFromConfig(ifname);
     SettingsIface::enableLLDP(enabled);
@@ -376,6 +377,7 @@ void Interface::updateOrCreateReceiveObj(
     try
     {
         auto tlvObj = std::make_unique<TLVs>(bus, path);
+        tlvObj->setExchangeType(TLVsIface::LLDPExchangeType::Receive);
         if (!chassisId.empty())
             tlvObj->setChassisId(chassisId);
         if (!portId.empty())

--- a/src/lldp/lldp_tlvs.cpp
+++ b/src/lldp/lldp_tlvs.cpp
@@ -31,6 +31,7 @@ TLVs::TLVs(sdbusplus::bus_t& bus, const std::string& objPath) :
     TLVsIface::managementAddressIPv6("");
     TLVsIface::managementAddressMAC("");
     TLVsIface::managementVlanId(0);
+    TLVsIface::exchangeType(TLVsIface::LLDPExchangeType::Unknown);
 
     emit_object_added();
 }
@@ -48,6 +49,7 @@ void TLVs::resetToDefaults()
     TLVsIface::managementAddressIPv6("");
     TLVsIface::managementAddressMAC("");
     TLVsIface::managementVlanId(0);
+    TLVsIface::exchangeType(TLVsIface::LLDPExchangeType::Unknown);
 }
 
 void TLVs::setChassisId(const std::string& v)
@@ -78,6 +80,11 @@ void TLVs::setManagementAddressIPv4(const std::string& v)
 void TLVs::setManagementAddressIPv6(const std::string& v)
 {
     TLVsIface::managementAddressIPv6(v);
+}
+
+void TLVs::setExchangeType(TLVsIface::LLDPExchangeType type)
+{
+    TLVsIface::exchangeType(type);
 }
 
 std::string TLVs::chassisId(std::string)
@@ -132,6 +139,11 @@ std::string TLVs::managementAddressMAC(std::string)
 }
 
 uint16_t TLVs::managementVlanId(uint16_t)
+{
+    elog<NotAllowed>(Reason("Property update is not allowed"));
+}
+
+TLVsIface::LLDPExchangeType TLVs::exchangeType(TLVsIface::LLDPExchangeType)
 {
     elog<NotAllowed>(Reason("Property update is not allowed"));
 }

--- a/src/lldp/lldp_tlvs.hpp
+++ b/src/lldp/lldp_tlvs.hpp
@@ -32,6 +32,7 @@ class TLVs : public TLVsIface
     void setSystemDescription(const std::string& v);
     void setManagementAddressIPv4(const std::string& v);
     void setManagementAddressIPv6(const std::string& v);
+    void setExchangeType(TLVsIface::LLDPExchangeType v);
 
     std::string chassisId(std::string) override;
     TLVsIface::IEEE802IdSubtype chassisIdSubtype(
@@ -47,6 +48,7 @@ class TLVs : public TLVsIface
     std::string managementAddressIPv6(std::string) override;
     std::string managementAddressMAC(std::string) override;
     uint16_t managementVlanId(uint16_t) override;
+    LLDPExchangeType exchangeType(TLVsIface::LLDPExchangeType) override;
 
     void resetToDefaults();
 };


### PR DESCRIPTION
Implemented a new property in TLVs interface:
* ExchangeType: to indicate whether the LLDP TLVs correspond to transmitted or received information on that port.

Tested By:
Ensured that in both /transmit and /receive objects, the "ExhangeType" is initialised appropriately.

* xyz.openbmc_project.Network.LLDP.TLVs.LLDPExchangeType.Receive
* xyz.openbmc_project.Network.LLDP.TLVs.LLDPExchangeType.Transmit