### PR TITLE
Add missing "logical_bmc" inv path check

### DIFF
--- a/src/inventory_mac.cpp
+++ b/src/inventory_mac.cpp
@@ -494,7 +494,9 @@ void registerSignals(sdbusplus::bus_t& bus)
 
         for (const auto& pattern : configJson.items())
         {
-            if (objPath.str.ends_with("/" + pattern.value().get<std::string>()))
+            if (objPath.str.ends_with(
+                    "/" + pattern.value().get<std::string>()) &&
+                objPath.str.contains("logical_bmc"))
             {
                 for (auto& interface : interfacesProperties)
                 {


### PR DESCRIPTION
There are two places in networkd where mac address will be fetched from and assigned to the interfaces:
1. when vpd is up before networkd, networkd comes up, reads the mac from inventory path and configures it on the interface
2. when networkd comes up first,it waits for dbus signal to fetch mac address from the corresponding inventory path

There was a previous commit that adds additional path filtering to retrieve mac address, which made changes to the first case mentioned above and second one was missed.

This commit adds changes to the inventory path for the second scenario as well.

Tested By:
Tested it on huygens simics, and rbmc-prototype machines.