### PR TITLE
Fix IPv6 link local address origin

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -428,7 +428,13 @@ void EthernetInterface::addAddr(const AddressInfo& info)
     }
 
 #ifdef LINK_LOCAL_AUTOCONFIGURATION
-    if (info.scope == RT_SCOPE_LINK)
+    if (info.scope == RT_SCOPE_LINK &&
+        std::holds_alternative<stdplus::In6Addr>(info.ifaddr.getAddr()))
+    {
+        origin = IP::AddressOrigin::LinkLocal;
+    }
+    else if (info.scope == RT_SCOPE_LINK &&
+             std::holds_alternative<stdplus::In4Addr>(info.ifaddr.getAddr()))
     {
         try
         {


### PR DESCRIPTION
This commit fixes IPv6 link local address origin on D-bus objects

Tested by:
Verified IPv6 linklocal address origin on redifsh/GUI