### PR TITLE
Remove IPv4 Linklocal address when interface has static IP

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -442,10 +442,64 @@ void EthernetInterface::addAddr(const AddressInfo& info)
         origin = IP::AddressOrigin::SLAAC;
     }
 #ifdef LINK_LOCAL_AUTOCONFIGURATION
-    if (info.scope == RT_SCOPE_LINK)
+    if (info.scope == RT_SCOPE_LINK &&
+        std::holds_alternative<in6_addr>(info.ifaddr.getAddr()))
     {
         origin = IP::AddressOrigin::LinkLocal;
     }
+    else if (info.scope == RT_SCOPE_LINK &&
+             std::holds_alternative<in_addr>(info.ifaddr.getAddr()))
+    {
+        try
+        {
+            auto obj =
+                fmt::format("/org/freedesktop/network1/link/_3{}", info.ifidx);
+            auto req = bus.get().new_method_call(
+                "org.freedesktop.network1", obj.c_str(),
+                "org.freedesktop.DBus.Properties", "GetAll");
+            req.append("org.freedesktop.network1.Link");
+            auto rsp = req.call();
+            std::map<std::string, std::variant<std::string>> props;
+            rsp.read(props);
+            auto operationalStateIt = props.find("OperationalState");
+            auto ipv4addressStateIt = props.find("IPv4AddressState");
+
+            if ((operationalStateIt != props.end()) &&
+                (ipv4addressStateIt != props.end()))
+            {
+                const std::string& opState =
+                    std::get<std::string>(operationalStateIt->second);
+                const std::string& ipv4State =
+                    std::get<std::string>(ipv4addressStateIt->second);
+                if ((opState == "routable") && (ipv4State == "routable"))
+                {
+                    bool status = system::deleteLinkLocalIPv4ViaNetlink(
+                        info.ifidx, info.ifaddr.getAddr());
+                    if (status)
+                    {
+                        log<level::ERR>("Deleted IPv4 linklocal address");
+                    }
+                    else
+                    {
+                        log<level::ERR>(
+                            "Failed to delete IPv4 Linklocal address");
+                    }
+                }
+                else
+                {
+                    origin = IP::AddressOrigin::LinkLocal;
+                }
+            }
+        }
+        catch (const std::exception& e)
+        {
+            auto msg = fmt::format("Failed to read link OperationalState and "
+                                   "IPv4AddressState : {}\n",
+                                   e.what());
+            log<level::ERR>(msg.c_str());
+        }
+    }
+
 #endif
 
     if ((info.scope == RT_SCOPE_UNIVERSE) && (info.flags & IFA_F_PERMANENT))
@@ -1270,26 +1324,69 @@ void EthernetInterface::writeConfigurationFile()
                 {
                     gateways.emplace_back(gateway4);
                     auto& gateway4route = config.map["Route"].emplace_back();
+                    gateway4route["Destination"].emplace_back("0.0.0.0/0");
                     gateway4route["Gateway"].emplace_back(gateway4);
                     gateway4route["GatewayOnLink"].emplace_back("true");
 
                     std::string routingTableId =
                         std::to_string(generateRouteTableID(interfaceName()));
                     gateway4route["Table"].emplace_back(routingTableId);
-                    std::string routeAddressPrefix =
+                    std::string routeGatewayPrefix =
                         generateNetworkRoute(gateway4, prefixLength);
 
-                    auto& routingPolicyTo =
+                    auto& routingPolicyGatewayTo =
                         config.map["RoutingPolicyRule"].emplace_back();
-                    routingPolicyTo["Table"].emplace_back(routingTableId);
-                    routingPolicyTo["To"].emplace_back(routeAddressPrefix);
-                    auto& routingPolicyFrom =
+                    routingPolicyGatewayTo["Table"].emplace_back(
+                        routingTableId);
+                    routingPolicyGatewayTo["Priority"].emplace_back("10");
+                    routingPolicyGatewayTo["To"].emplace_back(
+                        routeGatewayPrefix);
+
+                    auto& routingPolicyGatewayFrom =
                         config.map["RoutingPolicyRule"].emplace_back();
-                    routingPolicyFrom["Table"].emplace_back(routingTableId);
-                    routingPolicyFrom["From"].emplace_back(routeAddressPrefix);
+                    routingPolicyGatewayFrom["Table"].emplace_back(
+                        routingTableId);
+                    routingPolicyGatewayFrom["Priority"].emplace_back("10");
+                    routingPolicyGatewayFrom["From"].emplace_back(
+                        routeGatewayPrefix);
+                    auto& routingMainPolicyTo =
+                        config.map["RoutingPolicyRule"].emplace_back();
+                    routingMainPolicyTo["Table"].emplace_back("main");
+                    routingMainPolicyTo["Priority"].emplace_back("100");
+                    routingMainPolicyTo["To"].emplace_back(routeGatewayPrefix);
+
+                    auto& routingMainPolicyFrom =
+                        config.map["RoutingPolicyRule"].emplace_back();
+                    routingMainPolicyFrom["Table"].emplace_back("main");
+                    routingMainPolicyFrom["Priority"].emplace_back("100");
+                    routingMainPolicyFrom["From"].emplace_back(
+                        routeGatewayPrefix);
+
+                    for (const auto& addr : addrs)
+                    {
+                        if (originIsManuallyAssigned(addr.second->origin()))
+                        {
+                            std::stringstream ss(fmt::format("{}", addr.first));
+                            std::string address;
+                            std::getline(ss, address, '/');
+                            std::string routeAddressPrefix =
+                                generateNetworkRoute(address, prefixLength);
+
+                            if (!routeAddressPrefix.empty())
+                            {
+                                auto& routingPolicyDestination =
+                                    config.map["Route"].emplace_back();
+                                routingPolicyDestination["Table"].emplace_back(
+                                    routingTableId);
+                                routingPolicyDestination["Destination"]
+                                    .emplace_back(routeAddressPrefix);
+                                routingPolicyDestination["Scope"].emplace_back(
+                                    "link");
+                            }
+                        }
+                    }
                 }
             }
-
             auto& gateways = network["Gateway"];
             if (!dhcp6())
             {

--- a/src/system_queries.cpp
+++ b/src/system_queries.cpp
@@ -2,13 +2,18 @@
 
 #include "netlink.hpp"
 
+#include <arpa/inet.h>
 #include <fmt/format.h>
 #include <linux/ethtool.h>
+#include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/sockios.h>
 #include <net/if.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include <algorithm>
+#include <cstring>
 #include <optional>
 #include <phosphor-logging/log.hpp>
 #include <stdexcept>
@@ -132,6 +137,89 @@ void deleteIntf(unsigned idx)
             throw std::runtime_error(
                 fmt::format("Failed to delete `{}`: {}", idx, strerror(err)));
         });
+}
+
+bool deleteLinkLocalIPv4ViaNetlink(unsigned ifidx, const InAddrAny& ip)
+{
+    bool success = false;
+
+    std::visit(
+        [&](const auto& wrappedAddr) {
+            using T = std::decay_t<decltype(wrappedAddr)>;
+            if constexpr (std::is_same_v<T, in_addr>)
+            {
+                in_addr addr = static_cast<in_addr>(wrappedAddr);
+
+                if ((ntohl(addr.s_addr) & 0xFFFF0000) != 0xA9FE0000)
+                    return;
+
+                int sock = ::socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+                if (sock < 0)
+                {
+                    auto msg =
+                        fmt::format("Failed to open the NETLINK_ROUTE socket");
+                    log<level::ERR>(msg.c_str());
+                    return;
+                }
+
+                struct
+                {
+                    nlmsghdr nlh;
+                    ifaddrmsg ifa;
+                    char buf[256];
+                } req{};
+
+                req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(ifaddrmsg));
+                req.nlh.nlmsg_type = RTM_DELADDR;
+                req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+                req.ifa.ifa_family = AF_INET;
+                req.ifa.ifa_index = ifidx;
+                req.ifa.ifa_prefixlen = 32;
+
+                rtattr* rta = reinterpret_cast<rtattr*>(req.buf);
+                rta->rta_type = IFA_LOCAL;
+                rta->rta_len = RTA_LENGTH(sizeof(in_addr));
+                std::memcpy(RTA_DATA(rta), &addr, sizeof(in_addr));
+
+                req.nlh.nlmsg_len += rta->rta_len;
+
+                const ssize_t sent = ::send(sock, &req, req.nlh.nlmsg_len, 0);
+                if (sent != static_cast<ssize_t>(req.nlh.nlmsg_len))
+                {
+                    auto msg = fmt::format(
+                        "Failed to send netlink message for RTM_DELADDR");
+                    log<level::ERR>(msg.c_str());
+                    ::close(sock);
+                    return;
+                }
+
+                std::array<char, 4096> resp;
+                ssize_t len = ::recv(sock, resp.data(), resp.size(), 0);
+                ::close(sock);
+
+                if (len >= NLMSG_LENGTH(0))
+                {
+                    const nlmsghdr* hdr =
+                        reinterpret_cast<nlmsghdr*>(resp.data());
+                    if (hdr->nlmsg_type == NLMSG_ERROR)
+                    {
+                        const nlmsgerr* err =
+                            reinterpret_cast<nlmsgerr*>(NLMSG_DATA(hdr));
+                        if (err->error != 0)
+                        {
+                            std::ostringstream oss;
+                            oss << "Failed to delete link-local IP on ifidx "
+                                << ifidx << ": " << strerror(-err->error);
+                            throw std::runtime_error(oss.str());
+                        }
+                    }
+                }
+                success = true;
+            }
+        },
+        ip);
+
+    return success;
 }
 
 } // namespace phosphor::network::system

--- a/src/system_queries.hpp
+++ b/src/system_queries.hpp
@@ -20,4 +20,5 @@ void setNICUp(std::string_view ifname, bool up);
 
 void deleteIntf(unsigned idx);
 
+bool deleteLinkLocalIPv4ViaNetlink(unsigned ifidx, const InAddrAny& ip);
 } // namespace phosphor::network::system


### PR DESCRIPTION
This commit removes IPv4 linklocal IP when ethernet interface already has routable ip address assigned on the interface.

Keeping linklocal ip address along with static ip addresses causing network routing issues.

systemd-networkd must drop linklocal IP when interface has routable static IP address, but currently its not implemented.
Here is systemd issue systemd/systemd#25424

Tested By:
Verified both interfaces in different static subnets Verified HMC connection