### PR TITLE
Add NTP server address validation

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -27,6 +27,7 @@
 #include <format>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <variant>
 
 namespace phosphor
@@ -725,7 +726,26 @@ ObjectPath EthernetInterface::createVLAN(uint16_t id)
 
 ServerList EthernetInterface::staticNTPServers(ServerList value)
 {
-    value = EthernetInterfaceIntf::staticNTPServers(std::move(value));
+    // Validate and remove duplicates from NTP servers
+    std::vector<std::string> validatedServers;
+    validatedServers.reserve(value.size());
+    for (const auto& server : value)
+    {
+        if (!internal::isValidNtpServer(server))
+        {
+            lg2::error("Invalid NTP server {NET_NTP}", "NET_NTP", server);
+            elog<InvalidArgument>(Argument::ARGUMENT_NAME("StaticNTPServer"),
+                                  Argument::ARGUMENT_VALUE(server.c_str()));
+        }
+        if (std::find(validatedServers.begin(), validatedServers.end(),
+                      server) == validatedServers.end())
+        {
+            validatedServers.push_back(server);
+        }
+    }
+
+    value =
+        EthernetInterfaceIntf::staticNTPServers(std::move(validatedServers));
 
     writeConfigurationFile();
     manager.get().reloadConfigs();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5,19 +5,26 @@
 #include "config_parser.hpp"
 #include "types.hpp"
 
+#include <arpa/inet.h>
+#include <netinet/in.h>
 #include <sys/wait.h>
 
 #include <phosphor-logging/elog-errors.hpp>
 #include <phosphor-logging/lg2.hpp>
+#include <stdplus/net/addr/hostname.hpp>
+#include <stdplus/net/addr/ip.hpp>
 #include <stdplus/numeric/str.hpp>
 #include <stdplus/str/buf.hpp>
 #include <stdplus/str/cat.hpp>
 #include <xyz/openbmc_project/Common/error.hpp>
 
+#include <algorithm>
 #include <cctype>
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace phosphor
 {
@@ -31,6 +38,31 @@ static constexpr std::string_view lldpdConfigFilePath = "/etc/lldpd.conf";
 
 namespace internal
 {
+
+bool isValidNtpServer(const std::string& server)
+{
+    // Try IP validation (IPv4 or IPv6)
+    try
+    {
+        stdplus::fromStr<stdplus::InAnyAddr>(server);
+        return true;
+    }
+    catch (...)
+    {
+        // Not an IP, try hostname
+    }
+
+    // Try hostname validation
+    try
+    {
+        stdplus::fromStr<stdplus::Hostname>(server);
+        return true;
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
 
 void executeCommandinChildProcess(stdplus::zstring_view path, char** args)
 {

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -80,6 +80,14 @@ std::map<std::string, bool> parseLLDPConf();
 namespace internal
 {
 
+/**
+ * @brief Validates if a string is a valid NTP server
+ * Accepts: IPv4, IPv6, FQDN, and hostnames
+ * @param[in] server - NTP server string
+ * @return true if valid, false otherwise
+ */
+bool isValidNtpServer(const std::string& server);
+
 /* @brief runs the given command in child process.
  * @param[in] path - path of the binary file which needs to be execeuted.
  * @param[in] args - arguments of the command.

--- a/test/test_ethernet_interface.cpp
+++ b/test/test_ethernet_interface.cpp
@@ -301,5 +301,228 @@ TEST_F(TestEthernetInterface, AddMultipleIPv6StaticGateways)
                                      Key(std::string("2004:903:15f:325::1"))));
 }
 
+TEST_F(TestEthernetInterface, addStaticNTPServers_InvalidIPv4)
+{
+    using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+
+    // Set valid servers first
+    ServerList validServers = {"10.1.1.1", "10.2.2.2"};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(validServers);
+
+    // Try to set invalid IPv4 with negative octets
+    ServerList invalidServers = {"-8.-8.-8.-8"};
+    EXPECT_THROW(interface.staticNTPServers(invalidServers), InvalidArgument);
+
+    // Verify NTP servers were not modified - check config file
+    config::Parser parser((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(validServers, parser.map.getValueStrings("Network", "NTP"));
+}
+
+TEST_F(TestEthernetInterface, addStaticNTPServers_InvalidIPv4_OutOfRange)
+{
+    using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+
+    // Set valid servers first
+    ServerList validServers = {"8.8.8.8"};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(validServers);
+
+    // Try to set invalid IPv4 out of range
+    ServerList invalidServers = {"256.256.256.256"};
+    EXPECT_THROW(interface.staticNTPServers(invalidServers), InvalidArgument);
+
+    // Verify NTP servers were not modified - check config file
+    config::Parser parser((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(validServers, parser.map.getValueStrings("Network", "NTP"));
+}
+
+TEST_F(TestEthernetInterface, addStaticNTPServers_InvalidSpecialChar)
+{
+    using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+
+    // Set valid servers first
+    ServerList validServers = {"pool.ntp.org"};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(validServers);
+
+    // Test with @ symbol
+    ServerList servers1 = {"ntp@server.com"};
+    EXPECT_THROW(interface.staticNTPServers(servers1), InvalidArgument);
+    config::Parser parser1((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(validServers, parser1.map.getValueStrings("Network", "NTP"));
+
+    // Test with ! symbol
+    ServerList servers2 = {"ntp!server.com"};
+    EXPECT_THROW(interface.staticNTPServers(servers2), InvalidArgument);
+    config::Parser parser2((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(validServers, parser2.map.getValueStrings("Network", "NTP"));
+
+    // Test with underscore
+    ServerList servers3 = {"ntp_server.com"};
+    EXPECT_THROW(interface.staticNTPServers(servers3), InvalidArgument);
+    config::Parser parser3((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(validServers, parser3.map.getValueStrings("Network", "NTP"));
+}
+
+TEST_F(TestEthernetInterface, addStaticNTPServers_InvalidHyphens)
+{
+    using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+
+    // Set valid servers first
+    ServerList validServers = {"time.google.com"};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(validServers);
+
+    // Leading hyphen
+    ServerList servers1 = {"-ntp.example.com"};
+    EXPECT_THROW(interface.staticNTPServers(servers1), InvalidArgument);
+    config::Parser parser1((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(validServers, parser1.map.getValueStrings("Network", "NTP"));
+
+    // Trailing hyphen
+    ServerList servers2 = {"ntp-.example.com"};
+    EXPECT_THROW(interface.staticNTPServers(servers2), InvalidArgument);
+    config::Parser parser2((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(validServers, parser2.map.getValueStrings("Network", "NTP"));
+}
+
+TEST_F(TestEthernetInterface, addStaticNTPServers_InvalidDots)
+{
+    using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+
+    // Set valid servers first
+    ServerList validServers = {"1.1.1.1"};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(validServers);
+
+    // Leading dot
+    ServerList servers1 = {".ntp.example.com"};
+    EXPECT_THROW(interface.staticNTPServers(servers1), InvalidArgument);
+    config::Parser parser1((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(validServers, parser1.map.getValueStrings("Network", "NTP"));
+
+    // Trailing dot
+    ServerList servers2 = {"ntp.example.com."};
+    ServerList servers_remove_trail_dot = {"ntp.example.com"};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(servers_remove_trail_dot);
+
+    // Double dot
+    ServerList servers3 = {"ntp..example.com"};
+    EXPECT_THROW(interface.staticNTPServers(servers3), InvalidArgument);
+    config::Parser parser3((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(servers_remove_trail_dot,
+              parser3.map.getValueStrings("Network", "NTP"));
+}
+
+TEST_F(TestEthernetInterface, addStaticNTPServers_MixedValidInvalid)
+{
+    using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+
+    // Set valid servers first
+    ServerList validServers = {"9.9.9.9"};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(validServers);
+
+    // Mix of valid and invalid - should reject all
+    ServerList servers = {"pool.ntp.org", "invalid@server.com", "8.8.8.8"};
+    EXPECT_THROW(interface.staticNTPServers(servers), InvalidArgument);
+
+    // Verify NTP servers were not modified - check config file
+    config::Parser parser((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(validServers, parser.map.getValueStrings("Network", "NTP"));
+}
+
+TEST_F(TestEthernetInterface, addStaticNTPServers_ValidAfterInvalid)
+{
+    using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+
+    // Set initial valid servers
+    ServerList initialServers = {"1.2.3.4"};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(initialServers);
+
+    // Try invalid
+    ServerList invalidServers = {"-8.-8.-8.-8"};
+    EXPECT_THROW(interface.staticNTPServers(invalidServers), InvalidArgument);
+
+    // Verify initial servers still in config
+    config::Parser parser1((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(initialServers, parser1.map.getValueStrings("Network", "NTP"));
+
+    // Then set valid servers - should succeed
+    ServerList validServers = {"pool.ntp.org", "8.8.8.8"};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(validServers);
+
+    // Verify valid servers were set in config
+    config::Parser parser2((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(validServers, parser2.map.getValueStrings("Network", "NTP"));
+}
+
+TEST_F(TestEthernetInterface, addStaticNTPServers_EmptyString)
+{
+    using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+
+    // Set valid servers first
+    ServerList validServers = {"time.nist.gov"};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(validServers);
+
+    ServerList servers = {""};
+    EXPECT_THROW(interface.staticNTPServers(servers), InvalidArgument);
+
+    // Verify NTP servers were not modified - check config file
+    config::Parser parser((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(validServers, parser.map.getValueStrings("Network", "NTP"));
+}
+
+TEST_F(TestEthernetInterface, addStaticNTPServers_TooLong)
+{
+    using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+
+    // Set valid servers first
+    ServerList validServers = {"ntp.ubuntu.com"};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(validServers);
+
+    // Create a string longer than 253 characters
+    std::string longServer(254, 'a');
+    longServer += ".com";
+    ServerList servers = {longServer};
+    EXPECT_THROW(interface.staticNTPServers(servers), InvalidArgument);
+
+    // Verify NTP servers were not modified - check config file
+    config::Parser parser((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(validServers, parser.map.getValueStrings("Network", "NTP"));
+}
+
+TEST_F(TestEthernetInterface, addStaticNTPServers_ValidEdgeCases)
+{
+    // 63 character label (maximum valid)
+    std::string validLabel(63, 'a');
+    validLabel += ".example.com";
+    ServerList servers1 = {validLabel};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(servers1);
+    config::Parser parser1((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(servers1, parser1.map.getValueStrings("Network", "NTP"));
+
+    // Mixed case
+    ServerList servers2 = {"NTP.Example.COM"};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(servers2);
+    config::Parser parser2((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(servers2, parser2.map.getValueStrings("Network", "NTP"));
+
+    // Hyphen in middle
+    ServerList servers3 = {"ntp-server.example.com"};
+    EXPECT_CALL(manager.mockReload, schedule());
+    interface.staticNTPServers(servers3);
+    config::Parser parser3((confDir / "00-bmc-test0.network").native());
+    EXPECT_EQ(servers3, parser3.map.getValueStrings("Network", "NTP"));
+}
+
 } // namespace network
 } // namespace phosphor


### PR DESCRIPTION
https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/88215

Prevent invalid NTP server entries from being accepted by adding comprehensive validation. This addresses an issue where malformed NTP servers were silently accepted, including:
- Negative octets (e.g., -8.-8.-8.-8)
- Out-of-range values (e.g., 256.1.1.1)
- Invalid formats (e.g., invalid@server.com)

Implementation adds isValidNtpServer() function supporting IPv4, IPv6, FQDN, and hostnames. Validation occurs in staticNTPServers() before accepting entries. Duplicate NTP server entries are removed. Invalid addresses return InvalidArgument D-Bus error. Added the Unit testcases to validate the NTPservers.

Depends on 8810(I1817326d24734e05af5c7c615890b75f1f8568c6)

Tested by:
Get/Patch on
```
	1. Valid IPs (8.8.8.8, pool.ntp.org, time.google.com)
		accepted
	PATCH -d '{"NTP":{"NTPServers":["pool.ntp.org",
	"time.google.com","8.8.8.8"], "ProtocolEnabled":true}}'
	GET https://${BMC}/redfish/v1/Managers/bmc/NetworkProtocol
	{
        	"NTPServers": [
    		"pool.ntp.org",
    		"time.google.com",
    		"8.8.8.8"
  		],
  		"NetworkSuppliedServers": [],
  		"ProtocolEnabled": true
	}
	2. Invalid IPs (-8.-8.-8.-8, 256.1.1.1,ntp@server!.com)
		rejected
	PATCH -d '{"NTP":{"NTPServers":["-8.-8.-8.-8"],
		 "ProtocolEnabled":true}
	}
	GET https://${BMC}/redfish/v1/Managers/bmc/NetworkProtocol
        {
                "NTPServers": [
                "pool.ntp.org",
                "time.google.com",
                "8.8.8.8"
                ],
                "NetworkSuppliedServers": [],
                "ProtocolEnabled": true
        }
	PATCH -d '{"NTP":{"NTPServers":["256.1.1.1"],
		"ProtocolEnabled":true}
	GET https://${BMC}/redfish/v1/Managers/bmc/NetworkProtocol
        {
                "NTPServers": [
                "pool.ntp.org",
                "time.google.com",
                "8.8.8.8"
                ],
                "NetworkSuppliedServers": [],
                "ProtocolEnabled": true
        }
	PATCH -d '{"NTP":{"NTPServers":["ntp@server!.com"],
                "ProtocolEnabled":true}
        GET https://${BMC}/redfish/v1/Managers/bmc/NetworkProtocol
        {
                "NTPServers": [
                "pool.ntp.org",
                "time.google.com",
                "8.8.8.8"
                ],
                "NetworkSuppliedServers": [],
                "ProtocolEnabled": true
        }
```

Change-Id: I587c613b098b5399162321bbd1a2f121c494dc7d