### PR TITLE
skiboards: Read Position generically across arch

### DIFF
--- a/src/inventory_mac.cpp
+++ b/src/inventory_mac.cpp
@@ -327,8 +327,9 @@ std::optional<uint64_t> getPositionFromInventory(sdbusplus::bus_t& bus)
 
         auto reply = bus.call(method);
 
-        auto value = reply.unpack<std::variant<uint64_t>>();
-        uint64_t position = std::get<uint64_t>(value);
+        auto value = reply.unpack<std::variant<uint32_t, uint64_t>>();
+        uint64_t position =
+            std::visit([](auto v) { return static_cast<uint64_t>(v); }, value);
 
         if (position == 0 || position == 1)
         {


### PR DESCRIPTION
The inventory Position property is exposed with different dbus types depending on the platform.

Skiboards running armv7l (32-bit) expose the property as uint32 ("u"), while rbmc-prototype running aarch64 (64-bit) expose it as uint64 ("t") as defined by the PDI type `size`.

The previous implementation assumed a uint64 type and failed when the property was exposed as uint32.

This commit updates the implementation to read the Position property generically by accepting both uint32 and uint64 and normalizing the value internally.

Tested By:
Verified this change on skiboards and rbmc-prototype machine.