### PR TITLE
Revert "LLDP: Fix compilation warnings in openbmc (ibm-openbmc#227)"

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -36,9 +36,4 @@ option(
     type: 'boolean',
     description: 'Enable rbmc configuration on internal interface, assigns IP address using BMC position ',
 )
-option(
-    'lldp',
-    type: 'boolean',
-    value: false,
-    description: 'Enable LLDP neighbor discovery',
-)
+option('lldp', type: 'boolean', description: 'Enable LLDP neighbor discovery')

--- a/src/lldp/lldp_interface.cpp
+++ b/src/lldp/lldp_interface.cpp
@@ -1,5 +1,3 @@
-#if ENABLE_LLDP
-
 #include "lldp_interface.hpp"
 
 #include "lldp_manager.hpp"
@@ -404,4 +402,3 @@ void Interface::updateOrCreateReceiveObj(
 } // namespace lldp
 } // namespace network
 } // namespace phosphor
-#endif // ENABLE_LLDP

--- a/src/lldp/lldp_interface.hpp
+++ b/src/lldp/lldp_interface.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#if ENABLE_LLDP
-
 #include "lldp_tlvs.hpp"
 
 #include <sdbusplus/server/object.hpp>
@@ -70,4 +68,3 @@ class Interface : public SettingsIface
 } // namespace lldp
 } // namespace network
 } // namespace phosphor
-#endif // ENABLE_LLDP

--- a/src/lldp/lldp_manager.cpp
+++ b/src/lldp/lldp_manager.cpp
@@ -1,5 +1,3 @@
-#if ENABLE_LLDP
-
 #include "lldp_manager.hpp"
 
 #include "lldp_interface.hpp"
@@ -82,4 +80,3 @@ std::vector<std::string> Manager::getInterfaces()
 } // namespace lldp
 } // namespace network
 } // namespace phosphor
-#endif // ENABLE_LLDP

--- a/src/lldp/lldp_manager.hpp
+++ b/src/lldp/lldp_manager.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#if ENABLE_LLDP
-
 #include "lldp_interface.hpp"
 
 #include <sdbusplus/bus.hpp>
@@ -43,4 +41,3 @@ class Manager
 } // namespace lldp
 } // namespace network
 } // namespace phosphor
-#endif // ENABLE_LLDP

--- a/src/lldp/lldp_manager_main.cpp
+++ b/src/lldp/lldp_manager_main.cpp
@@ -1,5 +1,3 @@
-#if ENABLE_LLDP
-
 #include "lldp_config.h"
 
 #include "lldp_manager.hpp"
@@ -25,5 +23,3 @@ int main()
 
     return sdeventplus::utility::loopWithBus(event, bus);
 }
-
-#endif // ENABLE_LLDP

--- a/src/lldp/lldp_tlvs.cpp
+++ b/src/lldp/lldp_tlvs.cpp
@@ -1,5 +1,3 @@
-#if ENABLE_LLDP
-
 #include "lldp_tlvs.hpp"
 
 #include <phosphor-logging/elog-errors.hpp>
@@ -153,4 +151,3 @@ TLVsIface::LLDPExchangeType TLVs::exchangeType(TLVsIface::LLDPExchangeType)
 } // namespace lldp
 } // namespace network
 } // namespace phosphor
-#endif // ENABLE_LLDP

--- a/src/lldp/lldp_tlvs.hpp
+++ b/src/lldp/lldp_tlvs.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#if ENABLE_LLDP
-
 #include <sdbusplus/server/object.hpp>
 #include <xyz/openbmc_project/Network/LLDP/TLVs/server.hpp>
 
@@ -57,4 +55,3 @@ class TLVs : public TLVsIface
 } // namespace lldp
 } // namespace network
 } // namespace phosphor
-#endif // ENABLE_LLDP

--- a/src/lldp/meson.build
+++ b/src/lldp/meson.build
@@ -2,7 +2,6 @@ lldp_default_busname = 'xyz.openbmc_project.LLDP'
 
 config = configuration_data()
 config.set_quoted('LLDP_DEFAULT_BUSNAME', lldp_default_busname)
-config.set('ENABLE_LLDP', get_option('lldp') ? 1 : 0)
 
 configure_file(output: 'lldp_config.h', configuration: config)
 


### PR DESCRIPTION
This commit[1]  is not needed. Compilation should go fine without the specified commit.

Tested:
Built openbmc image for skiboards and huygens from 1210-ghe -- compilation successful
Built openbmc image for skiboards, p10bmc, rbmc-prototype from 1120-ghe -- compilation successful

[1] https://github.com/ibm-openbmc/phosphor-networkd/commit/eb6fd3263ea81e6159d69d31429270915789c8ef