### PR TITLE
LLDP: Fix compilation warnings in openbmc

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -36,4 +36,9 @@ option(
     type: 'boolean',
     description: 'Enable rbmc configuration on internal interface, assigns IP address using BMC position ',
 )
-option('lldp', type: 'boolean', description: 'Enable LLDP neighbor discovery')
+option(
+    'lldp',
+    type: 'boolean',
+    value: false,
+    description: 'Enable LLDP neighbor discovery',
+)

--- a/src/lldp/lldp_interface.cpp
+++ b/src/lldp/lldp_interface.cpp
@@ -1,3 +1,5 @@
+#if ENABLE_LLDP
+
 #include "lldp_interface.hpp"
 
 #include "lldp_manager.hpp"
@@ -402,3 +404,4 @@ void Interface::updateOrCreateReceiveObj(
 } // namespace lldp
 } // namespace network
 } // namespace phosphor
+#endif // ENABLE_LLDP

--- a/src/lldp/lldp_interface.hpp
+++ b/src/lldp/lldp_interface.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#if ENABLE_LLDP
+
 #include "lldp_tlvs.hpp"
 
 #include <sdbusplus/server/object.hpp>
@@ -68,3 +70,4 @@ class Interface : public SettingsIface
 } // namespace lldp
 } // namespace network
 } // namespace phosphor
+#endif // ENABLE_LLDP

--- a/src/lldp/lldp_manager.cpp
+++ b/src/lldp/lldp_manager.cpp
@@ -1,3 +1,5 @@
+#if ENABLE_LLDP
+
 #include "lldp_manager.hpp"
 
 #include "lldp_interface.hpp"
@@ -80,3 +82,4 @@ std::vector<std::string> Manager::getInterfaces()
 } // namespace lldp
 } // namespace network
 } // namespace phosphor
+#endif // ENABLE_LLDP

--- a/src/lldp/lldp_manager.hpp
+++ b/src/lldp/lldp_manager.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#if ENABLE_LLDP
+
 #include "lldp_interface.hpp"
 
 #include <sdbusplus/bus.hpp>
@@ -41,3 +43,4 @@ class Manager
 } // namespace lldp
 } // namespace network
 } // namespace phosphor
+#endif // ENABLE_LLDP

--- a/src/lldp/lldp_manager_main.cpp
+++ b/src/lldp/lldp_manager_main.cpp
@@ -1,3 +1,5 @@
+#if ENABLE_LLDP
+
 #include "lldp_config.h"
 
 #include "lldp_manager.hpp"
@@ -23,3 +25,5 @@ int main()
 
     return sdeventplus::utility::loopWithBus(event, bus);
 }
+
+#endif // ENABLE_LLDP

--- a/src/lldp/lldp_tlvs.cpp
+++ b/src/lldp/lldp_tlvs.cpp
@@ -1,3 +1,5 @@
+#if ENABLE_LLDP
+
 #include "lldp_tlvs.hpp"
 
 #include <phosphor-logging/elog-errors.hpp>
@@ -151,3 +153,4 @@ TLVsIface::LLDPExchangeType TLVs::exchangeType(TLVsIface::LLDPExchangeType)
 } // namespace lldp
 } // namespace network
 } // namespace phosphor
+#endif // ENABLE_LLDP

--- a/src/lldp/lldp_tlvs.hpp
+++ b/src/lldp/lldp_tlvs.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#if ENABLE_LLDP
+
 #include <sdbusplus/server/object.hpp>
 #include <xyz/openbmc_project/Network/LLDP/TLVs/server.hpp>
 
@@ -55,3 +57,4 @@ class TLVs : public TLVsIface
 } // namespace lldp
 } // namespace network
 } // namespace phosphor
+#endif // ENABLE_LLDP

--- a/src/lldp/meson.build
+++ b/src/lldp/meson.build
@@ -2,6 +2,7 @@ lldp_default_busname = 'xyz.openbmc_project.LLDP'
 
 config = configuration_data()
 config.set_quoted('LLDP_DEFAULT_BUSNAME', lldp_default_busname)
+config.set('ENABLE_LLDP', get_option('lldp') ? 1 : 0)
 
 configure_file(output: 'lldp_config.h', configuration: config)
 


### PR DESCRIPTION
This commit defaults lldp flag to false and checks for dependency of liblldpctl only when lldp is set to true.

Tested By:
Built openbmc image for:
* skiboards which has lldp distro included and compilation was successful.
* machine that has lldp distro disabled and compilation was successful.