### PR TITLE
inventory_mac: Skip IP assignment if already configured

### DIFF
--- a/src/inventory_mac.cpp
+++ b/src/inventory_mac.cpp
@@ -343,23 +343,44 @@ bool assignIPBasedOnPosition(sdbusplus::bus_t& bus)
         {
             if (interface.first == targetInterface)
             {
-                try
+                // Check if the IP address is already assigned
+                bool ipAlreadyExists = false;
+                for (const auto& addr : interface.second->addrs)
                 {
-                    interface.second->deleteAll();
-                    lg2::info("Successfully cleared all IPs from {NET_INTF}",
-                              "NET_INTF", targetInterface);
-                }
-                catch (const std::exception& e)
-                {
-                    lg2::warning("Failed to delete all IPs: {ERROR}", "ERROR",
-                                 e.what());
+                    if (addr.second->address() == ipAddress &&
+                        addr.second->prefixLength() == prefixLength)
+                    {
+                        lg2::info(
+                            "IP {IP_ADDR}/{PREFIX} is already assigned to {NET_INTF}, skipping assignment",
+                            "IP_ADDR", ipAddress, "PREFIX", prefixLength,
+                            "NET_INTF", targetInterface);
+                        ipAlreadyExists = true;
+                        ipAssigned = true;
+                        break;
+                    }
                 }
 
-                interface.second->ip(IP::Protocol::IPv4, ipAddress,
-                                     prefixLength, "");
-                lg2::info("Successfully assigned IP address to {NET_INTF}",
-                          "NET_INTF", targetInterface);
-                ipAssigned = true;
+                if (!ipAlreadyExists)
+                {
+                    try
+                    {
+                        interface.second->deleteAll();
+                        lg2::info(
+                            "Successfully cleared all IPs from {NET_INTF}",
+                            "NET_INTF", targetInterface);
+                    }
+                    catch (const std::exception& e)
+                    {
+                        lg2::warning("Failed to delete all IPs: {ERROR}",
+                                     "ERROR", e.what());
+                    }
+
+                    interface.second->ip(IP::Protocol::IPv4, ipAddress,
+                                         prefixLength, "");
+                    lg2::info("Successfully assigned IP address to {NET_INTF}",
+                              "NET_INTF", targetInterface);
+                    ipAssigned = true;
+                }
                 break;
             }
         }


### PR DESCRIPTION
Add check to prevent unnecessary IP deletion and reassignment when the target IP address and prefix length are already configured on the network interface. This optimization avoids disrupting existing network connections and reduces unnecessary operations.

Changes:
- Check if IP address and prefix are already assigned before deletion
- Skip deleteAll() and ip() calls if IP already exists
- Add informative logging when skipping assignment
- Maintain ipAssigned flag for both new and existing IP cases

This prevents network disruption when the same IP configuration is applied multiple times to the same interface.