### PR TITLE
Fix MAC and Position inventory path filtering

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,10 +19,6 @@ conf_data.set('SYNC_MAC_FROM_INVENTORY', get_option('sync-mac'))
 conf_data.set('PERSIST_MAC', get_option('persist-mac'))
 conf_data.set10('FORCE_SYNC_MAC_FROM_INVENTORY', get_option('force-sync-mac'))
 conf_data.set('ENABLE_RBMC_CONFIG', get_option('enable-rbmc-config'))
-conf_data.set(
-    'ENABLE_SKIBOARDS_MAC_PATH',
-    get_option('enable-skiboards-mac-path'),
-)
 
 sdbusplus_dep = dependency('sdbusplus')
 sdbusplusplus_prog = find_program('sdbus++', native: true)

--- a/meson.options
+++ b/meson.options
@@ -36,8 +36,4 @@ option(
     type: 'boolean',
     description: 'Enable rbmc configuration on internal interface, assigns IP address using BMC position ',
 )
-option(
-    'enable-skiboards-mac-path',
-    type: 'boolean',
-    description: 'Enable reading skiboards specific inventory MAC path (/xyz/openbmc_project/inventory/system/eth<N>)',
-)
+option('lldp', type: 'boolean', description: 'Enable LLDP neighbor discovery')

--- a/src/inventory_mac.cpp
+++ b/src/inventory_mac.cpp
@@ -90,71 +90,6 @@ void setFirstBootMACOnInterface(const std::string& intf, const std::string& mac)
 stdplus::EtherAddr getfromInventory(sdbusplus::bus_t& bus,
                                     const std::string& intfName)
 {
-#ifdef ENABLE_SKIBOARDS_MAC_PATH
-    // For skiboards, use direct path:
-    // /xyz/openbmc_project/inventory/system/eth<N>
-    std::string skiboardsPath =
-        "/xyz/openbmc_project/inventory/system/" + intfName;
-
-    lg2::info("Skiboards mode: Reading MAC from path {DBUS_PATH}", "DBUS_PATH",
-              skiboardsPath);
-
-    try
-    {
-        auto mapperCall =
-            bus.new_method_call(mapperBus, mapperObj, mapperIntf, "GetObject");
-
-        std::vector<std::string> interfaces;
-        interfaces.emplace_back(invNetworkIntf);
-        mapperCall.append(skiboardsPath, interfaces);
-
-        auto mapperReply = bus.call(mapperCall);
-        if (mapperReply.is_method_error())
-        {
-            lg2::error("Error in mapper call for skiboards path {DBUS_PATH}",
-                       "DBUS_PATH", skiboardsPath);
-            elog<InternalFailure>();
-        }
-
-        std::map<std::string, std::vector<std::string>> mapperResponse;
-        mapperReply.read(mapperResponse);
-
-        if (mapperResponse.empty())
-        {
-            lg2::error("No service found for skiboards path {DBUS_PATH}",
-                       "DBUS_PATH", skiboardsPath);
-            elog<InternalFailure>();
-        }
-
-        auto service = mapperResponse.begin()->first;
-
-        auto method = bus.new_method_call(
-            service.c_str(), skiboardsPath.c_str(), propIntf, methodGet);
-        method.append(invNetworkIntf, "MACAddress");
-
-        auto reply = bus.call(method);
-        if (reply.is_method_error())
-        {
-            lg2::error(
-                "Failed to get MACAddress for skiboards path {DBUS_PATH}",
-                "DBUS_PATH", skiboardsPath);
-            elog<InternalFailure>();
-        }
-
-        std::variant<std::string> value;
-        reply.read(value);
-        return stdplus::fromStr<stdplus::EtherAddr>(
-            std::get<std::string>(value));
-    }
-    catch (const std::exception& e)
-    {
-        lg2::error(
-            "Exception reading MAC from skiboards path {DBUS_PATH}: {ERROR}",
-            "DBUS_PATH", skiboardsPath, "ERROR", e.what());
-        elog<InternalFailure>();
-    }
-#else
-    // For all other machine types
     std::string interfaceName = configJson[intfName];
 
     std::vector<DbusInterface> interfaces;
@@ -234,7 +169,6 @@ stdplus::EtherAddr getfromInventory(sdbusplus::bus_t& bus,
     std::variant<std::string> value;
     reply.read(value);
     return stdplus::fromStr<stdplus::EtherAddr>(std::get<std::string>(value));
-#endif
 }
 
 bool setInventoryMACOnSystem(sdbusplus::bus_t& bus, const std::string& intfname)

--- a/src/inventory_mac.cpp
+++ b/src/inventory_mac.cpp
@@ -512,6 +512,12 @@ void registerBMCPositionInterfacesAddedSignal(sdbusplus::bus_t& bus)
         sdbusplus::message::object_path objPath;
         m.read(objPath, interfacesProperties);
 
+        // Only process Position interface from system object
+        if (objPath.str != systemPath)
+        {
+            return;
+        }
+
         for (auto& interface : interfacesProperties)
         {
             if (interface.first == invPositionIntf)

--- a/src/inventory_mac.cpp
+++ b/src/inventory_mac.cpp
@@ -200,7 +200,8 @@ stdplus::EtherAddr getfromInventory(sdbusplus::bus_t& bus,
         {
             lg2::info("Get info on interface {NET_INTF}, object {OBJ}",
                       "NET_INTF", interfaceName, "OBJ", object.first);
-            if (object.first.ends_with("/" + interfaceName))
+            if (object.first.contains("logical_bmc") &&
+                object.first.ends_with(interfaceName))
             {
                 objPath = object.first;
                 service = object.second.begin()->first;


### PR DESCRIPTION
Add path filtering to ensure inventory lookups only match the correct objects:

1. MAC Address Lookup: Filter to only match objects under the
   "logical_bmc" path that end with the interface name. This prevents
   incorrect matches when multiple interfaces share the same name
   suffix.

2. BMC Position Watch: Add check in InterfacesAdded signal handler to
   only process Position interface from /xyz/openbmc_project/inventory/
   system object. This prevents reading Position from other chassis
   objects that also host the Position interface.