### PR TITLE
LLDP: Fix emit signal on Recv TLV object creation

### DIFF
--- a/src/lldp/lldp_interface.cpp
+++ b/src/lldp/lldp_interface.cpp
@@ -97,11 +97,14 @@ Interface::Interface(sdbusplus::bus_t& bus, Manager& manager,
     SettingsIface::enableLLDP(enabled);
     refreshInterface();
 
-    // Setup periodic refresh timer (every 60 seconds)
+    // Setup periodic refresh timer
+    std::chrono::seconds interval =
+        (ifname == "eth2") ? std::chrono::seconds(10)
+                           : std::chrono::seconds(60);
+
     refreshTimer = std::make_unique<TimerType>(
         manager.getEventLoop(),
-        [this](TimerType&) { this->refreshInterface(); },
-        std::chrono::seconds(60));
+        [this](TimerType&) { this->refreshInterface(); }, interval);
 
     refreshTimer->setEnabled(true);
     this->emit_object_added();
@@ -263,6 +266,22 @@ void Interface::refreshInterface()
             const char* sysdesc =
                 lldpctl_atom_get_str(neigh, lldpctl_k_chassis_descr);
 
+            std::string mgmtMac;
+            const char* portSubtypeStr =
+                lldpctl_atom_get_str(neigh, lldpctl_k_port_id_subtype);
+            if (portSubtypeStr && std::string_view(portSubtypeStr) == "mac")
+            {
+                mgmtMac = portid ? portid : "";
+            }
+
+            const char* chassisSubtypeStr =
+                lldpctl_atom_get_str(neigh, lldpctl_k_chassis_id_subtype);
+            if (mgmtMac.empty() && chassisSubtypeStr &&
+                std::string_view(chassisSubtypeStr) == "mac")
+            {
+                mgmtMac = chassis ? chassis : "";
+            }
+
             std::string mgmtV4;
             std::string mgmtV6;
             lldpctl_atom_t* mgmts =
@@ -316,7 +335,8 @@ void Interface::refreshInterface()
                 chassis ? std::string(chassis) : std::string(),
                 portid ? std::string(portid) : std::string(),
                 sysname ? std::string(sysname) : std::string(),
-                sysdesc ? std::string(sysdesc) : std::string(), mgmtV4, mgmtV6);
+                sysdesc ? std::string(sysdesc) : std::string(), mgmtV4, mgmtV6,
+                mgmtMac);
         }
 
         lldpctl_atom_dec_ref(neighbors);
@@ -341,32 +361,46 @@ void Interface::refreshInterface()
 void Interface::updateOrCreateReceiveObj(
     const std::string& chassisId, const std::string& portId,
     const std::string& sysName, const std::string& sysDesc,
-    const std::string& mgmtIPv4, const std::string& mgmtIPv6)
+    const std::string& mgmtIPv4, const std::string& mgmtIPv6,
+    const std::string& mgmtMac)
 {
-    bool changed = false;
+    bool neighborChanged = false;
     if (receive)
     {
         TLVs& tlv = *receive;
 
         // Check if any TLV value from the current lldp packet
         // is different from what is on dbus
-        changed = (tlv.TLVsIface::chassisId() != chassisId) ||
-                  (tlv.TLVsIface::portId() != portId) ||
-                  (tlv.TLVsIface::systemName() != sysName) ||
-                  (tlv.TLVsIface::systemDescription() != sysDesc) ||
-                  (tlv.TLVsIface::managementAddressIPv4() != mgmtIPv4) ||
-                  (tlv.TLVsIface::managementAddressIPv6() != mgmtIPv6);
+        neighborChanged =
+            (tlv.TLVsIface::chassisId() != chassisId) ||
+            (tlv.TLVsIface::portId() != portId) ||
+            (tlv.TLVsIface::managementAddressIPv4() != mgmtIPv4) ||
+            (tlv.TLVsIface::managementAddressIPv6() != mgmtIPv6) ||
+            (tlv.TLVsIface::managementAddressMAC() != mgmtMac);
 
-        if (!changed)
+        if (neighborChanged)
         {
+            // If TLV values are changed, remove existing receive object before
+            // recreating
+            lg2::info(
+                "Neighbor TLV changed on {IF}. Removing existing \"receive\" object.",
+                "IF", ifname);
+            receive.reset();
+        }
+        else
+        {
+            // Check if there are any changes in other property values
+            // If yes, update the current receive object
+            bool otherPropChanged =
+                (tlv.TLVsIface::systemName() != sysName) ||
+                (tlv.TLVsIface::systemDescription() != sysDesc);
+            if (otherPropChanged)
+            {
+                tlv.setSystemName(sysName);
+                tlv.setSystemDescription(sysDesc);
+            }
             return;
         }
-
-        // If changed, remove existing receive object before recreating
-        lg2::info(
-            "Neighbor TLV changed on {IF}. Removing existing \"receive\" object.",
-            "IF", ifname);
-        receive.reset();
     }
 
     std::string path = objPath + "/receive";
@@ -376,20 +410,16 @@ void Interface::updateOrCreateReceiveObj(
 
     try
     {
-        auto tlvObj = std::make_unique<TLVs>(bus, path);
-        tlvObj->setExchangeType(TLVsIface::LLDPExchangeType::Receive);
-        if (!chassisId.empty())
-            tlvObj->setChassisId(chassisId);
-        if (!portId.empty())
-            tlvObj->setPortId(portId);
-        if (!sysName.empty())
-            tlvObj->setSystemName(sysName);
-        if (!sysDesc.empty())
-            tlvObj->setSystemDescription(sysDesc);
-        if (!mgmtIPv4.empty())
-            tlvObj->setManagementAddressIPv4(mgmtIPv4);
-        if (!mgmtIPv6.empty())
-            tlvObj->setManagementAddressIPv6(mgmtIPv6);
+        auto tlvObj = std::make_unique<TLVs>(
+            bus, path, chassisId.empty() ? "" : chassisId,
+            TLVsIface::IEEE802IdSubtype::NotTransmitted,
+            portId.empty() ? "" : portId,
+            TLVsIface::IEEE802IdSubtype::NotTransmitted,
+            sysName.empty() ? "" : sysName, sysDesc.empty() ? "" : sysDesc,
+            std::vector<TLVsIface::SystemCapabilities>(),
+            mgmtIPv4.empty() ? "" : mgmtIPv4, mgmtIPv6.empty() ? "" : mgmtIPv6,
+            mgmtMac.empty() ? "" : mgmtMac, 0,
+            TLVsIface::LLDPExchangeType::Receive);
         receive = std::move(tlvObj);
     }
     catch (const std::exception& e)

--- a/src/lldp/lldp_tlvs.cpp
+++ b/src/lldp/lldp_tlvs.cpp
@@ -36,6 +36,35 @@ TLVs::TLVs(sdbusplus::bus_t& bus, const std::string& objPath) :
     emit_object_added();
 }
 
+TLVs::TLVs(
+    sdbusplus::bus_t& bus, const std::string& objPath,
+    const std::string& chassisIdIn,
+    TLVsIface::IEEE802IdSubtype chassisIdSubTypeIn, const std::string& portIdIn,
+    TLVsIface::IEEE802IdSubtype portIdSubtypeIn,
+    const std::string& systemNameIn, const std::string& systemDescriptionIn,
+    std::vector<TLVsIface::SystemCapabilities> systemCapabilitiesIn,
+    const std::string& managementAddressIPv4In,
+    const std::string& managementAddressIPv6In,
+    const std::string& managementAddressMACIn, uint16_t managementVlanIdIn,
+    LLDPExchangeType exchangeTypeIn) :
+    TLVsIface(bus, objPath.c_str(), TLVsIface::action::defer_emit)
+{
+    TLVsIface::chassisId(chassisIdIn);
+    TLVsIface::chassisIdSubtype(chassisIdSubTypeIn);
+    TLVsIface::portId(portIdIn);
+    TLVsIface::portIdSubtype(portIdSubtypeIn);
+    TLVsIface::systemName(systemNameIn);
+    TLVsIface::systemDescription(systemDescriptionIn);
+    TLVsIface::systemCapabilities(systemCapabilitiesIn);
+    TLVsIface::managementAddressIPv4(managementAddressIPv4In);
+    TLVsIface::managementAddressIPv6(managementAddressIPv6In);
+    TLVsIface::managementAddressMAC(managementAddressMACIn);
+    TLVsIface::managementVlanId(managementVlanIdIn);
+    TLVsIface::exchangeType(exchangeTypeIn);
+
+    emit_object_added();
+}
+
 void TLVs::resetToDefaults()
 {
     TLVsIface::chassisId("");

--- a/src/lldp/lldp_tlvs.hpp
+++ b/src/lldp/lldp_tlvs.hpp
@@ -24,6 +24,18 @@ class TLVs : public TLVsIface
     TLVs& operator=(const TLVs&) = delete;
 
     TLVs(sdbusplus::bus_t& bus, const std::string& objPath);
+    TLVs(sdbusplus::bus_t& bus, const std::string& objPath,
+         const std::string& chassisIdIn,
+         TLVsIface::IEEE802IdSubtype chassisIdSubTypeIn,
+         const std::string& portIdIn,
+         TLVsIface::IEEE802IdSubtype portIdSubtypeIn,
+         const std::string& systemNameIn,
+         const std::string& systemDescriptionIn,
+         std::vector<TLVsIface::SystemCapabilities> systemCapabilitiesIn,
+         const std::string& managementAddressIPv4In,
+         const std::string& managementAddressIPv6In,
+         const std::string& managementAddressMACIn, uint16_t managementVlanIdIn,
+         LLDPExchangeType exchangeTypeIn);
     ~TLVs() = default;
 
     void setChassisId(const std::string& v);


### PR DESCRIPTION
In this commit, the receive object is created with all the values fetched from lldp packet and then the signal will be emitted with the updated properties. This is needed for apps that listen on InterfacesAdded signal to fetch the TLV properties.