### PR TITLE
1120: Allow hypervisor static ip config with 0.0.0.0 gw (#232)

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -913,10 +913,6 @@ ObjectPath HypEthInterface::ip(HypIP::Protocol protType, std::string ipaddress,
                 validateGateway<stdplus::In4Addr>(gateway);
             }
         }
-        else
-        {
-            throw std::invalid_argument("Empty gateway");
-        }
     }
     catch (const std::exception& e)
     {

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.hpp
@@ -153,11 +153,8 @@ class HypEthInterface : public CreateIface
         try
         {
             auto ip = stdplus::fromStr<Addr>(gw);
-            if (ip == Addr{})
-            {
-                throw std::invalid_argument("Empty gateway");
-            }
-            if (!validIntfIP(ip))
+            // Allow 0.0.0.0 as a valid gateway for static IP configuration
+            if (!validIntfIP(ip) && ip != Addr{})
             {
                 throw std::invalid_argument("Invalid unicast");
             }


### PR DESCRIPTION
#### Allow hypervisor static ip config with 0.0.0.0 gw (#232)
```
This commit allows users to configure static IP with 0.0.0.0 gateway.

Tested By:

[1] PATCH -d '{"IPv4StaticAddresses":[{"Address": "X.X.X.X","SubnetMask": "255.255.255.0","Gateway":"0.0.0.0"}]}' https://${bmc}/redfish/v1/Systems/hypervisor/EthernetInterfaces/eth0

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>```