### PR TITLE
lldp: Use systemd-networkd for interface discovery

### DIFF
--- a/src/lldp/lldp_manager.cpp
+++ b/src/lldp/lldp_manager.cpp
@@ -47,31 +47,41 @@ std::vector<std::string> Manager::getInterfaces()
 
     try
     {
+        lg2::info("LLDP: Using systemd-networkd to discover interfaces");
+
         auto method = bus.new_method_call(
-            "xyz.openbmc_project.Network", "/xyz/openbmc_project/network",
-            "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+            "org.freedesktop.network1", "/org/freedesktop/network1",
+            "org.freedesktop.network1.Manager", "ListLinks");
 
         auto reply = bus.call(method);
 
-        std::map<sdbusplus::message::object_path,
-                 std::map<std::string, std::map<std::string, DBusProp>>>
-            objects;
+        std::vector<
+            std::tuple<int32_t, std::string, sdbusplus::message::object_path>>
+            links;
+        reply.read(links);
 
-        reply.read(objects);
+        lg2::info("LLDP: Discovered {COUNT} network links", "COUNT",
+                  links.size());
 
-        for (const auto& [path, ifacesMap] : objects)
+        for (const auto& [ifindex, ifname, linkPath] : links)
         {
-            if (ifacesMap.find(
-                    "xyz.openbmc_project.Network.EthernetInterface") !=
-                ifacesMap.end())
+            if (ifname != "lo")
             {
-                ifnames.push_back(path.filename());
+                ifnames.push_back(ifname);
+                lg2::debug("LLDP: Monitoring interface {IF} (index={IDX})",
+                           "IF", ifname, "IDX", ifindex);
             }
         }
     }
+    catch (const sdbusplus::exception_t& e)
+    {
+        lg2::error("LLDP: DBus error while querying interfaces: {ERR}", "ERR",
+                   e.what());
+    }
     catch (const std::exception& e)
     {
-        lg2::error("Failed to call GetManagedObjects: {ERR}", "ERR", e.what());
+        lg2::error("LLDP: Failed to discover interfaces: {ERR}", "ERR",
+                   e.what());
     }
 
     return ifnames;

--- a/src/lldp/xyz.openbmc_project.LLDP.service.in
+++ b/src/lldp/xyz.openbmc_project.LLDP.service.in
@@ -2,8 +2,9 @@
 Description=LLDP for Neighbor Discovery
 After=lldpd.service
 After=network.target
-After=xyz.openbmc_project.Network.service
-Requires=xyz.openbmc_project.Network.service
+After=systemd-networkd.service
+Requires=systemd-networkd.service
+BindsTo=systemd-networkd.service
 
 [Service]
 ExecStart=/usr/bin/phosphor-lldpd


### PR DESCRIPTION
jira:PFEBMC-2674
Change LLDP manager to discover network interfaces via systemd-networkd's DBus API instead of depending on phosphor-networkd. This provides a more direct and reliable method for interface discovery.

Changes:
- Query org.freedesktop.network1.Manager.ListLinks for interface list
- Update service dependencies to require systemd-networkd
- Remove dependency on xyz.openbmc_project.Network service
- Add BindsTo to ensure LLDP lifecycle matches systemd-networkd

Rationale:
LLDP needs to know about all network interfaces, including those that may not have phosphor-networkd DBus objects. Querying systemd-networkd directly ensures LLDP can discover and monitor all interfaces managed by the system.

Tested: LLDP successfully discovers all interfaces including internal management interfaceis, both transit and recieve objects were created for internal interface.