### PR TITLE
Add skiboards flag for specific inventory MAC path

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,10 @@ conf_data.set('SYNC_MAC_FROM_INVENTORY', get_option('sync-mac'))
 conf_data.set('PERSIST_MAC', get_option('persist-mac'))
 conf_data.set10('FORCE_SYNC_MAC_FROM_INVENTORY', get_option('force-sync-mac'))
 conf_data.set('ENABLE_RBMC_CONFIG', get_option('enable-rbmc-config'))
+conf_data.set(
+    'ENABLE_SKIBOARDS_MAC_PATH',
+    get_option('enable-skiboards-mac-path'),
+)
 
 sdbusplus_dep = dependency('sdbusplus')
 sdbusplusplus_prog = find_program('sdbus++', native: true)

--- a/meson.options
+++ b/meson.options
@@ -36,4 +36,8 @@ option(
     type: 'boolean',
     description: 'Enable rbmc configuration on internal interface, assigns IP address using BMC position ',
 )
-option('lldp', type: 'boolean', description: 'Enable LLDP neighbor discovery')
+option(
+    'enable-skiboards-mac-path',
+    type: 'boolean',
+    description: 'Enable reading skiboards specific inventory MAC path (/xyz/openbmc_project/inventory/system/eth<N>)',
+)

--- a/src/inventory_mac.cpp
+++ b/src/inventory_mac.cpp
@@ -90,6 +90,71 @@ void setFirstBootMACOnInterface(const std::string& intf, const std::string& mac)
 stdplus::EtherAddr getfromInventory(sdbusplus::bus_t& bus,
                                     const std::string& intfName)
 {
+#ifdef ENABLE_SKIBOARDS_MAC_PATH
+    // For skiboards, use direct path:
+    // /xyz/openbmc_project/inventory/system/eth<N>
+    std::string skiboardsPath =
+        "/xyz/openbmc_project/inventory/system/" + intfName;
+
+    lg2::info("Skiboards mode: Reading MAC from path {DBUS_PATH}", "DBUS_PATH",
+              skiboardsPath);
+
+    try
+    {
+        auto mapperCall =
+            bus.new_method_call(mapperBus, mapperObj, mapperIntf, "GetObject");
+
+        std::vector<std::string> interfaces;
+        interfaces.emplace_back(invNetworkIntf);
+        mapperCall.append(skiboardsPath, interfaces);
+
+        auto mapperReply = bus.call(mapperCall);
+        if (mapperReply.is_method_error())
+        {
+            lg2::error("Error in mapper call for skiboards path {DBUS_PATH}",
+                       "DBUS_PATH", skiboardsPath);
+            elog<InternalFailure>();
+        }
+
+        std::map<std::string, std::vector<std::string>> mapperResponse;
+        mapperReply.read(mapperResponse);
+
+        if (mapperResponse.empty())
+        {
+            lg2::error("No service found for skiboards path {DBUS_PATH}",
+                       "DBUS_PATH", skiboardsPath);
+            elog<InternalFailure>();
+        }
+
+        auto service = mapperResponse.begin()->first;
+
+        auto method = bus.new_method_call(
+            service.c_str(), skiboardsPath.c_str(), propIntf, methodGet);
+        method.append(invNetworkIntf, "MACAddress");
+
+        auto reply = bus.call(method);
+        if (reply.is_method_error())
+        {
+            lg2::error(
+                "Failed to get MACAddress for skiboards path {DBUS_PATH}",
+                "DBUS_PATH", skiboardsPath);
+            elog<InternalFailure>();
+        }
+
+        std::variant<std::string> value;
+        reply.read(value);
+        return stdplus::fromStr<stdplus::EtherAddr>(
+            std::get<std::string>(value));
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error(
+            "Exception reading MAC from skiboards path {DBUS_PATH}: {ERROR}",
+            "DBUS_PATH", skiboardsPath, "ERROR", e.what());
+        elog<InternalFailure>();
+    }
+#else
+    // For all other machine types
     std::string interfaceName = configJson[intfName];
 
     std::vector<DbusInterface> interfaces;
@@ -168,6 +233,7 @@ stdplus::EtherAddr getfromInventory(sdbusplus::bus_t& bus,
     std::variant<std::string> value;
     reply.read(value);
     return stdplus::fromStr<stdplus::EtherAddr>(std::get<std::string>(value));
+#endif
 }
 
 bool setInventoryMACOnSystem(sdbusplus::bus_t& bus, const std::string& intfname)


### PR DESCRIPTION
Added a meson option "enable-skiboards-mac-path" to support skiboards where mac addresses are stored under a specific inventory path (/xyz/openbmc_project/inventory/system/eth<N>).

On enabling this option, phosphor-networkd reads mac addresses from the above path and configures it on the corresponding ethernet interfaces.

The option is disabled by default and enabled only for the skiboards machine configuration.

Tested By:
Verified this change along with the corresponding recipe file change on skiboards simics, and mac address was assigned properly on the respective ethernet interfaces by networkd.