### PR TITLE
Add include for lg2 due to CI error

### DIFF
--- a/src/ethernet_interface.hpp
+++ b/src/ethernet_interface.hpp
@@ -239,7 +239,7 @@ class EthernetInterface : public Ifaces
 
     bool dhcpIsEnabled(IP::Protocol family, bool ignoreProtocol);
     void disableDHCP(IP::Protocol protocol);
-    
+
     /** @brief set conf file for LLDP
      *  @param[in] value - lldp value of the interface.
      */

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -11,6 +11,7 @@
 #include <net/if.h>
 
 #include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <phosphor-logging/log.hpp>
 #include <sdbusplus/message.hpp>
 #include <stdplus/pinned.hpp>


### PR DESCRIPTION
Added include for logging/phosphor headers

Tested the local CI run and no errors were seen.
Jira: https://jsw.ibm.com/browse/PFEBMC-5213
defect:https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=804599