### PR TITLE
vmi: Update static v6 default gateway in bios

### DIFF
--- a/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ethernet_interface.cpp
@@ -721,6 +721,7 @@ static void normalizeGateway(std::string& gw)
 
 std::string HypEthInterface::defaultGateway6(std::string gateway)
 {
+    lg2::info("Setting IPv6 static default gateway");
     normalizeGateway<stdplus::In6Addr>(gateway);
     if (gateway.empty())
     {
@@ -739,8 +740,9 @@ std::string HypEthInterface::defaultGateway6(std::string gateway)
             if (ipObj->origin() == HypIP::AddressOrigin::Static)
             {
                 HypEthernetIntf::defaultGateway6(gateway);
-                // Update ipv6 gateway as well
-                ipObj->HypIP::gateway(gateway);
+                // Update ipv6 gateway as well - this will trigger the BIOS
+                // table update
+                ipObj->gateway(gateway);
             }
             else
             {

--- a/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
+++ b/src/ibm/hypervisor-network-mgr-src/hyp_ip_interface.cpp
@@ -392,8 +392,6 @@ std::string HypIPAddress::gateway(std::string gateway)
             else if (protocol == HypIP::Protocol::IPv6)
             {
                 parent.get().validateGateway<stdplus::In6Addr>(gateway);
-                // update the default gw of the ethernet interface
-                parent.get().defaultGateway6(gateway);
             }
         }
         else


### PR DESCRIPTION
Currently, on configuring the IPv6 static default gateway via redfish, the value is set on hypervisor dbus but the corresponding bios attribute (vmi_if<0/1>_ipv6_gateway) is not updated. This prevents PLDM from picking up the gateway configuration and updating the host attribute table to apply it to the hypervisor interface.

The defaultGateway6() method was directly setting the gateway dbus property of IP object, which bypasses the gateway() method that contains the BIOS table update logic.

Tested-by:
Verified that vmi_if<0/1>_ipv6_gateway BIOS attribute is now updated when static IPv6 gateway is configured via Redfish.