### PR TITLE
Add LLDP configuration support for 1060

### DIFF
--- a/src/ethernet_interface.cpp
+++ b/src/ethernet_interface.cpp
@@ -159,7 +159,11 @@ EthernetInterface::EthernetInterface(stdplus::PinnedRef<sdbusplus::bus_t> bus,
     EthernetInterfaceIntf::dhcp6(dhcpVal.v6, true);
     EthernetInterfaceIntf::ipv6AcceptRA(getIPv6AcceptRA(config), true);
     EthernetInterfaceIntf::nicEnabled(enabled, true);
-
+    auto lldpVal = parseLLDPConf();
+    if (!lldpVal.empty())
+    {
+        EthernetInterfaceIntf::emitLLDP(lldpVal[interfaceName()], true);
+    }
     EthernetInterfaceIntf::ntpServers(
         config.map.getValueStrings("Network", "NTP"), true);
 
@@ -1657,6 +1661,16 @@ void EthernetInterface::addDHCPConfigurations()
         bus, objPath + "/dhcp4", *this, DHCPType::v4));
     this->dhcpConfigs.emplace_back(std::make_unique<dhcp::Configuration>(
         bus, objPath + "/dhcp6", *this, DHCPType::v6));
+}
+
+bool EthernetInterface::emitLLDP(bool value)
+{
+    if (emitLLDP() != EthernetInterfaceIntf::emitLLDP(value))
+    {
+        manager.get().writeLLDPDConfigurationFile();
+        manager.get().reloadLLDPService();
+    }
+    return value;
 }
 
 void EthernetInterface::reloadConfigs()

--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -239,6 +239,12 @@ class EthernetInterface : public Ifaces
 
     bool dhcpIsEnabled(IP::Protocol family, bool ignoreProtocol);
     void disableDHCP(IP::Protocol protocol);
+    
+    /** @brief set conf file for LLDP
+     *  @param[in] value - lldp value of the interface.
+     */
+    bool emitLLDP(bool value) override;
+
     using EthernetInterfaceIntf::interfaceName;
     using EthernetInterfaceIntf::linkUp;
     using EthernetInterfaceIntf::mtu;
@@ -247,6 +253,7 @@ class EthernetInterface : public Ifaces
 
     using EthernetInterfaceIntf::defaultGateway;
     using EthernetInterfaceIntf::defaultGateway6;
+    using EthernetInterfaceIntf::emitLLDP;
 
   protected:
     /** @brief get the NTP server list from the timsyncd dbus obj

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -17,14 +17,14 @@
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <filesystem>
-
-constexpr char SYSTEMD_BUSNAME[] = "org.freedesktop.systemd1";
 constexpr char SYSTEMD_PATH[] = "/org/freedesktop/systemd1";
 constexpr char SYSTEMD_INTERFACE[] = "org.freedesktop.systemd1.Manager";
 
 constexpr char NETWORKD_BUSNAME[] = "org.freedesktop.network1";
 constexpr char NETWORKD_PATH[] = "/org/freedesktop/network1";
 constexpr char NETWORKD_INTERFACE[] = "org.freedesktop.network1.Manager";
+#include <format>
+#include <fstream>
 
 namespace phosphor
 {
@@ -34,6 +34,12 @@ namespace network
 using namespace phosphor::logging;
 using namespace sdbusplus::xyz::openbmc_project::Common::Error;
 using Argument = xyz::openbmc_project::Common::InvalidArgument;
+
+constexpr auto systemdBusname = "org.freedesktop.systemd1";
+constexpr auto systemdObjPath = "/org/freedesktop/systemd1";
+constexpr auto systemdInterface = "org.freedesktop.systemd1.Manager";
+constexpr auto lldpFilePath = "/etc/lldpd.conf";
+constexpr auto lldpService = "lldpd.service";
 
 static constexpr const char enabledMatch[] =
     "type='signal',sender='org.freedesktop.network1',path_namespace='/org/"
@@ -522,6 +528,46 @@ void Manager::handleAdminState(std::string_view state, unsigned ifidx)
         {
             createInterface(it->second, managed);
         }
+    }
+}
+
+void Manager::writeLLDPDConfigurationFile()
+{
+    std::ofstream lldpdConfig(lldpFilePath);
+
+    lldpdConfig << "configure system description BMC" << std::endl;
+    lldpdConfig << "configure system ip management pattern eth*" << std::endl;
+    for (const auto& intf : interfaces)
+    {
+        bool emitlldp = intf.second->emitLLDP();
+        if (emitlldp)
+        {
+            lldpdConfig << "configure ports " << intf.second->interfaceName()
+                        << " lldp status tx-only" << std::endl;
+        }
+        else
+        {
+            lldpdConfig << "configure ports " << intf.second->interfaceName()
+                        << " lldp status disabled" << std::endl;
+        }
+    }
+
+    lldpdConfig.close();
+}
+
+void Manager::reloadLLDPService()
+{
+    try
+    {
+        auto method = bus.get().new_method_call(
+            systemdBusname, systemdObjPath, systemdInterface, "RestartUnit");
+        method.append(lldpService, "replace");
+        bus.get().call_noreply(method);
+    }
+    catch (const sdbusplus::exception_t& ex)
+    {
+        lg2::error("Failed to restart service {SERVICE}: {ERR}", "SERVICE",
+                   lldpService, "ERR", ex);
     }
 }
 

--- a/src/network_manager.hpp
+++ b/src/network_manager.hpp
@@ -61,6 +61,10 @@ class Manager : public ManagerIface
      */
     void writeToConfigurationFile();
 
+    /** @brief write the lldp conf file
+     */
+    void writeLLDPDConfigurationFile();
+
     /** @brief Adds a single interface to the interface map */
     void addInterface(const InterfaceInfo& info);
     void removeInterface(const InterfaceInfo& info);
@@ -99,6 +103,10 @@ class Manager : public ManagerIface
     {
         reload.schedule();
     }
+
+    /** Reload LLDP configuration
+     */
+    void reloadLLDPService();
 
     /** @brief Persistent map of EthernetInterface dbus objects and their names
      */

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -15,6 +15,7 @@
 #include <xyz/openbmc_project/Common/error.hpp>
 
 #include <cctype>
+#include <fstream>
 #include <string>
 #include <string_view>
 
@@ -26,6 +27,7 @@ namespace network
 using std::literals::string_view_literals::operator""sv;
 using namespace phosphor::logging;
 using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+static constexpr std::string_view lldpdConfigFilePath = "/etc/lldpd.conf";
 
 namespace internal
 {
@@ -299,6 +301,43 @@ std::string generateNetworkRoute(const std::string& ip, int prefixLength)
         return {};
 
     return std::string(buf.data()) + "/" + std::to_string(prefixLength);
+}
+
+std::map<std::string, bool> parseLLDPConf()
+{
+    std::ifstream lldpdConfig(lldpdConfigFilePath.data());
+    std::map<std::string, bool> portStatus;
+
+    if (!lldpdConfig.is_open())
+    {
+        return portStatus;
+    }
+
+    std::string line;
+    while (std::getline(lldpdConfig, line))
+    {
+        std::string configurePortsStr = "configure ports ";
+        std::string lldpStatusStr = "lldp status ";
+        size_t portStart = line.find(configurePortsStr);
+        if (portStart != std::string::npos)
+        {
+            portStart += configurePortsStr.size();
+            size_t portEnd = line.find(' ', portStart);
+            if (portEnd == std::string::npos)
+            {
+                portEnd = line.length();
+            }
+            std::string portName = line.substr(portStart, portEnd - portStart);
+            size_t pos = line.find(lldpStatusStr);
+            if (pos != std::string::npos)
+            {
+                std::string statusStr = line.substr(pos + lldpStatusStr.size());
+                portStatus[portName] = (statusStr == "disabled") ? false : true;
+            }
+        }
+    }
+    lldpdConfig.close();
+    return portStatus;
 }
 
 } // namespace network

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -4,6 +4,7 @@
 #include <stdplus/raw.hpp>
 #include <stdplus/zstring.hpp>
 
+#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -128,6 +129,10 @@ std::string generateNetworkRoute(const std::string& gateway, int prefixLength);
  *  @param[in] iface - interface name
  */
 uint32_t generateRouteTableID(const std::string& iface);
+
+/** @brief Read LLDP configuration from lldpd conf file
+ */
+std::map<std::string, bool> parseLLDPConf();
 
 namespace internal
 {


### PR DESCRIPTION
upstream commit:https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/76368
This commit implements EmitLLDP D-bus property to support configuration of enable/disable LLDP of each ethernet interface.

Tested by:
Set EmitLLDP D-bus property on
xyz.openbmc_project.Network.EthernetInterface

Change-Id: I4ebedff9d3f914219f2f84c861fdee126584a94b