### PR TITLE
Add IP configuration helper functions

### DIFF
--- a/src/system_queries.cpp
+++ b/src/system_queries.cpp
@@ -2,6 +2,7 @@
 
 #include "netlink.hpp"
 
+#include <arpa/inet.h>
 #include <linux/ethtool.h>
 #include <linux/rtnetlink.h>
 #include <linux/sockios.h>
@@ -93,6 +94,182 @@ EthInfo getEthInfo(stdplus::zstring_view ifname)
                },
                &edata)
         .value_or(EthInfo{});
+}
+
+/**
+ * @brief Check if a network interface exists
+ * @param ifname Interface name to check
+ * @return true if interface exists, false otherwise
+ */
+static bool interfaceExists(std::string_view ifname)
+{
+    auto ifr = makeIFReq(ifname);
+    try
+    {
+        getIFSock().ioctl(SIOCGIFFLAGS, &ifr);
+        return true;
+    }
+    catch (const std::system_error& e)
+    {
+        lg2::error("Interface does not exist: {INTERFACE}, error: {ERROR}",
+                   "INTERFACE", ifname, "ERROR", e.what());
+        return false;
+    }
+}
+
+static struct in_addr validateIPv4Address(std::string_view ipAddress)
+{
+    struct in_addr addr;
+    // inet_pton requires null-terminated string
+    std::string ipStr(ipAddress);
+    if (inet_pton(AF_INET, ipStr.c_str(), &addr) != 1)
+    {
+        throw std::invalid_argument(
+            std::format("Invalid IP address: {}", ipAddress));
+    }
+    return addr;
+}
+
+/**
+ * @brief Calculate netmask from prefix length
+ * @param prefixLength Prefix length (0-32)
+ * @return in_addr structure with the netmask
+ */
+static struct in_addr calculateNetmask(uint8_t prefixLength)
+{
+    if (prefixLength == 0 || prefixLength == 32 || prefixLength > 32)
+    {
+        throw std::invalid_argument(
+            std::format("Invalid prefix length: {}", prefixLength));
+    }
+
+    struct in_addr netmask;
+    uint32_t mask = htonl(0xFFFFFFFFU << (32 - prefixLength));
+    netmask.s_addr = mask;
+    return netmask;
+}
+
+/**
+ * @brief Calculate broadcast address
+ * @param addr IP address
+ * @param netmask Network mask
+ * @return in_addr structure with the broadcast address
+ */
+static struct in_addr calculateBroadcast(struct in_addr addr,
+                                         struct in_addr netmask)
+{
+    struct in_addr bcast;
+    bcast.s_addr = (addr.s_addr & netmask.s_addr) | ~netmask.s_addr;
+    return bcast;
+}
+
+/**
+ * @brief Validate interface name
+ * @param ifname Interface name to validate
+ * @throws std::system_error if name is empty or exceeds IFNAMSIZ-1
+ */
+static void validateInterfaceName(std::string_view ifname)
+{
+    if (ifname.empty() || ifname.length() > IFNAMSIZ - 1)
+    {
+        throw std::system_error(
+            std::make_error_code(std::errc::invalid_argument),
+            std::format("Invalid interface name length: {}", ifname));
+    }
+}
+
+/**
+ * @brief Set sockaddr_in structure with IPv4 address
+ * @param sa Reference to sockaddr structure to populate
+ * @param addr IPv4 address to set
+ */
+static void setSockAddrIn(struct sockaddr& sa, const struct in_addr& addr)
+{
+    auto* sin = reinterpret_cast<struct sockaddr_in*>(&sa);
+    sin->sin_family = AF_INET;
+    sin->sin_addr = addr;
+}
+
+/**
+ * @brief Set IP address on a network interface
+ * @param ifname Interface name (e.g., "eth0")
+ * @param ipAddress IPv4 address in dotted-decimal notation (e.g.,
+ * "192.168.1.100")
+ * @param prefixLength CIDR prefix length (1-31, rejects 0, 32, and >32)
+ * @throws std::system_error if interface doesn't exist or ioctl fails
+ * @throws std::invalid_argument if IP address format is invalid or prefix
+ * length is invalid
+ */
+void setIPAddress(std::string_view ifname, std::string_view ipAddress,
+                  uint8_t prefixLength)
+{
+    try
+    {
+        // Validate interface name
+        validateInterfaceName(ifname);
+
+        if (!interfaceExists(ifname))
+        {
+            throw std::system_error(
+                std::make_error_code(std::errc::no_such_device),
+                std::format("Interface {} does not exist", ifname));
+        }
+
+        // Validate IP address and calculate network parameters
+        struct in_addr addr = validateIPv4Address(ipAddress);
+        struct in_addr netmask = calculateNetmask(prefixLength);
+        struct in_addr bcast = calculateBroadcast(addr, netmask);
+
+        // Prepare ifreq structure
+        auto ifr = makeIFReq(ifname);
+
+        // Set IP address
+        setSockAddrIn(ifr.ifr_addr, addr);
+        lg2::info("Setting IP {NET_IP} on {NET_INTF}", "NET_IP", ipAddress,
+                  "NET_INTF", ifname);
+        getIFSock().ioctl(SIOCSIFADDR, &ifr);
+
+        // Set netmask
+        setSockAddrIn(ifr.ifr_netmask, netmask);
+        lg2::info("Setting netmask /{PREFIX} on {NET_INTF}", "PREFIX",
+                  prefixLength, "NET_INTF", ifname);
+        getIFSock().ioctl(SIOCSIFNETMASK, &ifr);
+
+        // Set broadcast address (non-critical)
+        setSockAddrIn(ifr.ifr_broadaddr, bcast);
+        try
+        {
+            getIFSock().ioctl(SIOCSIFBRDADDR, &ifr);
+        }
+        catch (const std::system_error& e)
+        {
+            lg2::warning("Failed to set broadcast on {INTF}: {ERROR}", "INTF",
+                         ifname, "ERROR", e.what());
+        }
+
+        lg2::info("Successfully configured IP address on {NET_INTF}",
+                  "NET_INTF", ifname);
+    }
+    catch (const std::invalid_argument& e)
+    {
+        lg2::error("Invalid IP configuration for {INTF}: {ERROR}", "INTF",
+                   ifname, "ERROR", e.what());
+        throw;
+    }
+    catch (const std::system_error& e)
+    {
+        lg2::error("Failed to configure IP on {INTF}: {ERROR}", "INTF", ifname,
+                   "ERROR", e.what());
+        throw std::system_error(
+            e.code(),
+            std::format("Failed to configure IP on {}: {}", ifname, e.what()));
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Unexpected error configuring IP on {INTF}: {ERROR}", "INTF",
+                   ifname, "ERROR", e.what());
+        throw;
+    }
 }
 
 void setMTU(std::string_view ifname, unsigned mtu)

--- a/src/system_queries.hpp
+++ b/src/system_queries.hpp
@@ -19,6 +19,15 @@ void setMTU(std::string_view ifname, unsigned mtu);
 
 void setNICUp(std::string_view ifname, bool up);
 
+/** @brief Sets the IP address of the interface
+ *  use for interfaces explicitly marked as ignored.
+ *  @param[in] ifname - Interface name
+ *  @param[in] ipAddress - IP address string
+ *  @param[in] prefixLength - Prefix length
+ */
+void setIPAddress(std::string_view ifname, std::string_view ipAddress,
+                  uint8_t prefixLength);
+
 void deleteIntf(unsigned idx);
 
 } // namespace phosphor::network::system

--- a/test/mock_syscall.cpp
+++ b/test/mock_syscall.cpp
@@ -189,6 +189,59 @@ int ioctl(int fd, unsigned long int request, ...)
         req->ifr_mtu = *it->second.mtu;
         return 0;
     }
+    else if (request == SIOCSIFMTU)
+    {
+        auto it = mock_if.find(req->ifr_name);
+        if (it == mock_if.end())
+        {
+            errno = ENXIO;
+            return -1;
+        }
+        it->second.mtu = req->ifr_mtu;
+        return 0;
+    }
+    else if (request == SIOCSIFADDR)
+    {
+        auto it = mock_if.find(req->ifr_name);
+        if (it == mock_if.end())
+        {
+            errno = ENXIO;
+            return -1;
+        }
+        return 0;
+    }
+    else if (request == SIOCSIFNETMASK)
+    {
+        auto it = mock_if.find(req->ifr_name);
+        if (it == mock_if.end())
+        {
+            errno = ENXIO;
+            return -1;
+        }
+        return 0;
+    }
+    else if (request == SIOCSIFBRDADDR)
+    {
+        auto it = mock_if.find(req->ifr_name);
+        if (it == mock_if.end())
+        {
+            errno = ENXIO;
+            return -1;
+        }
+        return 0;
+    }
+    else if (request == SIOCETHTOOL)
+    {
+        auto it = mock_if.find(req->ifr_name);
+        if (it == mock_if.end())
+        {
+            errno = ENXIO;
+            return -1;
+        }
+        // Return default/zeroed ethtool data for mock interfaces
+        // This ensures tests get predictable values
+        return 0;
+    }
 
     static auto real_ioctl =
         reinterpret_cast<decltype(&ioctl)>(dlsym(RTLD_NEXT, "ioctl"));

--- a/test/test_system_queries.cpp
+++ b/test/test_system_queries.cpp
@@ -1,0 +1,398 @@
+#include "mock_syscall.hpp"
+#include "system_queries.hpp"
+
+#include <net/if.h>
+#include <net/if_arp.h>
+
+#include <stdplus/raw.hpp>
+
+#include <gtest/gtest.h>
+
+namespace phosphor
+{
+namespace network
+{
+namespace system
+{
+
+using stdplus::operator""_sub;
+
+class TestSystemQueries : public testing::Test
+{
+  public:
+    void SetUp() override
+    {
+        mock_clear();
+    }
+
+    void TearDown() override
+    {
+        mock_clear();
+    }
+};
+
+TEST_F(TestSystemQueries, GetEthInfoSuccess)
+{
+    mock_addIF(InterfaceInfo{
+        .type = 1, .idx = 1, .flags = IFF_UP | IFF_RUNNING, .name = "eth0"});
+
+    auto info = getEthInfo("eth0");
+
+    EXPECT_FALSE(info.autoneg);
+    EXPECT_EQ(0, info.speed);
+    EXPECT_FALSE(info.fullDuplex);
+}
+
+TEST_F(TestSystemQueries, GetEthInfoMultipleInterfaces)
+{
+    mock_addIF(
+        InterfaceInfo{.type = 1, .idx = 1, .flags = IFF_UP, .name = "eth0"});
+    mock_addIF(
+        InterfaceInfo{.type = 1, .idx = 2, .flags = IFF_UP, .name = "eth1"});
+
+    auto info0 = getEthInfo("eth0");
+    auto info1 = getEthInfo("eth1");
+
+    EXPECT_FALSE(info0.autoneg);
+    EXPECT_FALSE(info1.autoneg);
+}
+
+TEST_F(TestSystemQueries, GetEthInfoMultipleInterfacesSpeed)
+{
+    mock_addIF(
+        InterfaceInfo{.type = 1, .idx = 1, .flags = IFF_UP, .name = "eth0"});
+    mock_addIF(
+        InterfaceInfo{.type = 1, .idx = 2, .flags = IFF_UP, .name = "eth1"});
+
+    auto ethInfo0 = getEthInfo("eth0");
+    auto ethInfo1 = getEthInfo("eth1");
+
+    EXPECT_EQ(0, ethInfo0.speed);
+    EXPECT_EQ(0, ethInfo1.speed);
+}
+
+TEST_F(TestSystemQueries, GetEthInfoNonExistentInterface)
+{
+    // Should throw when interface doesn't exist
+    EXPECT_THROW(getEthInfo("eth99"), std::system_error);
+}
+
+TEST_F(TestSystemQueries, GetEthInfoEmptyName)
+{
+    EXPECT_THROW(getEthInfo(""), std::system_error);
+}
+
+TEST_F(TestSystemQueries, SetMTUSuccess)
+{
+    mock_addIF(InterfaceInfo{
+        .type = 1, .idx = 1, .flags = 0, .name = "eth0", .mtu = 1500});
+
+    EXPECT_NO_THROW(setMTU("eth0", 9000));
+}
+
+TEST_F(TestSystemQueries, SetMTUStandardValues)
+{
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 1, .flags = 0, .name = "eth0"});
+
+    EXPECT_NO_THROW(setMTU("eth0", 1500)); // Standard Ethernet
+    EXPECT_NO_THROW(setMTU("eth0", 9000)); // Jumbo frames
+    EXPECT_NO_THROW(setMTU("eth0", 1280)); // IPv6 minimum
+}
+
+TEST_F(TestSystemQueries, SetMTUNonExistentInterface)
+{
+    EXPECT_THROW(setMTU("eth99", 1500), std::system_error);
+}
+
+TEST_F(TestSystemQueries, SetNICUpSuccess)
+{
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 1, .flags = 0, .name = "eth0"});
+
+    EXPECT_NO_THROW(setNICUp("eth0", true));
+}
+
+TEST_F(TestSystemQueries, SetNICDownSuccess)
+{
+    mock_addIF(
+        InterfaceInfo{.type = 1, .idx = 1, .flags = IFF_UP, .name = "eth0"});
+
+    EXPECT_NO_THROW(setNICUp("eth0", false));
+}
+
+TEST_F(TestSystemQueries, SetNICUpAlreadyUp)
+{
+    mock_addIF(
+        InterfaceInfo{.type = 1, .idx = 1, .flags = IFF_UP, .name = "eth0"});
+
+    EXPECT_NO_THROW(setNICUp("eth0", true));
+}
+
+TEST_F(TestSystemQueries, SetNICDownAlreadyDown)
+{
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 1, .flags = 0, .name = "eth0"});
+
+    EXPECT_NO_THROW(setNICUp("eth0", false));
+}
+
+TEST_F(TestSystemQueries, SetNICUpNonExistentInterface)
+{
+    EXPECT_THROW(setNICUp("eth99", true), std::system_error);
+}
+
+TEST_F(TestSystemQueries, SetNICStateMultipleInterfaces)
+{
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 1, .flags = 0, .name = "eth0"});
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 2, .flags = 0, .name = "eth1"});
+
+    EXPECT_NO_THROW(setNICUp("eth0", true));
+    EXPECT_NO_THROW(setNICUp("eth1", true));
+}
+
+TEST_F(TestSystemQueries, DeleteInterfaceSuccess)
+{
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 2, .flags = 0, .name = "eth0"});
+
+    EXPECT_NO_THROW(deleteIntf(2));
+}
+
+TEST_F(TestSystemQueries, DeleteInterfaceZeroIndex)
+{
+    EXPECT_NO_THROW(deleteIntf(0));
+}
+
+TEST_F(TestSystemQueries, DeleteMultipleInterfaces)
+{
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 2, .flags = 0, .name = "eth0"});
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 3, .flags = 0, .name = "eth1"});
+
+    EXPECT_NO_THROW(deleteIntf(2));
+    EXPECT_NO_THROW(deleteIntf(3));
+}
+
+TEST_F(TestSystemQueries, SetMTUAndBringUp)
+{
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 1, .flags = 0, .name = "eth0"});
+
+    EXPECT_NO_THROW(setMTU("eth0", 9000));
+    EXPECT_NO_THROW(setNICUp("eth0", true));
+}
+
+TEST_F(TestSystemQueries, BringUpSetMTUBringDown)
+{
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 1, .flags = 0, .name = "eth0"});
+
+    EXPECT_NO_THROW(setNICUp("eth0", true));
+    EXPECT_NO_THROW(setMTU("eth0", 1500));
+    EXPECT_NO_THROW(setNICUp("eth0", false));
+}
+
+TEST_F(TestSystemQueries, EmptyInterfaceName)
+{
+    EXPECT_THROW(setNICUp("", true), std::system_error);
+}
+
+TEST_F(TestSystemQueries, VeryLongInterfaceName)
+{
+    std::string longName(IFNAMSIZ + 10, 'a');
+    EXPECT_THROW(setNICUp(longName, true), std::system_error);
+}
+
+TEST_F(TestSystemQueries, InterfaceNameExactlyIFNAMSIZ)
+{
+    std::string maxName(IFNAMSIZ - 1, 'a');
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 1, .flags = 0, .name = maxName});
+
+    EXPECT_NO_THROW(setNICUp(maxName, true));
+}
+
+TEST_F(TestSystemQueries, SetMTUZero)
+{
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 1, .flags = 0, .name = "eth0"});
+
+    EXPECT_NO_THROW(setMTU("eth0", 0));
+}
+
+TEST_F(TestSystemQueries, SetMTUVeryLarge)
+{
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 1, .flags = 0, .name = "eth0"});
+
+    EXPECT_NO_THROW(setMTU("eth0", 65535));
+}
+
+TEST_F(TestSystemQueries, MultipleOperationsSameInterface)
+{
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 1, .flags = 0, .name = "eth0"});
+
+    EXPECT_NO_THROW(setMTU("eth0", 1500));
+    EXPECT_NO_THROW(setNICUp("eth0", true));
+    EXPECT_NO_THROW(setMTU("eth0", 9000));
+    EXPECT_NO_THROW(setNICUp("eth0", false));
+    EXPECT_NO_THROW(setNICUp("eth0", true));
+}
+
+TEST_F(TestSystemQueries, DifferentInterfaceTypes)
+{
+    mock_addIF(InterfaceInfo{
+        .type = ARPHRD_ETHER, .idx = 1, .flags = 0, .name = "eth0"});
+    mock_addIF(InterfaceInfo{
+        .type = ARPHRD_LOOPBACK, .idx = 2, .flags = 0, .name = "lo"});
+
+    EXPECT_NO_THROW(setNICUp("eth0", true));
+    EXPECT_NO_THROW(setNICUp("lo", true));
+}
+
+TEST_F(TestSystemQueries, ManyInterfaces)
+{
+    for (int i = 0; i < 100; ++i)
+    {
+        mock_addIF(InterfaceInfo{.type = 1,
+                                 .idx = static_cast<unsigned>(i + 1),
+                                 .flags = 0,
+                                 .name = "eth" + std::to_string(i)});
+    }
+
+    EXPECT_NO_THROW(setNICUp("eth0", true));
+    EXPECT_NO_THROW(setNICUp("eth50", true));
+    EXPECT_NO_THROW(setNICUp("eth99", true));
+}
+
+TEST_F(TestSystemQueries, RapidStateChanges)
+{
+    mock_addIF(InterfaceInfo{.type = 1, .idx = 1, .flags = 0, .name = "eth0"});
+
+    for (int i = 0; i < 10; ++i)
+    {
+        EXPECT_NO_THROW(setNICUp("eth0", true));
+        EXPECT_NO_THROW(setNICUp("eth0", false));
+    }
+}
+
+TEST_F(TestSystemQueries, SetIPAddressSuccess)
+{
+    mock_addIF(InterfaceInfo{
+        .type = 1, .idx = 1, .flags = 0, .name = "eth0", .mtu = 1500});
+
+    EXPECT_NO_THROW(setIPAddress("eth0", "192.168.1.100", 24));
+}
+
+TEST_F(TestSystemQueries, SetIPAddressInvalidIP)
+{
+    mock_addIF(InterfaceInfo{
+        .type = 1, .idx = 1, .flags = 0, .name = "eth0", .mtu = 1500});
+
+    EXPECT_THROW(setIPAddress("eth0", "invalid_ip", 24), std::invalid_argument);
+    EXPECT_THROW(setIPAddress("eth0", "256.1.1.1", 24), std::invalid_argument);
+    EXPECT_THROW(setIPAddress("eth0", "192.168.1", 24), std::invalid_argument);
+    EXPECT_THROW(setIPAddress("eth0", "192.168.1.1.1", 24),
+                 std::invalid_argument);
+    EXPECT_THROW(setIPAddress("eth0", "192.168.1.a", 24),
+                 std::invalid_argument);
+}
+
+TEST_F(TestSystemQueries, SetIPAddressNonExistentInterface)
+{
+    EXPECT_THROW(setIPAddress("eth99", "192.168.1.100", 24), std::system_error);
+}
+
+TEST_F(TestSystemQueries, SetIPAddressEdgePrefixLengths)
+{
+    mock_addIF(InterfaceInfo{
+        .type = 1, .idx = 1, .flags = 0, .name = "eth0", .mtu = 1500});
+
+    // /32 prefix (single host) - INVALID for interface assignment
+    EXPECT_THROW(setIPAddress("eth0", "10.0.0.1", 32), std::invalid_argument);
+
+    // /0 prefix (default route netmask) - INVALID for interface assignment
+    EXPECT_THROW(setIPAddress("eth0", "10.0.0.1", 0), std::invalid_argument);
+
+    // /1 prefix - VALID
+    EXPECT_NO_THROW(setIPAddress("eth0", "10.0.0.1", 1));
+
+    // /31 prefix (point-to-point) - VALID
+    EXPECT_NO_THROW(setIPAddress("eth0", "10.0.0.1", 31));
+}
+
+TEST_F(TestSystemQueries, SetIPAddressInvalidPrefix)
+{
+    mock_addIF(InterfaceInfo{
+        .type = 1, .idx = 1, .flags = 0, .name = "eth0", .mtu = 1500});
+
+    EXPECT_THROW(setIPAddress("eth0", "192.168.1.100", 33),
+                 std::invalid_argument);
+    EXPECT_THROW(setIPAddress("eth0", "192.168.1.100", 50),
+                 std::invalid_argument);
+    EXPECT_THROW(setIPAddress("eth0", "192.168.1.100", 255),
+                 std::invalid_argument);
+}
+
+TEST_F(TestSystemQueries, SetIPAddressCommonPrefixes)
+{
+    mock_addIF(InterfaceInfo{
+        .type = 1, .idx = 1, .flags = 0, .name = "eth0", .mtu = 1500});
+
+    // /8 (Class A)
+    EXPECT_NO_THROW(setIPAddress("eth0", "10.0.0.1", 8));
+
+    // /16 (Class B)
+    EXPECT_NO_THROW(setIPAddress("eth0", "172.16.0.1", 16));
+
+    // /24 (Class C)
+    EXPECT_NO_THROW(setIPAddress("eth0", "192.168.1.1", 24));
+}
+
+TEST_F(TestSystemQueries, SetIPAddressMultipleInterfaces)
+{
+    mock_addIF(InterfaceInfo{
+        .type = 1, .idx = 1, .flags = 0, .name = "eth0", .mtu = 1500});
+    mock_addIF(InterfaceInfo{
+        .type = 1, .idx = 2, .flags = 0, .name = "eth1", .mtu = 1500});
+    mock_addIF(InterfaceInfo{
+        .type = 1, .idx = 3, .flags = 0, .name = "eth2", .mtu = 1500});
+
+    EXPECT_NO_THROW(setIPAddress("eth0", "192.168.1.100", 24));
+    EXPECT_NO_THROW(setIPAddress("eth1", "192.168.2.100", 24));
+    EXPECT_NO_THROW(setIPAddress("eth2", "192.168.3.100", 24));
+}
+
+TEST_F(TestSystemQueries, SetIPAddressAllValidPrefixes)
+{
+    mock_addIF(InterfaceInfo{
+        .type = 1, .idx = 1, .flags = 0, .name = "eth0", .mtu = 1500});
+
+    // Test valid prefix lengths (1-31)
+    for (uint8_t prefix = 1; prefix <= 31; ++prefix)
+    {
+        EXPECT_NO_THROW(setIPAddress("eth0", "192.168.1.100", prefix))
+            << "Failed for prefix /" << static_cast<int>(prefix);
+    }
+
+    // Test invalid prefix lengths (0, 32, 33)
+    EXPECT_THROW(setIPAddress("eth0", "192.168.1.100", 0),
+                 std::invalid_argument)
+        << "Should throw for prefix /0";
+    EXPECT_THROW(setIPAddress("eth0", "192.168.1.100", 32),
+                 std::invalid_argument)
+        << "Should throw for prefix /32";
+    EXPECT_THROW(setIPAddress("eth0", "192.168.1.100", 33),
+                 std::invalid_argument)
+        << "Should throw for prefix /33";
+}
+
+TEST_F(TestSystemQueries, SetIPAddressEmptyInterface)
+{
+    EXPECT_THROW(setIPAddress("", "192.168.1.100", 24), std::system_error);
+}
+
+TEST_F(TestSystemQueries, SetIPAddressMultipleTimes)
+{
+    mock_addIF(InterfaceInfo{
+        .type = 1, .idx = 1, .flags = 0, .name = "eth0", .mtu = 1500});
+
+    // Set IP multiple times (should overwrite)
+    EXPECT_NO_THROW(setIPAddress("eth0", "192.168.1.100", 24));
+    EXPECT_NO_THROW(setIPAddress("eth0", "192.168.1.101", 24));
+    EXPECT_NO_THROW(setIPAddress("eth0", "192.168.1.102", 24));
+}
+} // namespace system
+} // namespace network
+} // namespace phosphor


### PR DESCRIPTION
Introduce setIPAddress() helpers to configure network interfaces directly via ioctl system calls.

Rationale:
The interfaces marked as "ignored" are excluded from external management but may still require IP configuration for their intended use cases (such as dedicated BMC communication, or other specialized purposes). Since no D-Bus objects exist for ignored interfaces, we use direct ioctl system calls to configure them.

Consumers:
- phosphor-networkd handling the set of IGNORED_INTERFACES environment variable for ignored interfaces requiring ip runtime configuration( interfaces which are not exposed via Dbus)

Implementation details:
Uses standard Linux ioctls:
- SIOCSIFADDR: Set IP address
- SIOCSIFNETMASK: Set network mask
- SIOCSIFBRDADDR: Set broadcast address Unit test
-Validates IPv4 addresses via inet_pton()
- Enforces prefix length range 1-31, rejects 0, 32, >32
- Updated test mock infrastructure to support new ioctls
- Added unit tests for valid and invalid IP addresses

gerrit link:https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/91467
Tested: Unit tests passed
Change-Id: Iae56fcb7122b1e76845359370f6c5ff6b5e4e850